### PR TITLE
Queries hold list of archetypes? Probably not...

### DIFF
--- a/ecs/query.go
+++ b/ecs/query.go
@@ -130,3 +130,18 @@ func (q *queryIter) Mask() Mask {
 func (q *queryIter) Close() {
 	q.world.closeQuery(q)
 }
+
+// JumpTo jumps to the given index of the query.
+func (q *queryIter) JumpTo(index int) {
+	q.archIndex = 0
+	q.archetype = q.archetypes[q.archIndex]
+	q.index = 0
+
+	idx := uint32(index)
+	for idx >= q.archetype.Len() {
+		idx -= q.archetype.Len()
+		q.archIndex++
+		q.archetype = q.archetypes[q.archIndex]
+	}
+	q.index = int(idx)
+}

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -37,6 +37,7 @@ func TestQuery(t *testing.T) {
 	w.Add(e4, rotID)
 
 	q := w.Query(All(posID, rotID))
+	assert.Equal(t, 2, q.Count())
 	cnt := 0
 	for q.Next() {
 		ent := q.Entity()
@@ -51,6 +52,7 @@ func TestQuery(t *testing.T) {
 	assert.Equal(t, 2, cnt)
 
 	q = w.Query(All(posID))
+	assert.Equal(t, 3, q.Count())
 	cnt = 0
 	for q.Next() {
 		ent := q.Entity()
@@ -105,6 +107,10 @@ func TestQuery(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 0, cnt)
+
+	q = w.Query(All(posID, rotID))
+	q.Close()
+	assert.Panics(t, func() { q.Next() })
 }
 
 func TestQueryClosed(t *testing.T) {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -385,21 +385,6 @@ func TestWorldLock(t *testing.T) {
 	assert.Panics(t, func() { world.Remove(entity, posID) })
 }
 
-func TestWorldNextArchetype(t *testing.T) {
-	world := NewWorld()
-
-	posID := ComponentID[position](&world)
-
-	var entity Entity
-	for i := 0; i < 10; i++ {
-		entity = world.NewEntity()
-		world.Add(entity, posID)
-	}
-
-	world.nextArchetype(All(posID), 0)
-	assert.Panics(t, func() { world.nextArchetype(All(posID), 2) })
-}
-
 func TestWorldStats(t *testing.T) {
 	w := NewWorld()
 
@@ -598,7 +583,6 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSize[componentRegistry]()
 	printTypeSize[bitPool]()
 	printTypeSize[Query]()
-	printTypeSize[archetypeIter]()
 }
 
 func printTypeSize[T any]() {


### PR DESCRIPTION
This would allow to get the count of entities in a query, as well as jumping to a certain position for e.g. random selection of entities.

However, it causes allocations when creating the query from a filter.

Not sure if this should really be merged.