### PR TITLE
Paged archetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Optimization of `Query` iteration, avoids allocations and makes it approx. 30% faster (#35)
 * Removed method `Query.Count()`, as it was a by-product of the allocations in the above point (#35)
+* Archetypes are stored in a paged collection to use more efficient access by pointers (#36)
 
 ## [[v0.1.4]](https://github.com/mlange-42/arche/compare/v0.1.3...v0.1.4)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ func main() {
 		// Iterate it
 		for query.Next() {
 			// Component access through a Query.
-			// About twice as fast as access through the World.
+			// About 20-30% faster than access through the World.
 			// Can also fetch components not in the query.
 			pos := (*Position)(query.Get(positionID))
 			vel := (*Velocity)(query.Get(velocityID))

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -19,6 +19,6 @@ func (e Entity) IsZero() bool {
 }
 
 type entityIndex struct {
-	arch  int
+	arch  *archetype
 	index uint32
 }

--- a/ecs/paged.go
+++ b/ecs/paged.go
@@ -1,0 +1,28 @@
+package ecs
+
+const fixedPageSize = 32
+
+// PagedArr32 is a paged collection working with pages of length 32 arrays
+type PagedArr32[T any] struct {
+	pages   [][fixedPageSize]T
+	len     int
+	lenLast int
+}
+
+func (p *PagedArr32[T]) Add(value T) {
+	if len(p.pages) == 0 || p.lenLast == fixedPageSize {
+		p.pages = append(p.pages, [fixedPageSize]T{})
+		p.lenLast = 0
+	}
+	p.pages[len(p.pages)-1][p.lenLast] = value
+	p.len++
+	p.lenLast++
+}
+
+func (p *PagedArr32[T]) Get(index int) *T {
+	return &p.pages[index/fixedPageSize][index%fixedPageSize]
+}
+
+func (p *PagedArr32[T]) Len() int {
+	return p.len
+}

--- a/ecs/paged_test.go
+++ b/ecs/paged_test.go
@@ -1,0 +1,17 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPagedArr32(t *testing.T) {
+	a := PagedArr32[int]{}
+
+	for i := 0; i < 66; i++ {
+		a.Add(i)
+		assert.Equal(t, i, *a.Get(i))
+		assert.Equal(t, i+1, a.Len())
+	}
+}

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1,6 +1,8 @@
 package ecs
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,4 +205,23 @@ func TestRegisterComponents(t *testing.T) {
 
 	assert.Equal(t, ID(0), ComponentID[position](&world))
 	assert.Equal(t, ID(1), ComponentID[rotation](&world))
+}
+
+func TestTypeSizes(t *testing.T) {
+	printTypeSize[World]()
+	printTypeSizeName[PagedArr32[archetype]]("PagedArr32")
+	printTypeSize[archetype]()
+	printTypeSize[storage]()
+	printTypeSize[Query]()
+	printTypeSize[archetypeIter]()
+}
+
+func printTypeSize[T any]() {
+	tp := reflect.TypeOf((*T)(nil)).Elem()
+	fmt.Printf("%16s: %5db\n", tp.Name(), tp.Size())
+}
+
+func printTypeSizeName[T any](name string) {
+	tp := reflect.TypeOf((*T)(nil)).Elem()
+	fmt.Printf("%16s: %5db\n", name, tp.Size())
 }

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -48,14 +48,14 @@ func TestWorldComponents(t *testing.T) {
 	e1 := w.NewEntity()
 	e2 := w.NewEntity()
 
-	assert.Equal(t, 1, len(w.archetypes))
+	assert.Equal(t, 1, w.archetypes.Len())
 
 	w.Add(e0, posID)
-	assert.Equal(t, 2, len(w.archetypes))
+	assert.Equal(t, 2, w.archetypes.Len())
 	w.Add(e1, posID, rotID)
-	assert.Equal(t, 3, len(w.archetypes))
+	assert.Equal(t, 3, w.archetypes.Len())
 	w.Add(e2, posID, rotID)
-	assert.Equal(t, 3, len(w.archetypes))
+	assert.Equal(t, 3, w.archetypes.Len())
 
 	w.Remove(e2, posID)
 
@@ -73,21 +73,21 @@ func TestWorldComponents(t *testing.T) {
 	archPosRot, ok := w.findArchetype(maskPosRot)
 	assert.True(t, ok)
 
-	assert.Equal(t, 0, int(w.archetypes[archNone].Len()))
-	assert.Equal(t, 1, int(w.archetypes[archPos].Len()))
-	assert.Equal(t, 1, int(w.archetypes[archRot].Len()))
-	assert.Equal(t, 1, int(w.archetypes[archPosRot].Len()))
+	assert.Equal(t, 0, int(archNone.Len()))
+	assert.Equal(t, 1, int(archPos.Len()))
+	assert.Equal(t, 1, int(archRot.Len()))
+	assert.Equal(t, 1, int(archPosRot.Len()))
 
 	w.Remove(e1, posID)
 
-	assert.Equal(t, 0, int(w.archetypes[archNone].Len()))
-	assert.Equal(t, 1, int(w.archetypes[archPos].Len()))
-	assert.Equal(t, 2, int(w.archetypes[archRot].Len()))
-	assert.Equal(t, 0, int(w.archetypes[archPosRot].Len()))
+	assert.Equal(t, 0, int(archNone.Len()))
+	assert.Equal(t, 1, int(archPos.Len()))
+	assert.Equal(t, 2, int(archRot.Len()))
+	assert.Equal(t, 0, int(archPosRot.Len()))
 
 	w.Add(e0, rotID)
-	assert.Equal(t, 0, int(w.archetypes[archPos].Len()))
-	assert.Equal(t, 1, int(w.archetypes[archPosRot].Len()))
+	assert.Equal(t, 0, int(archPos.Len()))
+	assert.Equal(t, 1, int(archPosRot.Len()))
 
 	w.Remove(e2, rotID)
 	// No-op add/remove


### PR DESCRIPTION
Use pages memory to store archetypes, use pointers instead of indices in entity list.

Pages are a minimal ovrhead, but they make it possible to store refs to artifacts. Speeds up component access through the world/using an entity ID by up to 30%.