### PR TITLE
World interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * The World handles ECS resources, i.e. component-like global data (!132)
 * Adds generic access to world resources (!132)
+* Adds interface `IWorld` to allow for using types that embed a World as arguments in many places (!134)
 
 ### Other
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -12,6 +12,8 @@ import (
 type IWorld interface {
 	NewEntity(comps ...ID) Entity
 	NewEntityWith(comps ...Component) Entity
+	RemoveEntity(entity Entity)
+	Alive(entity Entity) bool
 
 	Add(entity Entity, comps ...ID)
 	Assign(entity Entity, comps ...Component)
@@ -24,8 +26,14 @@ type IWorld interface {
 
 	Query(filter Filter) Query
 
+	AddResource(res any) ResID
 	GetResource(id ResID) interface{}
 	HasResource(id ResID) bool
+
+	Mask(entity Entity) Mask
+	IsLocked() bool
+	Stats() *stats.WorldStats
+	SetListener(listener func(e EntityEvent))
 
 	componentID(tp reflect.Type) ID
 	resourceID(tp reflect.Type) ResID

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -7,19 +7,41 @@ import (
 	"github.com/mlange-42/arche/ecs/stats"
 )
 
+// WorldComponents is an interface for accessing components. It is implemented by the [World].
+type WorldComponents interface {
+	NewEntity(comps ...ID) Entity
+	NewEntityWith(comps ...Component) Entity
+	Add(entity Entity, comps ...ID)
+	Assign(entity Entity, comps ...Component)
+	Remove(entity Entity, comps ...ID)
+	Exchange(entity Entity, add []ID, rem []ID)
+	Get(entity Entity, comp ID) unsafe.Pointer
+	Has(entity Entity, comp ID) bool
+	Set(entity Entity, id ID, comp interface{}) unsafe.Pointer
+	Query(filter Filter) Query
+	componentID(tp reflect.Type) ID
+}
+
+// WorldResources is an interface for accessing resources. It is implemented by the [World].
+type WorldResources interface {
+	GetResource(id ResID) interface{}
+	HasResource(id ResID) bool
+	resourceID(tp reflect.Type) ResID
+}
+
 // ComponentID returns the [ID] for a component type via generics. Registers the type if it is not already registered.
-func ComponentID[T any](w *World) ID {
+func ComponentID[T any](w WorldComponents) ID {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	return w.componentID(tp)
 }
 
 // TypeID returns the [ID] for a component type. Registers the type if it is not already registered.
-func TypeID(w *World, tp reflect.Type) ID {
+func TypeID(w WorldComponents, tp reflect.Type) ID {
 	return w.componentID(tp)
 }
 
 // ResourceID returns the [ResID] for a resource type via generics. Registers the type if it is not already registered.
-func ResourceID[T any](w *World) ResID {
+func ResourceID[T any](w WorldResources) ResID {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	return w.resourceID(tp)
 }
@@ -31,7 +53,7 @@ func ResourceID[T any](w *World) ResID {
 // Uses reflection. For more efficient access, see [World.GetResource],
 // and [github.com/mlange-42/arche/generic.Resource.Get] for a generic variant.
 // These methods are more than 20 times faster than the GetResource function.
-func GetResource[T any](w *World) *T {
+func GetResource[T any](w WorldResources) *T {
 	return w.GetResource(ResourceID[T](w)).(*T)
 }
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -7,41 +7,43 @@ import (
 	"github.com/mlange-42/arche/ecs/stats"
 )
 
-// WorldComponents is an interface for accessing components. It is implemented by the [World].
-type WorldComponents interface {
+// IWorld is an interface for accessing components and resources.
+// It is implemented by the [World] type.
+type IWorld interface {
 	NewEntity(comps ...ID) Entity
 	NewEntityWith(comps ...Component) Entity
+
 	Add(entity Entity, comps ...ID)
 	Assign(entity Entity, comps ...Component)
 	Remove(entity Entity, comps ...ID)
 	Exchange(entity Entity, add []ID, rem []ID)
+
 	Get(entity Entity, comp ID) unsafe.Pointer
 	Has(entity Entity, comp ID) bool
 	Set(entity Entity, id ID, comp interface{}) unsafe.Pointer
-	Query(filter Filter) Query
-	componentID(tp reflect.Type) ID
-}
 
-// WorldResources is an interface for accessing resources. It is implemented by the [World].
-type WorldResources interface {
+	Query(filter Filter) Query
+
 	GetResource(id ResID) interface{}
 	HasResource(id ResID) bool
+
+	componentID(tp reflect.Type) ID
 	resourceID(tp reflect.Type) ResID
 }
 
 // ComponentID returns the [ID] for a component type via generics. Registers the type if it is not already registered.
-func ComponentID[T any](w WorldComponents) ID {
+func ComponentID[T any](w IWorld) ID {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	return w.componentID(tp)
 }
 
 // TypeID returns the [ID] for a component type. Registers the type if it is not already registered.
-func TypeID(w WorldComponents, tp reflect.Type) ID {
+func TypeID(w IWorld, tp reflect.Type) ID {
 	return w.componentID(tp)
 }
 
 // ResourceID returns the [ResID] for a resource type via generics. Registers the type if it is not already registered.
-func ResourceID[T any](w WorldResources) ResID {
+func ResourceID[T any](w IWorld) ResID {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	return w.resourceID(tp)
 }
@@ -53,7 +55,7 @@ func ResourceID[T any](w WorldResources) ResID {
 // Uses reflection. For more efficient access, see [World.GetResource],
 // and [github.com/mlange-42/arche/generic.Resource.Get] for a generic variant.
 // These methods are more than 20 times faster than the GetResource function.
-func GetResource[T any](w WorldResources) *T {
+func GetResource[T any](w IWorld) *T {
 	return w.GetResource(ResourceID[T](w)).(*T)
 }
 

--- a/examples/systems/main.go
+++ b/examples/systems/main.go
@@ -26,13 +26,13 @@ func main() {
 
 // System interface
 type System interface {
-	Initialize(w *ecs.World)
-	Update(w *ecs.World)
+	Initialize(w *Scheduler)
+	Update(w *Scheduler)
 }
 
 // Scheduler for updating systems
 type Scheduler struct {
-	world   ecs.World
+	ecs.World
 	systems []System
 }
 
@@ -48,16 +48,16 @@ func (s *Scheduler) Run(steps int) {
 }
 
 func (s *Scheduler) initialize() {
-	s.world = ecs.NewWorld()
+	s.World = ecs.NewWorld()
 
 	for _, sys := range s.systems {
-		sys.Initialize(&s.world)
+		sys.Initialize(s)
 	}
 }
 
 func (s *Scheduler) update() {
 	for _, sys := range s.systems {
-		sys.Update(&s.world)
+		sys.Update(s)
 	}
 }
 
@@ -79,7 +79,7 @@ type InitializerSystem struct {
 }
 
 // Initialize the system
-func (s *InitializerSystem) Initialize(w *ecs.World) {
+func (s *InitializerSystem) Initialize(w *Scheduler) {
 	mapper := generic.NewMap2[Position, Velocity](w)
 	for i := 0; i < s.Count; i++ {
 		_, pos, vel := mapper.NewEntity()
@@ -92,7 +92,7 @@ func (s *InitializerSystem) Initialize(w *ecs.World) {
 }
 
 // Update the system
-func (s *InitializerSystem) Update(w *ecs.World) {}
+func (s *InitializerSystem) Update(w *Scheduler) {}
 
 // PosUpdaterSystem updates entity positions
 type PosUpdaterSystem struct {
@@ -100,12 +100,12 @@ type PosUpdaterSystem struct {
 }
 
 // Initialize the system
-func (s *PosUpdaterSystem) Initialize(w *ecs.World) {
+func (s *PosUpdaterSystem) Initialize(w *Scheduler) {
 	s.filter = *generic.NewFilter2[Position, Velocity]()
 }
 
 // Update the system
-func (s *PosUpdaterSystem) Update(w *ecs.World) {
+func (s *PosUpdaterSystem) Update(w *Scheduler) {
 	query := s.filter.Query(w)
 	for query.Next() {
 		pos, vel := query.Get()

--- a/examples/systems/main.go
+++ b/examples/systems/main.go
@@ -26,8 +26,8 @@ func main() {
 
 // System interface
 type System interface {
-	Initialize(w *Scheduler)
-	Update(w *Scheduler)
+	Initialize(w ecs.IWorld)
+	Update(w ecs.IWorld)
 }
 
 // Scheduler for updating systems
@@ -79,7 +79,7 @@ type InitializerSystem struct {
 }
 
 // Initialize the system
-func (s *InitializerSystem) Initialize(w *Scheduler) {
+func (s *InitializerSystem) Initialize(w ecs.IWorld) {
 	mapper := generic.NewMap2[Position, Velocity](w)
 	for i := 0; i < s.Count; i++ {
 		_, pos, vel := mapper.NewEntity()
@@ -92,7 +92,7 @@ func (s *InitializerSystem) Initialize(w *Scheduler) {
 }
 
 // Update the system
-func (s *InitializerSystem) Update(w *Scheduler) {}
+func (s *InitializerSystem) Update(w ecs.IWorld) {}
 
 // PosUpdaterSystem updates entity positions
 type PosUpdaterSystem struct {
@@ -100,12 +100,12 @@ type PosUpdaterSystem struct {
 }
 
 // Initialize the system
-func (s *PosUpdaterSystem) Initialize(w *Scheduler) {
+func (s *PosUpdaterSystem) Initialize(w ecs.IWorld) {
 	s.filter = *generic.NewFilter2[Position, Velocity]()
 }
 
 // Update the system
-func (s *PosUpdaterSystem) Update(w *Scheduler) {
+func (s *PosUpdaterSystem) Update(w ecs.IWorld) {
 	query := s.filter.Query(w)
 	for query.Next() {
 		pos, vel := query.Get()

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -10,7 +10,7 @@ type compiledQuery struct {
 	compiled bool
 }
 
-func (q *compiledQuery) Compile(world ecs.WorldComponents, include, optional, exclude []Comp) {
+func (q *compiledQuery) Compile(world ecs.IWorld, include, optional, exclude []Comp) {
 	if q.compiled {
 		return
 	}

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -10,14 +10,14 @@ type compiledQuery struct {
 	compiled bool
 }
 
-func (q *compiledQuery) Compile(w *ecs.World, include, optional, exclude []Comp) {
+func (q *compiledQuery) Compile(world ecs.WorldComponents, include, optional, exclude []Comp) {
 	if q.compiled {
 		return
 	}
-	q.Ids = toIds(w, include)
+	q.Ids = toIds(world, include)
 	q.filter = ecs.MaskFilter{
-		Include: toMaskOptional(w, q.Ids, optional),
-		Exclude: toMask(w, exclude),
+		Include: toMaskOptional(world, q.Ids, optional),
+		Exclude: toMask(world, exclude),
 	}
 	q.compiled = true
 }

--- a/generic/exchange.go
+++ b/generic/exchange.go
@@ -14,13 +14,13 @@ import "github.com/mlange-42/arche/ecs"
 type Exchange struct {
 	add    []ecs.ID
 	remove []ecs.ID
-	world  *ecs.World
+	world  ecs.WorldComponents
 }
 
 // NewExchange creates a new Exchange object.
-func NewExchange(w *ecs.World) *Exchange {
+func NewExchange(world ecs.WorldComponents) *Exchange {
 	return &Exchange{
-		world: w,
+		world: world,
 	}
 }
 

--- a/generic/exchange.go
+++ b/generic/exchange.go
@@ -14,11 +14,11 @@ import "github.com/mlange-42/arche/ecs"
 type Exchange struct {
 	add    []ecs.ID
 	remove []ecs.ID
-	world  ecs.WorldComponents
+	world  ecs.IWorld
 }
 
 // NewExchange creates a new Exchange object.
-func NewExchange(world ecs.WorldComponents) *Exchange {
+func NewExchange(world ecs.IWorld) *Exchange {
 	return &Exchange{
 		world: world,
 	}

--- a/generic/generate/main.go
+++ b/generic/generate/main.go
@@ -62,7 +62,7 @@ func generateMaps() {
 			types = "[" + strings.Join(typeLetters[:i], ", ") + "]"
 			returnTypes = "*" + strings.Join(typeLetters[:i], ", *")
 			fullTypes = "[" + strings.Join(typeLetters[:i], " any, ") + " any]"
-			include = "[]ecs.ID{ecs.ComponentID[" + strings.Join(typeLetters[:i], "](w), ecs.ComponentID[") + "](w)}"
+			include = "[]ecs.ID{ecs.ComponentID[" + strings.Join(typeLetters[:i], "](world), ecs.ComponentID[") + "](world)}"
 		} else {
 			include = "[]ecs.ID{}"
 		}

--- a/generic/generate/map.go.txt
+++ b/generic/generate/map.go.txt
@@ -4,14 +4,14 @@
 // Map{{ .Index }} is a helper for mapping {{ .NumberStr }} components.
 type Map{{ .Index }}{{ .TypesFull }} struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.Components
 }
 
 // NewMap{{ .Index }} creates a new Map{{ .Index }} object.
-func NewMap{{ .Index }}{{ .TypesFull }}(w *ecs.World) Map{{ .Index }}{{ .Types }} {
+func NewMap{{ .Index }}{{ .TypesFull }}(world ecs.Components) Map{{ .Index }}{{ .Types }} {
 	return Map{{ .Index }}{{ .Types }}{
 		ids:   {{ .Include }},
-		world: w,
+		world: world,
 	}
 }
 

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -46,10 +46,10 @@ func (q *Filter{{ .Index }}{{ .Types }}) Without(mask ...Comp) *Filter{{ .Index 
 }
 
 // Query builds a [Query{{ .Index }}] query for iteration.
-func (q *Filter{{ .Index }}{{ .Types }}) Query(w *ecs.World) Query{{ .Index }}{{ .Types }} {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter{{ .Index }}{{ .Types }}) Query(world ecs.Components) Query{{ .Index }}{{ .Types }} {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query{{ .Index }}{{ .Types }}{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -58,8 +58,8 @@ func (q *Filter{{ .Index }}{{ .Types }}) Query(w *ecs.World) Query{{ .Index }}{{
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter{{ .Index }}.Query].
-func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter{{ .Index }}{{ .Types }}) Filter(world ecs.Components) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 

--- a/generic/map.go
+++ b/generic/map.go
@@ -7,7 +7,7 @@ import "github.com/mlange-42/arche/ecs"
 // Create one with [NewMap].
 type Map[T any] struct {
 	id    ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap creates a new [Map] for a component type.
@@ -15,10 +15,10 @@ type Map[T any] struct {
 // Map provides a type-safe way to access a component type by entity ID.
 //
 // See also [ecs.World.Get], [ecs.World.Has] and [ecs.World.Set].
-func NewMap[T any](w *ecs.World) Map[T] {
+func NewMap[T any](world ecs.WorldComponents) Map[T] {
 	return Map[T]{
-		id:    ecs.ComponentID[T](w),
-		world: w,
+		id:    ecs.ComponentID[T](world),
+		world: world,
 	}
 }
 

--- a/generic/map.go
+++ b/generic/map.go
@@ -7,7 +7,7 @@ import "github.com/mlange-42/arche/ecs"
 // Create one with [NewMap].
 type Map[T any] struct {
 	id    ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap creates a new [Map] for a component type.
@@ -15,7 +15,7 @@ type Map[T any] struct {
 // Map provides a type-safe way to access a component type by entity ID.
 //
 // See also [ecs.World.Get], [ecs.World.Has] and [ecs.World.Set].
-func NewMap[T any](world ecs.WorldComponents) Map[T] {
+func NewMap[T any](world ecs.IWorld) Map[T] {
 	return Map[T]{
 		id:    ecs.ComponentID[T](world),
 		world: world,

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -11,11 +11,11 @@ import (
 // Map1 is a helper for mapping one components.
 type Map1[A any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap1 creates a new Map1 object.
-func NewMap1[A any](world ecs.WorldComponents) Map1[A] {
+func NewMap1[A any](world ecs.IWorld) Map1[A] {
 	return Map1[A]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world)},
 		world: world,
@@ -77,11 +77,11 @@ func (m *Map1[A]) Remove(entity ecs.Entity) {
 // Map2 is a helper for mapping two components.
 type Map2[A any, B any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap2 creates a new Map2 object.
-func NewMap2[A any, B any](world ecs.WorldComponents) Map2[A, B] {
+func NewMap2[A any, B any](world ecs.IWorld) Map2[A, B] {
 	return Map2[A, B]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world)},
 		world: world,
@@ -145,11 +145,11 @@ func (m *Map2[A, B]) Remove(entity ecs.Entity) {
 // Map3 is a helper for mapping three components.
 type Map3[A any, B any, C any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap3 creates a new Map3 object.
-func NewMap3[A any, B any, C any](world ecs.WorldComponents) Map3[A, B, C] {
+func NewMap3[A any, B any, C any](world ecs.IWorld) Map3[A, B, C] {
 	return Map3[A, B, C]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world)},
 		world: world,
@@ -215,11 +215,11 @@ func (m *Map3[A, B, C]) Remove(entity ecs.Entity) {
 // Map4 is a helper for mapping four components.
 type Map4[A any, B any, C any, D any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap4 creates a new Map4 object.
-func NewMap4[A any, B any, C any, D any](world ecs.WorldComponents) Map4[A, B, C, D] {
+func NewMap4[A any, B any, C any, D any](world ecs.IWorld) Map4[A, B, C, D] {
 	return Map4[A, B, C, D]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world)},
 		world: world,
@@ -287,11 +287,11 @@ func (m *Map4[A, B, C, D]) Remove(entity ecs.Entity) {
 // Map5 is a helper for mapping five components.
 type Map5[A any, B any, C any, D any, E any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap5 creates a new Map5 object.
-func NewMap5[A any, B any, C any, D any, E any](world ecs.WorldComponents) Map5[A, B, C, D, E] {
+func NewMap5[A any, B any, C any, D any, E any](world ecs.IWorld) Map5[A, B, C, D, E] {
 	return Map5[A, B, C, D, E]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world)},
 		world: world,
@@ -361,11 +361,11 @@ func (m *Map5[A, B, C, D, E]) Remove(entity ecs.Entity) {
 // Map6 is a helper for mapping six components.
 type Map6[A any, B any, C any, D any, E any, F any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap6 creates a new Map6 object.
-func NewMap6[A any, B any, C any, D any, E any, F any](world ecs.WorldComponents) Map6[A, B, C, D, E, F] {
+func NewMap6[A any, B any, C any, D any, E any, F any](world ecs.IWorld) Map6[A, B, C, D, E, F] {
 	return Map6[A, B, C, D, E, F]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world)},
 		world: world,
@@ -437,11 +437,11 @@ func (m *Map6[A, B, C, D, E, F]) Remove(entity ecs.Entity) {
 // Map7 is a helper for mapping seven components.
 type Map7[A any, B any, C any, D any, E any, F any, G any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap7 creates a new Map7 object.
-func NewMap7[A any, B any, C any, D any, E any, F any, G any](world ecs.WorldComponents) Map7[A, B, C, D, E, F, G] {
+func NewMap7[A any, B any, C any, D any, E any, F any, G any](world ecs.IWorld) Map7[A, B, C, D, E, F, G] {
 	return Map7[A, B, C, D, E, F, G]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world), ecs.ComponentID[G](world)},
 		world: world,
@@ -515,11 +515,11 @@ func (m *Map7[A, B, C, D, E, F, G]) Remove(entity ecs.Entity) {
 // Map8 is a helper for mapping eight components.
 type Map8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 	ids   []ecs.ID
-	world ecs.WorldComponents
+	world ecs.IWorld
 }
 
 // NewMap8 creates a new Map8 object.
-func NewMap8[A any, B any, C any, D any, E any, F any, G any, H any](world ecs.WorldComponents) Map8[A, B, C, D, E, F, G, H] {
+func NewMap8[A any, B any, C any, D any, E any, F any, G any, H any](world ecs.IWorld) Map8[A, B, C, D, E, F, G, H] {
 	return Map8[A, B, C, D, E, F, G, H]{
 		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world), ecs.ComponentID[G](world), ecs.ComponentID[H](world)},
 		world: world,

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -11,14 +11,14 @@ import (
 // Map1 is a helper for mapping one components.
 type Map1[A any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap1 creates a new Map1 object.
-func NewMap1[A any](w *ecs.World) Map1[A] {
+func NewMap1[A any](world ecs.WorldComponents) Map1[A] {
 	return Map1[A]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world)},
+		world: world,
 	}
 }
 
@@ -77,14 +77,14 @@ func (m *Map1[A]) Remove(entity ecs.Entity) {
 // Map2 is a helper for mapping two components.
 type Map2[A any, B any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap2 creates a new Map2 object.
-func NewMap2[A any, B any](w *ecs.World) Map2[A, B] {
+func NewMap2[A any, B any](world ecs.WorldComponents) Map2[A, B] {
 	return Map2[A, B]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world)},
+		world: world,
 	}
 }
 
@@ -145,14 +145,14 @@ func (m *Map2[A, B]) Remove(entity ecs.Entity) {
 // Map3 is a helper for mapping three components.
 type Map3[A any, B any, C any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap3 creates a new Map3 object.
-func NewMap3[A any, B any, C any](w *ecs.World) Map3[A, B, C] {
+func NewMap3[A any, B any, C any](world ecs.WorldComponents) Map3[A, B, C] {
 	return Map3[A, B, C]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world)},
+		world: world,
 	}
 }
 
@@ -215,14 +215,14 @@ func (m *Map3[A, B, C]) Remove(entity ecs.Entity) {
 // Map4 is a helper for mapping four components.
 type Map4[A any, B any, C any, D any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap4 creates a new Map4 object.
-func NewMap4[A any, B any, C any, D any](w *ecs.World) Map4[A, B, C, D] {
+func NewMap4[A any, B any, C any, D any](world ecs.WorldComponents) Map4[A, B, C, D] {
 	return Map4[A, B, C, D]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w), ecs.ComponentID[D](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world)},
+		world: world,
 	}
 }
 
@@ -287,14 +287,14 @@ func (m *Map4[A, B, C, D]) Remove(entity ecs.Entity) {
 // Map5 is a helper for mapping five components.
 type Map5[A any, B any, C any, D any, E any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap5 creates a new Map5 object.
-func NewMap5[A any, B any, C any, D any, E any](w *ecs.World) Map5[A, B, C, D, E] {
+func NewMap5[A any, B any, C any, D any, E any](world ecs.WorldComponents) Map5[A, B, C, D, E] {
 	return Map5[A, B, C, D, E]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w), ecs.ComponentID[D](w), ecs.ComponentID[E](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world)},
+		world: world,
 	}
 }
 
@@ -361,14 +361,14 @@ func (m *Map5[A, B, C, D, E]) Remove(entity ecs.Entity) {
 // Map6 is a helper for mapping six components.
 type Map6[A any, B any, C any, D any, E any, F any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap6 creates a new Map6 object.
-func NewMap6[A any, B any, C any, D any, E any, F any](w *ecs.World) Map6[A, B, C, D, E, F] {
+func NewMap6[A any, B any, C any, D any, E any, F any](world ecs.WorldComponents) Map6[A, B, C, D, E, F] {
 	return Map6[A, B, C, D, E, F]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w), ecs.ComponentID[D](w), ecs.ComponentID[E](w), ecs.ComponentID[F](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world)},
+		world: world,
 	}
 }
 
@@ -437,14 +437,14 @@ func (m *Map6[A, B, C, D, E, F]) Remove(entity ecs.Entity) {
 // Map7 is a helper for mapping seven components.
 type Map7[A any, B any, C any, D any, E any, F any, G any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap7 creates a new Map7 object.
-func NewMap7[A any, B any, C any, D any, E any, F any, G any](w *ecs.World) Map7[A, B, C, D, E, F, G] {
+func NewMap7[A any, B any, C any, D any, E any, F any, G any](world ecs.WorldComponents) Map7[A, B, C, D, E, F, G] {
 	return Map7[A, B, C, D, E, F, G]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w), ecs.ComponentID[D](w), ecs.ComponentID[E](w), ecs.ComponentID[F](w), ecs.ComponentID[G](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world), ecs.ComponentID[G](world)},
+		world: world,
 	}
 }
 
@@ -515,14 +515,14 @@ func (m *Map7[A, B, C, D, E, F, G]) Remove(entity ecs.Entity) {
 // Map8 is a helper for mapping eight components.
 type Map8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 	ids   []ecs.ID
-	world *ecs.World
+	world ecs.WorldComponents
 }
 
 // NewMap8 creates a new Map8 object.
-func NewMap8[A any, B any, C any, D any, E any, F any, G any, H any](w *ecs.World) Map8[A, B, C, D, E, F, G, H] {
+func NewMap8[A any, B any, C any, D any, E any, F any, G any, H any](world ecs.WorldComponents) Map8[A, B, C, D, E, F, G, H] {
 	return Map8[A, B, C, D, E, F, G, H]{
-		ids:   []ecs.ID{ecs.ComponentID[A](w), ecs.ComponentID[B](w), ecs.ComponentID[C](w), ecs.ComponentID[D](w), ecs.ComponentID[E](w), ecs.ComponentID[F](w), ecs.ComponentID[G](w), ecs.ComponentID[H](w)},
-		world: w,
+		ids:   []ecs.ID{ecs.ComponentID[A](world), ecs.ComponentID[B](world), ecs.ComponentID[C](world), ecs.ComponentID[D](world), ecs.ComponentID[E](world), ecs.ComponentID[F](world), ecs.ComponentID[G](world), ecs.ComponentID[H](world)},
+		world: world,
 	}
 }
 

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -40,10 +40,10 @@ func (q *Filter0) Without(mask ...Comp) *Filter0 {
 }
 
 // Query builds a [Query0] query for iteration.
-func (q *Filter0) Query(w *ecs.World) Query0 {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter0) Query(world ecs.WorldComponents) Query0 {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query0{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -52,8 +52,8 @@ func (q *Filter0) Query(w *ecs.World) Query0 {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter0.Query].
-func (q *Filter0) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter0) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -112,10 +112,10 @@ func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
 }
 
 // Query builds a [Query1] query for iteration.
-func (q *Filter1[A]) Query(w *ecs.World) Query1[A] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter1[A]) Query(world ecs.WorldComponents) Query1[A] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query1[A]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -124,8 +124,8 @@ func (q *Filter1[A]) Query(w *ecs.World) Query1[A] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter1.Query].
-func (q *Filter1[A]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter1[A]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -191,10 +191,10 @@ func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
 }
 
 // Query builds a [Query2] query for iteration.
-func (q *Filter2[A, B]) Query(w *ecs.World) Query2[A, B] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter2[A, B]) Query(world ecs.WorldComponents) Query2[A, B] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query2[A, B]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -203,8 +203,8 @@ func (q *Filter2[A, B]) Query(w *ecs.World) Query2[A, B] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter2.Query].
-func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter2[A, B]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -270,10 +270,10 @@ func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
 }
 
 // Query builds a [Query3] query for iteration.
-func (q *Filter3[A, B, C]) Query(w *ecs.World) Query3[A, B, C] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter3[A, B, C]) Query(world ecs.WorldComponents) Query3[A, B, C] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query3[A, B, C]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -282,8 +282,8 @@ func (q *Filter3[A, B, C]) Query(w *ecs.World) Query3[A, B, C] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter3.Query].
-func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter3[A, B, C]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -349,10 +349,10 @@ func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
 }
 
 // Query builds a [Query4] query for iteration.
-func (q *Filter4[A, B, C, D]) Query(w *ecs.World) Query4[A, B, C, D] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter4[A, B, C, D]) Query(world ecs.WorldComponents) Query4[A, B, C, D] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query4[A, B, C, D]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -361,8 +361,8 @@ func (q *Filter4[A, B, C, D]) Query(w *ecs.World) Query4[A, B, C, D] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter4.Query].
-func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter4[A, B, C, D]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -428,10 +428,10 @@ func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
 }
 
 // Query builds a [Query5] query for iteration.
-func (q *Filter5[A, B, C, D, E]) Query(w *ecs.World) Query5[A, B, C, D, E] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter5[A, B, C, D, E]) Query(world ecs.WorldComponents) Query5[A, B, C, D, E] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query5[A, B, C, D, E]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -440,8 +440,8 @@ func (q *Filter5[A, B, C, D, E]) Query(w *ecs.World) Query5[A, B, C, D, E] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter5.Query].
-func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter5[A, B, C, D, E]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -507,10 +507,10 @@ func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E
 }
 
 // Query builds a [Query6] query for iteration.
-func (q *Filter6[A, B, C, D, E, F]) Query(w *ecs.World) Query6[A, B, C, D, E, F] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter6[A, B, C, D, E, F]) Query(world ecs.WorldComponents) Query6[A, B, C, D, E, F] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query6[A, B, C, D, E, F]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -519,8 +519,8 @@ func (q *Filter6[A, B, C, D, E, F]) Query(w *ecs.World) Query6[A, B, C, D, E, F]
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter6.Query].
-func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter6[A, B, C, D, E, F]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -586,10 +586,10 @@ func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D
 }
 
 // Query builds a [Query7] query for iteration.
-func (q *Filter7[A, B, C, D, E, F, G]) Query(w *ecs.World) Query7[A, B, C, D, E, F, G] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter7[A, B, C, D, E, F, G]) Query(world ecs.WorldComponents) Query7[A, B, C, D, E, F, G] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query7[A, B, C, D, E, F, G]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -598,8 +598,8 @@ func (q *Filter7[A, B, C, D, E, F, G]) Query(w *ecs.World) Query7[A, B, C, D, E,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter7.Query].
-func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter7[A, B, C, D, E, F, G]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 
@@ -665,10 +665,10 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C
 }
 
 // Query builds a [Query8] query for iteration.
-func (q *Filter8[A, B, C, D, E, F, G, H]) Query(w *ecs.World) Query8[A, B, C, D, E, F, G, H] {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter8[A, B, C, D, E, F, G, H]) Query(world ecs.WorldComponents) Query8[A, B, C, D, E, F, G, H] {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query8[A, B, C, D, E, F, G, H]{
-		w.Query(&q.compiled.filter),
+		world.Query(&q.compiled.filter),
 		q.compiled.Ids,
 	}
 }
@@ -677,8 +677,8 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Query(w *ecs.World) Query8[A, B, C, D,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter8.Query].
-func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.MaskFilter {
-	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
 

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -40,7 +40,7 @@ func (q *Filter0) Without(mask ...Comp) *Filter0 {
 }
 
 // Query builds a [Query0] query for iteration.
-func (q *Filter0) Query(world ecs.WorldComponents) Query0 {
+func (q *Filter0) Query(world ecs.IWorld) Query0 {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query0{
 		world.Query(&q.compiled.filter),
@@ -52,7 +52,7 @@ func (q *Filter0) Query(world ecs.WorldComponents) Query0 {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter0.Query].
-func (q *Filter0) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter0) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -112,7 +112,7 @@ func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
 }
 
 // Query builds a [Query1] query for iteration.
-func (q *Filter1[A]) Query(world ecs.WorldComponents) Query1[A] {
+func (q *Filter1[A]) Query(world ecs.IWorld) Query1[A] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query1[A]{
 		world.Query(&q.compiled.filter),
@@ -124,7 +124,7 @@ func (q *Filter1[A]) Query(world ecs.WorldComponents) Query1[A] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter1.Query].
-func (q *Filter1[A]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter1[A]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -191,7 +191,7 @@ func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
 }
 
 // Query builds a [Query2] query for iteration.
-func (q *Filter2[A, B]) Query(world ecs.WorldComponents) Query2[A, B] {
+func (q *Filter2[A, B]) Query(world ecs.IWorld) Query2[A, B] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query2[A, B]{
 		world.Query(&q.compiled.filter),
@@ -203,7 +203,7 @@ func (q *Filter2[A, B]) Query(world ecs.WorldComponents) Query2[A, B] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter2.Query].
-func (q *Filter2[A, B]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter2[A, B]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -270,7 +270,7 @@ func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
 }
 
 // Query builds a [Query3] query for iteration.
-func (q *Filter3[A, B, C]) Query(world ecs.WorldComponents) Query3[A, B, C] {
+func (q *Filter3[A, B, C]) Query(world ecs.IWorld) Query3[A, B, C] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query3[A, B, C]{
 		world.Query(&q.compiled.filter),
@@ -282,7 +282,7 @@ func (q *Filter3[A, B, C]) Query(world ecs.WorldComponents) Query3[A, B, C] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter3.Query].
-func (q *Filter3[A, B, C]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter3[A, B, C]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -349,7 +349,7 @@ func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
 }
 
 // Query builds a [Query4] query for iteration.
-func (q *Filter4[A, B, C, D]) Query(world ecs.WorldComponents) Query4[A, B, C, D] {
+func (q *Filter4[A, B, C, D]) Query(world ecs.IWorld) Query4[A, B, C, D] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query4[A, B, C, D]{
 		world.Query(&q.compiled.filter),
@@ -361,7 +361,7 @@ func (q *Filter4[A, B, C, D]) Query(world ecs.WorldComponents) Query4[A, B, C, D
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter4.Query].
-func (q *Filter4[A, B, C, D]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter4[A, B, C, D]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -428,7 +428,7 @@ func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
 }
 
 // Query builds a [Query5] query for iteration.
-func (q *Filter5[A, B, C, D, E]) Query(world ecs.WorldComponents) Query5[A, B, C, D, E] {
+func (q *Filter5[A, B, C, D, E]) Query(world ecs.IWorld) Query5[A, B, C, D, E] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query5[A, B, C, D, E]{
 		world.Query(&q.compiled.filter),
@@ -440,7 +440,7 @@ func (q *Filter5[A, B, C, D, E]) Query(world ecs.WorldComponents) Query5[A, B, C
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter5.Query].
-func (q *Filter5[A, B, C, D, E]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter5[A, B, C, D, E]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -507,7 +507,7 @@ func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E
 }
 
 // Query builds a [Query6] query for iteration.
-func (q *Filter6[A, B, C, D, E, F]) Query(world ecs.WorldComponents) Query6[A, B, C, D, E, F] {
+func (q *Filter6[A, B, C, D, E, F]) Query(world ecs.IWorld) Query6[A, B, C, D, E, F] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query6[A, B, C, D, E, F]{
 		world.Query(&q.compiled.filter),
@@ -519,7 +519,7 @@ func (q *Filter6[A, B, C, D, E, F]) Query(world ecs.WorldComponents) Query6[A, B
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter6.Query].
-func (q *Filter6[A, B, C, D, E, F]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter6[A, B, C, D, E, F]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -586,7 +586,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D
 }
 
 // Query builds a [Query7] query for iteration.
-func (q *Filter7[A, B, C, D, E, F, G]) Query(world ecs.WorldComponents) Query7[A, B, C, D, E, F, G] {
+func (q *Filter7[A, B, C, D, E, F, G]) Query(world ecs.IWorld) Query7[A, B, C, D, E, F, G] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query7[A, B, C, D, E, F, G]{
 		world.Query(&q.compiled.filter),
@@ -598,7 +598,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Query(world ecs.WorldComponents) Query7[A
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter7.Query].
-func (q *Filter7[A, B, C, D, E, F, G]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter7[A, B, C, D, E, F, G]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }
@@ -665,7 +665,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C
 }
 
 // Query builds a [Query8] query for iteration.
-func (q *Filter8[A, B, C, D, E, F, G, H]) Query(world ecs.WorldComponents) Query8[A, B, C, D, E, F, G, H] {
+func (q *Filter8[A, B, C, D, E, F, G, H]) Query(world ecs.IWorld) Query8[A, B, C, D, E, F, G, H] {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return Query8[A, B, C, D, E, F, G, H]{
 		world.Query(&q.compiled.filter),
@@ -677,7 +677,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Query(world ecs.WorldComponents) Query
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter8.Query].
-func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(world ecs.WorldComponents) ecs.MaskFilter {
+func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(world ecs.IWorld) ecs.MaskFilter {
 	q.compiled.Compile(world, q.include, q.optional, q.exclude)
 	return q.compiled.filter
 }

--- a/generic/resource.go
+++ b/generic/resource.go
@@ -7,7 +7,7 @@ import "github.com/mlange-42/arche/ecs"
 // Create one with [NewResource].
 type Resource[T any] struct {
 	id    ecs.ResID
-	world ecs.WorldResources
+	world ecs.IWorld
 }
 
 // NewResource creates a new [Resource] mapper for a resource type.
@@ -16,7 +16,7 @@ type Resource[T any] struct {
 // [Resource] provides a type-safe way to access a world resources.
 //
 // See also [ecs.World.GetResource], [ecs.World.HasResource] and [ecs.World.AddResource].
-func NewResource[T any](world ecs.WorldResources) Resource[T] {
+func NewResource[T any](world ecs.IWorld) Resource[T] {
 	return Resource[T]{
 		id:    ecs.ResourceID[T](world),
 		world: world,

--- a/generic/resource.go
+++ b/generic/resource.go
@@ -7,7 +7,7 @@ import "github.com/mlange-42/arche/ecs"
 // Create one with [NewResource].
 type Resource[T any] struct {
 	id    ecs.ResID
-	world *ecs.World
+	world ecs.WorldResources
 }
 
 // NewResource creates a new [Resource] mapper for a resource type.
@@ -16,10 +16,10 @@ type Resource[T any] struct {
 // [Resource] provides a type-safe way to access a world resources.
 //
 // See also [ecs.World.GetResource], [ecs.World.HasResource] and [ecs.World.AddResource].
-func NewResource[T any](w *ecs.World) Resource[T] {
+func NewResource[T any](world ecs.WorldResources) Resource[T] {
 	return Resource[T]{
-		id:    ecs.ResourceID[T](w),
-		world: w,
+		id:    ecs.ResourceID[T](world),
+		world: world,
 	}
 }
 

--- a/generic/util.go
+++ b/generic/util.go
@@ -17,7 +17,7 @@ func typeOf[T any]() Comp {
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
 
-func toIds(w *ecs.World, types []Comp) []ecs.ID {
+func toIds(w ecs.WorldComponents, types []Comp) []ecs.ID {
 	ids := make([]ecs.ID, len(types))
 	for i, t := range types {
 		ids[i] = ecs.TypeID(w, t)
@@ -25,7 +25,7 @@ func toIds(w *ecs.World, types []Comp) []ecs.ID {
 	return ids
 }
 
-func toMask(w *ecs.World, types []Comp) ecs.Mask {
+func toMask(w ecs.WorldComponents, types []Comp) ecs.Mask {
 	mask := ecs.Mask{}
 	for _, t := range types {
 		mask.Set(ecs.TypeID(w, t), true)
@@ -33,7 +33,7 @@ func toMask(w *ecs.World, types []Comp) ecs.Mask {
 	return mask
 }
 
-func toMaskOptional(w *ecs.World, include []ecs.ID, optional []Comp) ecs.Mask {
+func toMaskOptional(w ecs.WorldComponents, include []ecs.ID, optional []Comp) ecs.Mask {
 	mask := ecs.All(include...)
 	for _, t := range optional {
 		mask.Set(ecs.TypeID(w, t), false)

--- a/generic/util.go
+++ b/generic/util.go
@@ -17,7 +17,7 @@ func typeOf[T any]() Comp {
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
 
-func toIds(w ecs.WorldComponents, types []Comp) []ecs.ID {
+func toIds(w ecs.IWorld, types []Comp) []ecs.ID {
 	ids := make([]ecs.ID, len(types))
 	for i, t := range types {
 		ids[i] = ecs.TypeID(w, t)
@@ -25,7 +25,7 @@ func toIds(w ecs.WorldComponents, types []Comp) []ecs.ID {
 	return ids
 }
 
-func toMask(w ecs.WorldComponents, types []Comp) ecs.Mask {
+func toMask(w ecs.IWorld, types []Comp) ecs.Mask {
 	mask := ecs.Mask{}
 	for _, t := range types {
 		mask.Set(ecs.TypeID(w, t), true)
@@ -33,7 +33,7 @@ func toMask(w ecs.WorldComponents, types []Comp) ecs.Mask {
 	return mask
 }
 
-func toMaskOptional(w ecs.WorldComponents, include []ecs.ID, optional []Comp) ecs.Mask {
+func toMaskOptional(w ecs.IWorld, include []ecs.ID, optional []Comp) ecs.Mask {
 	mask := ecs.All(include...)
 	for _, t := range optional {
 		mask.Set(ecs.TypeID(w, t), false)


### PR DESCRIPTION
Use an interface to the world to make working with an embedded world easier.

However, this slows down generic access in some cases by factor 2. So will probably not get merged.