### PR TITLE
Paged memory - too slow!

### DIFF
--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -100,6 +100,6 @@ func (a *archetype) HasComponent(id ID) bool {
 }
 
 // Len reports the number of entities in the archetype
-func (a *archetype) Len() uint32 {
+func (a *archetype) Len() int {
 	return a.entities.Len()
 }

--- a/ecs/config.go
+++ b/ecs/config.go
@@ -8,7 +8,7 @@ type Config struct {
 // NewConfig creates a new default config
 func NewConfig() Config {
 	return Config{
-		CapacityIncrement: 128,
+		CapacityIncrement: 1024,
 	}
 }
 

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -6,45 +6,62 @@ import (
 	"unsafe"
 )
 
-// storage is a storage implementation that works with reflection
 type storage struct {
-	buffer            reflect.Value
-	bufferAddress     unsafe.Pointer
 	typeOf            reflect.Type
 	itemSize          uintptr
-	len               uint32
-	cap               uint32
+	capacityExponent  int
 	capacityIncrement uint32
+	len               uint32
+	pages             []storagePage
 }
 
-// newStorage creates a new ReflectStorage
+// newStorage creates a new storage
 func newStorage(tp reflect.Type, increment int) storage {
+	capacityExponent := math.Ilogb(float64(increment))
+	if 1<<capacityExponent != increment {
+		panic("capacity increment must be a power of 2 value")
+	}
+
 	size := tp.Size()
 	align := uintptr(tp.Align())
 	size = (size + (align - 1)) / align * align
 
-	buffer := reflect.New(reflect.ArrayOf(increment, tp)).Elem()
 	return storage{
-		buffer:            buffer,
-		bufferAddress:     buffer.Addr().UnsafePointer(),
 		typeOf:            tp,
 		itemSize:          size,
-		len:               0,
-		cap:               uint32(increment),
+		capacityExponent:  capacityExponent,
 		capacityIncrement: uint32(increment),
+		pages:             make([]storagePage, 0),
 	}
 }
 
 // Get retrieves an unsafe pointer to an element
 func (s *storage) Get(index uint32) unsafe.Pointer {
-	ptr := unsafe.Add(s.bufferAddress, uintptr(index)*s.itemSize)
+	if index >= s.len {
+		return nil
+	}
+	ind := index >> s.capacityExponent
+	offset := index & (s.capacityIncrement - 1)
+	ptr := unsafe.Add(s.pages[ind].bufferAddress, uintptr(offset)*s.itemSize)
 	return unsafe.Pointer(ptr)
+}
+
+func (s *storage) page(index uint32) uint32 {
+	return index >> s.capacityExponent
+}
+
+// Alloc adds an empty element to the end of the storage
+func (s *storage) Alloc() (index uint32) {
+	s.extend()
+	s.incrLen()
+	s.Zero(s.len - 1)
+	return s.len - 1
 }
 
 // Add adds an element to the end of the storage
 func (s *storage) Add(value interface{}) (index uint32) {
 	s.extend()
-	s.len++
+	s.incrLen()
 	s.set(s.len-1, value)
 	return s.len - 1
 }
@@ -52,26 +69,18 @@ func (s *storage) Add(value interface{}) (index uint32) {
 // AddPointer adds an element to the end of the storage, based on a pointer
 func (s *storage) AddPointer(value unsafe.Pointer) (index uint32) {
 	s.extend()
-	s.len++
+	s.incrLen()
 	s.setPointer(s.len-1, value)
 	return s.len - 1
 }
 
-// Alloc adds an empty element to the end of the storage
-func (s *storage) Alloc() (index uint32) {
-	s.extend()
-	s.len++
-	s.Zero(s.len - 1)
-	return s.len - 1
-}
+// Zero resets a block of storage
+func (s *storage) Zero(index uint32) {
+	dst := s.Get(index)
 
-func (s *storage) extend() {
-	if s.cap < s.len+1 {
-		old := s.buffer
-		s.cap = s.cap + s.capacityIncrement
-		s.buffer = reflect.New(reflect.ArrayOf(int(s.cap), s.typeOf)).Elem()
-		s.bufferAddress = s.buffer.Addr().UnsafePointer()
-		reflect.Copy(s.buffer, old)
+	for i := uintptr(0); i < s.itemSize; i++ {
+		*(*byte)(dst) = 0
+		dst = unsafe.Add(dst, 1)
 	}
 }
 
@@ -84,20 +93,40 @@ func (s *storage) Remove(index uint32) bool {
 	if n < o {
 		size := s.itemSize
 
-		src := unsafe.Add(s.bufferAddress, uintptr(o)*s.itemSize)
-		dst := unsafe.Add(s.bufferAddress, uintptr(n)*s.itemSize)
+		src := s.Get(o)
+		dst := s.Get(n)
 
 		dstSlice := (*[math.MaxInt32]byte)(dst)[:size:size]
 		srcSlice := (*[math.MaxInt32]byte)(src)[:size:size]
 
 		copy(dstSlice, srcSlice)
 
-		s.len--
+		s.decrLen()
 		return true
 	}
 
-	s.len--
+	s.decrLen()
 	return false
+}
+
+func (s *storage) incrLen() {
+	s.pages[s.page(s.len)].len++
+	s.len++
+}
+
+func (s *storage) decrLen() {
+	s.len--
+	s.pages[s.page(s.len)].len--
+}
+
+// Len returns the number of items in the storage
+func (s *storage) Len() int {
+	return int(s.len)
+}
+
+// Len returns the current capacity of the storage
+func (s *storage) Cap() int {
+	return len(s.pages) * int(s.capacityIncrement)
 }
 
 func (s *storage) set(index uint32, value interface{}) {
@@ -124,19 +153,26 @@ func (s *storage) setPointer(index uint32, value unsafe.Pointer) {
 	copy(dstSlice, srcSlice)
 }
 
-// Zero resets a block of storage
-func (s *storage) Zero(index uint32) {
-	dst := s.Get(index)
-
-	for i := uintptr(0); i < s.itemSize; i++ {
-		*(*byte)(dst) = 0
-		dst = unsafe.Add(dst, 1)
+func (s *storage) extend() {
+	if len(s.pages) == 0 || s.pages[len(s.pages)-1].len == s.capacityIncrement {
+		s.newStoragePage()
 	}
 }
 
-// Len returns the number of items in the storage
-func (s *storage) Len() uint32 {
-	return s.len
+func (s *storage) newStoragePage() {
+	buffer := reflect.New(reflect.ArrayOf(int(s.capacityIncrement), s.typeOf)).Elem()
+	s.pages = append(s.pages, storagePage{
+		buffer:        buffer,
+		bufferAddress: buffer.Addr().UnsafePointer(),
+		len:           0,
+	})
+}
+
+// storage is a storage implementation that works with reflection
+type storagePage struct {
+	buffer        reflect.Value
+	bufferAddress unsafe.Pointer
+	len           uint32
 }
 
 // toSlice converts the content of a storage to a slice of structs

--- a/ecs/storage_test.go
+++ b/ecs/storage_test.go
@@ -99,6 +99,28 @@ func TestReflectStorageDataSize(t *testing.T) {
 	assert.Equal(t, 6, s.Cap())
 }
 
+func TestReflectStoragePages(t *testing.T) {
+	ref := simpleStruct{}
+	s := newStorage(reflect.TypeOf(ref), 4)
+
+	for i := 0; i < 4; i++ {
+		s.Add(&simpleStruct{i})
+	}
+
+	assert.Equal(t, 4, s.Len())
+	assert.Equal(t, 4, s.Cap())
+
+	s.Add(&simpleStruct{0})
+	assert.Equal(t, 5, s.Len())
+	assert.Equal(t, 8, s.Cap())
+
+	for i := 0; i < 4; i++ {
+		s.Add(&simpleStruct{i})
+	}
+
+	assert.Equal(t, 12, s.Cap())
+}
+
 func TestNewReflectStorage(t *testing.T) {
 	_ = newStorage(reflect.TypeOf(simpleStruct{}), 32)
 }

--- a/ecs/storage_test.go
+++ b/ecs/storage_test.go
@@ -63,14 +63,14 @@ func storageRemove(t *testing.T, s storage) {
 		s.Add(&obj)
 	}
 
-	assert.Equal(t, uint32(5), s.Len(), "Wrong storage length")
+	assert.Equal(t, 5, s.Len(), "Wrong storage length")
 
 	s.Remove(4)
-	assert.Equal(t, uint32(4), s.Len(), "Wrong storage length")
+	assert.Equal(t, 4, s.Len(), "Wrong storage length")
 	assert.Equal(t, []simpleStruct{{0}, {1}, {2}, {3}}, toSlice[simpleStruct](s), "Wrong slice after remove")
 
 	s.Remove(1)
-	assert.Equal(t, uint32(3), s.Len(), "Wrong storage length")
+	assert.Equal(t, 3, s.Len(), "Wrong storage length")
 	assert.Equal(t, []simpleStruct{{0}, {3}, {2}}, toSlice[simpleStruct](s), "Wrong slice after remove")
 }
 
@@ -83,20 +83,20 @@ func TestReflectStorageDataSize(t *testing.T) {
 		s.Add(&obj)
 	}
 
-	assert.Equal(t, 5, int(s.cap))
+	assert.Equal(t, 5, s.Cap())
 
 	s.Remove(0)
-	assert.Equal(t, 5, int(s.cap))
+	assert.Equal(t, 5, s.Cap())
 	s.Remove(0)
-	assert.Equal(t, 5, int(s.cap))
+	assert.Equal(t, 5, s.Cap())
 
 	s.Add(&simpleStruct{})
-	assert.Equal(t, 5, int(s.cap))
+	assert.Equal(t, 5, s.Cap())
 	s.Add(&simpleStruct{})
-	assert.Equal(t, 5, int(s.cap))
+	assert.Equal(t, 5, s.Cap())
 
 	s.Add(&simpleStruct{})
-	assert.Equal(t, 6, int(s.cap))
+	assert.Equal(t, 6, s.Cap())
 }
 
 func TestNewReflectStorage(t *testing.T) {
@@ -110,11 +110,11 @@ func BenchmarkIterReflectStorage_1000(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		s.Add(&testStruct{})
 	}
-	assert.Equal(b, 1000, int(s.Len()))
+	assert.Equal(b, 1000, s.Len())
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < int(s.Len()); j++ {
+		for j := 0; j < s.Len(); j++ {
 			a := (*testStruct)(s.Get(uint32(j)))
 			_ = a
 		}


### PR DESCRIPTION
Doubles query access time by factor 2, and world access time even more.
Will probably not get merged except if a bottleneck can be identifies and fixed.

Here, component `Storage`s themself are paged individually: `arch.comp[c].page[p]`. It might be worth to try paging of the archetypes instead: `arch.page[p].comp[c]`.

Fixes #21