### PR TITLE
Move resource handling out of the world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 * Generic mappers do no longer return all components when creating entities or components (!145)
+* Resources API moved out of the world, to a helper to get by `World.Resources()` (!150)
 
 ### Features
 

--- a/benchmark/arche/resources/arche_test.go
+++ b/benchmark/arche/resources/arche_test.go
@@ -12,14 +12,16 @@ func BenchmarkArcheGetResource(b *testing.B) {
 	b.StopTimer()
 
 	w := ecs.NewWorld()
+	resources := w.Resources()
+
 	posID := ecs.ResourceID[c.Position](&w)
-	w.AddResource(posID, &c.Position{X: 1, Y: 2})
+	resources.Add(posID, &c.Position{X: 1, Y: 2})
 
 	b.StartTimer()
 
 	var res *c.Position
 	for i := 0; i < b.N; i++ {
-		res = w.GetResource(posID).(*c.Position)
+		res = resources.Get(posID).(*c.Position)
 	}
 
 	_ = res
@@ -46,14 +48,16 @@ func BenchmarkArcheHasResource(b *testing.B) {
 	b.StopTimer()
 
 	w := ecs.NewWorld()
+	resources := w.Resources()
+
 	posID := ecs.ResourceID[c.Position](&w)
-	w.AddResource(posID, &c.Position{X: 1, Y: 2})
+	resources.Add(posID, &c.Position{X: 1, Y: 2})
 
 	b.StartTimer()
 
 	var res bool
 	for i := 0; i < b.N; i++ {
-		res = w.HasResource(posID)
+		res = resources.Has(posID)
 	}
 
 	_ = res

--- a/ecs/resources.go
+++ b/ecs/resources.go
@@ -5,13 +5,15 @@ import (
 	"reflect"
 )
 
-type resources struct {
+// Resources manage a world's resources.
+// Access is using [World.Resources].
+type Resources struct {
 	registry  componentRegistry[ResID]
 	resources []any
 }
 
-func newResources() resources {
-	return resources{
+func newResources() Resources {
+	return Resources{
 		registry:  newComponentRegistry(),
 		resources: make([]any, MaskTotalBits),
 	}
@@ -21,7 +23,9 @@ func newResources() resources {
 // The resource should always be a pointer.
 //
 // Panics if there is already a resource of the given type.
-func (r *resources) Add(id ResID, res any) {
+//
+// See also [github.com/mlange-42/arche/generic.Resource.Add] for a generic variant.
+func (r *Resources) Add(id ResID, res any) {
 	if r.resources[id] != nil {
 		panic(fmt.Sprintf("Resource of ID %d was already added (type %v)", id, reflect.TypeOf(res)))
 	}
@@ -31,7 +35,9 @@ func (r *resources) Add(id ResID, res any) {
 // Remove removes a resource from the world.
 //
 // Panics if there is no resource of the given type.
-func (r *resources) Remove(id ResID) {
+//
+// See also [github.com/mlange-42/arche/generic.Resource.Remove] for a generic variant.
+func (r *Resources) Remove(id ResID) {
 	if r.resources[id] == nil {
 		panic(fmt.Sprintf("Resource of ID %d is not present", id))
 	}
@@ -41,17 +47,21 @@ func (r *resources) Remove(id ResID) {
 // Get returns a pointer to the resource of the given type.
 //
 // Returns nil if there is no such resource.
-func (r *resources) Get(id ResID) interface{} {
+//
+// See also [github.com/mlange-42/arche/generic.Resource.Get] for a generic variant.
+func (r *Resources) Get(id ResID) interface{} {
 	return r.resources[id]
 }
 
 // Has returns whether the world has the given resource.
-func (r *resources) Has(id ResID) bool {
+//
+// See also [github.com/mlange-42/arche/generic.Resource.Has] for a generic variant.
+func (r *Resources) Has(id ResID) bool {
 	return r.resources[id] != nil
 }
 
-// Reset removes all resources.
-func (r *resources) Reset() {
+// reset removes all resources.
+func (r *Resources) reset() {
 	for i := 0; i < len(r.resources); i++ {
 		r.resources[i] = nil
 	}

--- a/ecs/resources_test.go
+++ b/ecs/resources_test.go
@@ -53,7 +53,7 @@ func TestResourcesReset(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, rotation{5}, *rot)
 
-	res.Reset()
+	res.reset()
 
 	assert.False(t, res.Has(posID))
 	assert.False(t, res.Has(rotID))

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -552,27 +552,27 @@ func TestWorldResources(t *testing.T) {
 	posID := ResourceID[position](&w)
 	rotID := ResourceID[rotation](&w)
 
-	assert.False(t, w.HasResource(posID))
-	assert.Nil(t, w.GetResource(posID))
+	assert.False(t, w.Resources().Has(posID))
+	assert.Nil(t, w.Resources().Get(posID))
 
 	AddResource(&w, &position{1, 2})
 
-	assert.True(t, w.HasResource(posID))
-	pos, ok := w.GetResource(posID).(*position)
+	assert.True(t, w.Resources().Has(posID))
+	pos, ok := w.Resources().Get(posID).(*position)
 
 	assert.True(t, ok)
 	assert.Equal(t, position{1, 2}, *pos)
 
-	assert.Panics(t, func() { w.AddResource(posID, &position{1, 2}) })
+	assert.Panics(t, func() { w.Resources().Add(posID, &position{1, 2}) })
 
 	pos = GetResource[position](&w)
 	assert.Equal(t, position{1, 2}, *pos)
 
-	w.AddResource(rotID, &rotation{5})
-	assert.True(t, w.HasResource(rotID))
-	w.RemoveResource(rotID)
-	assert.False(t, w.HasResource(rotID))
-	assert.Panics(t, func() { w.RemoveResource(rotID) })
+	w.Resources().Add(rotID, &rotation{5})
+	assert.True(t, w.Resources().Has(rotID))
+	w.Resources().Remove(rotID)
+	assert.False(t, w.Resources().Has(rotID))
+	assert.Panics(t, func() { w.Resources().Remove(rotID) })
 }
 
 func TestRegisterComponents(t *testing.T) {
@@ -870,7 +870,7 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSize[bitPool]()
 	printTypeSize[Query]()
 	printTypeSize[archetypeIter]()
-	printTypeSize[resources]()
+	printTypeSize[Resources]()
 	printTypeSizeName[reflect.Value]("reflect.Value")
 }
 
@@ -895,7 +895,7 @@ func BenchmarkGetResource(b *testing.B) {
 
 	var res *position
 	for i := 0; i < b.N; i++ {
-		res = w.GetResource(posID).(*position)
+		res = w.Resources().Get(posID).(*position)
 	}
 
 	_ = res

--- a/examples/resources/main.go
+++ b/examples/resources/main.go
@@ -35,7 +35,7 @@ func run(w *ecs.World) {
 
 	for {
 		// Get the the TimeStep resource from the world
-		time := w.GetResource(timeStepID).(*TimeStep)
+		time := w.Resources().Get(timeStepID).(*TimeStep)
 
 		// Use the resource
 		time.Step++

--- a/generic/resource.go
+++ b/generic/resource.go
@@ -15,7 +15,7 @@ type Resource[T any] struct {
 //
 // [Resource] provides a type-safe way to access a world resources.
 //
-// See also [ecs.World.GetResource], [ecs.World.HasResource] and [ecs.World.AddResource].
+// See also [ecs.World.Resources].
 func NewResource[T any](w *ecs.World) Resource[T] {
 	return Resource[T]{
 		id:    ecs.ResourceID[T](w),
@@ -32,32 +32,32 @@ func (g *Resource[T]) ID() ecs.ResID {
 //
 // Panics if there is already a resource of the given type.
 //
-// See also [ecs.World.AddResource].
+// See also [ecs.Resources.Add].
 func (g *Resource[T]) Add(res *T) {
-	g.world.AddResource(g.id, res)
+	g.world.Resources().Add(g.id, res)
 }
 
 // Remove removes a resource from the world.
 //
 // Panics if there is no resource of the given type.
 //
-// See also [ecs.World.RemoveResource].
+// See also [ecs.Resources.Remove].
 func (g *Resource[T]) Remove() {
-	g.world.RemoveResource(g.id)
+	g.world.Resources().Remove(g.id)
 }
 
 // Get gets the resource of the given type.
 //
 // Returns nil if there is no such resource.
 //
-// See also [ecs.World.GetResource].
+// See also [ecs.Resources.Get].
 func (g *Resource[T]) Get() *T {
-	return g.world.GetResource(g.id).(*T)
+	return g.world.Resources().Get(g.id).(*T)
 }
 
 // Has returns whether the world has the resource type.
 //
-// See also [ecs.World.HasResource].
+// See also [ecs.Resources.Has].
 func (g *Resource[T]) Has() bool {
-	return g.world.HasResource(g.id)
+	return g.world.Resources().Has(g.id)
 }


### PR DESCRIPTION
An object to handle resources can now be obtained via `world.Resources()`.