### PR TITLE
Bugfix: Allow GC on pointers in removed components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Speedup of archetype mask checks by 10% by checking mask before empty archetype (!139)
 * Speedup of generic queries and mappers to come closer to ID-based access (!144)
 
+### Bugfixes
+
+* Archetype storage buffers are "zeroed" when removing entities, to allow GC on pointers and slices in components (!147)
+
 ## [[v0.5.1]](https://github.com/mlange-42/arche/compare/v0.5.0...v0.5.1)
 
 ### Performance

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -207,6 +207,7 @@ func (a *archetype) Remove(index uintptr) bool {
 			a.copy(src, dst, lay.itemSize)
 		}
 	}
+	a.ZeroAll(old)
 	a.len--
 
 	return swapped
@@ -264,6 +265,9 @@ func (a *archetype) SetPointer(index uintptr, id ID, comp unsafe.Pointer) unsafe
 // Does NOT free the reserved memory.
 func (a *archetype) Reset() {
 	a.len = 0
+	for _, buf := range a.buffers {
+		buf.SetZero()
+	}
 }
 
 // Components returns the component IDs for this archetype


### PR DESCRIPTION
Set component memory to zero when removing from or resetting archetype.