### PR TITLE
Remove `archetype.GetUnsafe()`

### DIFF
--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -63,14 +63,6 @@ func (a *archetype) Get(index uint32, id ID) unsafe.Pointer {
 	return a.references[id].Get(index)
 }
 
-// GetUnsafe returns the component with the given ID at the given index,
-// without checking if the entity contains that component.
-//
-// This is used by queries, where the entity is guaranteed to be in the archetype.
-func (a *archetype) GetUnsafe(index uint32, id ID) unsafe.Pointer {
-	return a.references[id].Get(index)
-}
-
 // Add adds an entity with zeroed components to the archetype
 func (a *archetype) Alloc(entity Entity, zero bool) uint32 {
 	idx := a.entities.Add(entity)

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -109,27 +109,3 @@ func BenchmarkArchetypeAccess_1000(b *testing.B) {
 		}
 	}
 }
-
-func BenchmarkArchetypeAccessUnsafe_1000(b *testing.B) {
-	b.StopTimer()
-	comps := []componentType{
-		{ID: 0, Type: reflect.TypeOf(testStruct0{})},
-	}
-
-	arch := archetype{}
-	arch.Init(32, true, comps...)
-
-	for i := 0; i < 1000; i++ {
-		arch.Alloc(newEntity(eid(i)), true)
-	}
-	b.StartTimer()
-
-	for i := 0; i < b.N; i++ {
-		len := int(arch.Len())
-		id := ID(0)
-		for j := 0; j < len; j++ {
-			pos := (*testStruct0)(arch.GetUnsafe(uint32(j), id))
-			pos.Val = 1
-		}
-	}
-}

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -134,7 +134,7 @@ func (it *archetypeIter) Has(comp ID) bool {
 
 // Get returns the pointer to the given component at the iterator's position
 func (it *archetypeIter) Get(comp ID) unsafe.Pointer {
-	return it.Archetype.GetUnsafe(it.Index, comp)
+	return it.Archetype.Get(it.Index, comp)
 }
 
 // Entity returns the entity at the iterator's position


### PR DESCRIPTION
Remove unsafe getter from archetype (problem with optional comps, minimal overhead)