### PR TITLE
More consistent `EntityEvent` values on removed entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.4.2...main)
+## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.4.3...main)
 
 Nothing
+
+## [[v0.4.3]](https://github.com/mlange-42/arche/compare/v0.4.2...v0.4.3)
+
+## Bugfixes
+
+* `EntityEvent` has more consistent values when an entity is removed (#115)
+  * `EntityEvent.NewMask` is zero
+  * `EntityEvent.Removed` is contains all former components
+  * `EntityEvent.Current` is `nil`
 
 ## [[v0.4.2]](https://github.com/mlange-42/arche/compare/v0.4.1...v0.4.2)
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -164,7 +164,7 @@ func (w *World) RemoveEntity(entity Entity) {
 	oldArch := index.arch
 
 	if w.listener != nil {
-		w.listener(EntityEvent{entity, oldArch.Mask, oldArch.Mask, nil, nil, oldArch.Ids, -1})
+		w.listener(EntityEvent{entity, oldArch.Mask, Mask{}, nil, oldArch.Ids, nil, -1})
 	}
 
 	swapped := oldArch.Remove(index.index)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -481,8 +481,9 @@ func TestWorldListener(t *testing.T) {
 	assert.Equal(t, EntityEvent{
 		Entity:       e0,
 		OldMask:      All(posID, velID),
-		NewMask:      All(posID, velID),
-		Current:      []ID{posID, velID},
+		NewMask:      Mask{},
+		Removed:      []ID{posID, velID},
+		Current:      nil,
 		AddedRemoved: -1,
 	}, events[len(events)-1])
 


### PR DESCRIPTION
* `EntityEvent` has more consistent values when an entity is removed
  * `EntityEvent.NewMask` is zero
  * `EntityEvent.Removed` is contains all former components
  * `EntityEvent.Current` is `nil`