### PR TITLE
Optimize query iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.1.4...main)
 
-Nothing
+### Other
+
+* Optimization of `Query` iteration, avoids allocations and makes it approx. 30% faster (#35)
+* Removed method `Query.Count()`, as it was a by-product of the allocations in the above point (#35)
 
 ## [[v0.1.4]](https://github.com/mlange-42/arche/compare/v0.1.3...v0.1.4)
 

--- a/benchmark/iterate/arche_test.go
+++ b/benchmark/iterate/arche_test.go
@@ -30,6 +30,30 @@ func runArcheQuery(b *testing.B, count int) {
 	}
 }
 
+func runArcheQueryEntity(b *testing.B, count int) {
+	b.StopTimer()
+	world := ecs.NewWorld()
+
+	posID := ecs.ComponentID[position](&world)
+	rotID := ecs.ComponentID[rotation](&world)
+
+	for i := 0; i < count; i++ {
+		entity := world.NewEntity()
+		world.Add(entity, posID, rotID)
+	}
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := world.Query(posID, rotID)
+		b.StartTimer()
+		for query.Next() {
+			e := query.Entity()
+			_ = e
+		}
+	}
+}
+
 func runArcheWorld(b *testing.B, count int) {
 	b.StopTimer()
 	world := ecs.NewWorld()
@@ -65,6 +89,18 @@ func BenchmarkArcheIterQuery_10_000(b *testing.B) {
 
 func BenchmarkArcheIterQuery_100_000(b *testing.B) {
 	runArcheQuery(b, 100000)
+}
+
+func BenchmarkArcheIterQueryEntity_1_000(b *testing.B) {
+	runArcheQueryEntity(b, 1000)
+}
+
+func BenchmarkArcheIterQueryEntity_10_000(b *testing.B) {
+	runArcheQueryEntity(b, 10000)
+}
+
+func BenchmarkArcheIterQueryEntity_100_000(b *testing.B) {
+	runArcheQueryEntity(b, 100000)
 }
 
 func BenchmarkArcheIterWorld_1_000(b *testing.B) {

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
 // Package arche is an archetype-based Entity Component System for Go.
 //
-// See sub-package [ecs] for the API docs.
+// See sub-package [arche/ecs] for the API docs.
 package arche

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -15,11 +15,9 @@ type archetype struct {
 
 var entityType = reflect.TypeOf(Entity{})
 
-// newArchetype creates a new Archetype for the given components
-// Component arguments must be sorted by ID!
-func newArchetype(capacityIncrement int, components ...componentType) archetype {
+func (a *archetype) init(capacityIncrement int, components ...componentType) {
 	var mask Mask
-	indices := make([]ID, len(components))
+	a.indices = make([]ID, len(components))
 	comps := [MaskTotalBits]storage{}
 
 	prev := -1
@@ -30,16 +28,15 @@ func newArchetype(capacityIncrement int, components ...componentType) archetype 
 		prev = int(c.ID)
 
 		mask.Set(c.ID, true)
-		indices[i] = c.ID
-		comps[c.ID] = newStorage(c.Type, capacityIncrement)
+		a.indices[i] = c.ID
+		comps[c.ID] = storage{}
+		comps[c.ID].init(c.Type, capacityIncrement)
 	}
 
-	return archetype{
-		mask:       mask,
-		indices:    indices,
-		entities:   newStorage(entityType, capacityIncrement),
-		components: comps,
-	}
+	a.mask = mask
+	a.components = comps
+	a.entities = storage{}
+	a.entities.init(entityType, capacityIncrement)
 }
 
 // GetEntity returns the entity at the given index

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -13,7 +13,8 @@ func TestArchetype(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	arch := newArchetype(32, comps...)
+	arch := archetype{}
+	arch.init(32, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -76,14 +77,16 @@ func TestNewArchetype(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(position{})},
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
-	_ = newArchetype(32, comps...)
+	arch := archetype{}
+	arch.init(32, comps...)
 
 	comps = []componentType{
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 		{ID: 0, Type: reflect.TypeOf(position{})},
 	}
 	assert.Panics(t, func() {
-		_ = newArchetype(32, comps...)
+		arch := archetype{}
+		arch.init(32, comps...)
 	})
 }
 
@@ -94,7 +97,8 @@ func BenchmarkArchetypeAccess_1000(b *testing.B) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	arch := newArchetype(32, comps...)
+	arch := archetype{}
+	arch.init(32, comps...)
 
 	for i := 0; i < 1000; i++ {
 		arch.Add(

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -93,8 +93,7 @@ func TestNewArchetype(t *testing.T) {
 func BenchmarkArchetypeAccess_1000(b *testing.B) {
 	b.StopTimer()
 	comps := []componentType{
-		{ID: 0, Type: reflect.TypeOf(position{})},
-		{ID: 1, Type: reflect.TypeOf(rotation{})},
+		{ID: 0, Type: reflect.TypeOf(testStruct{})},
 	}
 
 	arch := archetype{}
@@ -103,15 +102,16 @@ func BenchmarkArchetypeAccess_1000(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		arch.Add(
 			newEntity(i),
-			component{ID: 0, Component: &position{1, 2}},
-			component{ID: 1, Component: &rotation{3}},
+			component{ID: 0, Component: &testStruct{}},
 		)
 	}
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 1000; j++ {
-			pos := (*position)(arch.Get(i, ID(0)))
+		len := int(arch.Len())
+		id := ID(0)
+		for j := 0; j < len; j++ {
+			pos := (*testStruct)(arch.Get(i, id))
 			_ = pos
 		}
 	}

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -36,21 +36,18 @@ func newQuery(world *World, mask Mask, lockBit uint8) Query {
 
 // Next proceeds to the next [Entity] in the Query.
 func (q *Query) Next() bool {
-	for {
-		if q.archetype.Next() {
-			return true
-		}
-		i, a, ok := q.world.nextArchetype(q.mask, q.index)
-		q.index = i
-		if ok {
-			q.archetype = a
-			q.archetype.Next()
-			return true
-		}
-		q.done = true
-		q.world.closeQuery(q)
-		return false
+	if q.archetype.Next() {
+		return true
 	}
+	i, a, ok := q.world.nextArchetype(q.mask, q.index)
+	q.index = i
+	if ok {
+		q.archetype = a
+		return true
+	}
+	q.done = true
+	q.world.closeQuery(q)
+	return false
 }
 
 // Has returns whether the current [Entity] has the given component
@@ -87,7 +84,6 @@ func newArchetypeIter(arch *archetype) archetypeIter {
 	return archetypeIter{
 		Archetype: arch,
 		Length:    int(arch.Len()),
-		Index:     -1,
 	}
 }
 

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -36,15 +36,13 @@ func newQuery(world *World, mask Mask, lockBit uint8) Query {
 
 // Next proceeds to the next [Entity] in the Query.
 func (q *Query) Next() bool {
-	if q.done {
-		panic("Query is used up. Create a new Query!")
-	}
 	for {
 		if q.archetype.Next() {
 			return true
 		}
-		if i, a, ok := q.world.nextArchetype(q.mask, q.index); ok {
-			q.index = i
+		i, a, ok := q.world.nextArchetype(q.mask, q.index)
+		q.index = i
+		if ok {
 			q.archetype = a
 			q.archetype.Next()
 			return true
@@ -57,25 +55,16 @@ func (q *Query) Next() bool {
 
 // Has returns whether the current [Entity] has the given component
 func (q *Query) Has(comp ID) bool {
-	if q.done {
-		panic("Query is used up. Create a new Query!")
-	}
 	return q.archetype.Has(comp)
 }
 
 // Get returns the pointer to the given component at the iterator's current [Entity]
 func (q *Query) Get(comp ID) unsafe.Pointer {
-	if q.done {
-		panic("Query is used up. Create a new Query!")
-	}
 	return q.archetype.Get(comp)
 }
 
 // Entity returns the [Entity] at the iterator's position
 func (q *Query) Entity() Entity {
-	if q.done {
-		panic("Query is used up. Create a new Query!")
-	}
 	return q.archetype.Entity()
 }
 

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -8,7 +8,7 @@ import (
 //
 // Create queries through the [World] using [World.Query].
 //
-// ## Example:
+// # Example:
 //
 //	query := world.Query(posID, rotID)
 //	for query.Next() {

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -36,7 +36,6 @@ func TestQuery(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 2, cnt)
-	assert.Equal(t, 2, q.Count())
 
 	q = w.Query(posID)
 	cnt = 0
@@ -48,7 +47,6 @@ func TestQuery(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 3, cnt)
-	assert.Equal(t, 3, q.Count())
 
 	q = w.Query(rotID)
 	cnt = 0
@@ -62,7 +60,6 @@ func TestQuery(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 4, cnt)
-	assert.Equal(t, 4, q.Count())
 
 	assert.Panics(t, func() { q.Next() })
 	assert.Panics(t, func() { q.Entity() })

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -62,7 +62,4 @@ func TestQuery(t *testing.T) {
 	assert.Equal(t, 4, cnt)
 
 	assert.Panics(t, func() { q.Next() })
-	assert.Panics(t, func() { q.Entity() })
-	assert.Panics(t, func() { q.Has(posID) })
-	assert.Panics(t, func() { q.Get(posID) })
 }

--- a/ecs/storage.go
+++ b/ecs/storage.go
@@ -18,21 +18,18 @@ type storage struct {
 }
 
 // newStorage creates a new ReflectStorage
-func newStorage(tp reflect.Type, increment int) storage {
+func (s *storage) init(tp reflect.Type, increment int) {
 	size := tp.Size()
 	align := uintptr(tp.Align())
 	size = (size + (align - 1)) / align * align
 
-	buffer := reflect.New(reflect.ArrayOf(increment, tp)).Elem()
-	return storage{
-		buffer:            buffer,
-		bufferAddress:     buffer.Addr().UnsafePointer(),
-		typeOf:            tp,
-		itemSize:          size,
-		len:               0,
-		cap:               uint32(increment),
-		capacityIncrement: uint32(increment),
-	}
+	s.buffer = reflect.New(reflect.ArrayOf(increment, tp)).Elem()
+	s.bufferAddress = s.buffer.Addr().UnsafePointer()
+	s.typeOf = tp
+	s.itemSize = size
+	s.len = 0
+	s.cap = uint32(increment)
+	s.capacityIncrement = uint32(increment)
 }
 
 // Get retrieves an unsafe pointer to an element

--- a/ecs/storage_test.go
+++ b/ecs/storage_test.go
@@ -20,7 +20,8 @@ type simpleStruct struct {
 
 func TestReflectStorageAddGet(t *testing.T) {
 	obj1 := testStruct{}
-	s := newStorage(reflect.TypeOf(obj1), 1)
+	s := storage{}
+	s.init(reflect.TypeOf(obj1), 1)
 	storageAddGet(t, s)
 }
 
@@ -52,7 +53,8 @@ func storageAddGet(t *testing.T, s storage) {
 
 func TestReflectStorageRemove(t *testing.T) {
 	ref := simpleStruct{}
-	s := newStorage(reflect.TypeOf(ref), 32)
+	s := storage{}
+	s.init(reflect.TypeOf(ref), 32)
 
 	storageRemove(t, s)
 }
@@ -76,7 +78,8 @@ func storageRemove(t *testing.T, s storage) {
 
 func TestReflectStorageDataSize(t *testing.T) {
 	ref := simpleStruct{}
-	s := newStorage(reflect.TypeOf(ref), 1)
+	s := storage{}
+	s.init(reflect.TypeOf(ref), 1)
 
 	for i := 0; i < 5; i++ {
 		obj := simpleStruct{i}
@@ -100,13 +103,15 @@ func TestReflectStorageDataSize(t *testing.T) {
 }
 
 func TestNewReflectStorage(t *testing.T) {
-	_ = newStorage(reflect.TypeOf(simpleStruct{}), 32)
+	s := storage{}
+	s.init(reflect.TypeOf(simpleStruct{}), 32)
 }
 
 func BenchmarkIterReflectStorage_1000(b *testing.B) {
 	b.StopTimer()
 	ref := testStruct{}
-	s := newStorage(reflect.TypeOf(ref), 128)
+	s := storage{}
+	s.init(reflect.TypeOf(ref), 128)
 	for i := 0; i < 1000; i++ {
 		s.Add(&testStruct{})
 	}
@@ -159,7 +164,8 @@ func BenchmarkAddReflectStorage_1000(b *testing.B) {
 	ref := testStruct{}
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		s := newStorage(reflect.TypeOf(ref), 1024)
+		s := storage{}
+		s.init(reflect.TypeOf(ref), 1024)
 		b.StartTimer()
 
 		for i := 0; i < 1000; i++ {
@@ -206,7 +212,8 @@ func BenchmarkRemoveReflectStorage_1000(b *testing.B) {
 	ref := testStruct{}
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
-		s := newStorage(reflect.TypeOf(ref), 1024)
+		s := storage{}
+		s.init(reflect.TypeOf(ref), 1024)
 		for i := 0; i < 1000; i++ {
 			s.Add(&ref)
 		}

--- a/ecs/storage_test.go
+++ b/ecs/storage_test.go
@@ -119,7 +119,8 @@ func BenchmarkIterReflectStorage_1000(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < int(s.Len()); j++ {
+		len := int(s.Len())
+		for j := 0; j < len; j++ {
 			a := (*testStruct)(s.Get(uint32(j)))
 			_ = a
 		}

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -53,10 +53,11 @@ func (w *World) NewEntity() Entity {
 
 	entity := w.entityPool.Get()
 	idx := w.archetypes[0].Add(entity)
-	if int(entity.id) == len(w.entities) {
-		if len(w.entities) == cap(w.entities) {
+	len := len(w.entities)
+	if int(entity.id) == len {
+		if len == cap(w.entities) {
 			old := w.entities
-			w.entities = make([]entityIndex, len(w.entities), len(w.entities)+w.config.CapacityIncrement)
+			w.entities = make([]entityIndex, len, len+w.config.CapacityIncrement)
 			copy(w.entities, old)
 		}
 		w.entities = append(w.entities, entityIndex{0, idx})

--- a/profile/main/profile.go
+++ b/profile/main/profile.go
@@ -22,7 +22,7 @@ type rotation struct {
 
 func main() {
 
-	count := 100
+	count := 250
 	iters := 10000
 	entities := 1000
 


### PR DESCRIPTION
Change `Query` iterator to avoid allocations as well as indexing into a slice of archetypes.