### PR TITLE
Optimize entity batch-allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Speedup of archetype mask checks by 10% by checking mask before empty archetype (#139)
 * Speedup of generic queries and mappers to come closer to ID-based access (#144)
 * Speedup of archetype mask checks by casting filter interface to concrete type when possible (#148)
+* Optimized batch creation of entities (#159)
 
 ### Bugfixes
 

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -372,10 +372,7 @@ func (a *archetype) extend(by uint32) {
 	if a.cap >= required {
 		return
 	}
-	a.cap = a.capacityIncrement * (required / a.capacityIncrement)
-	if required%a.capacityIncrement != 0 {
-		a.cap += a.capacityIncrement
-	}
+	a.cap = capacityU32(required, a.capacityIncrement)
 
 	old := a.entityBuffer
 	a.entityBuffer = reflect.New(reflect.ArrayOf(int(a.cap), entityType)).Elem()

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -1,0 +1,17 @@
+package ecs
+
+func capacity(size, increment int) int {
+	cap := increment * (size / increment)
+	if size%increment != 0 {
+		cap += increment
+	}
+	return cap
+}
+
+func capacityU32(size, increment uint32) uint32 {
+	cap := increment * (size / increment)
+	if size%increment != 0 {
+		cap += increment
+	}
+	return cap
+}

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -1,0 +1,21 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCapacity(t *testing.T) {
+	assert.Equal(t, 0, capacity(0, 8))
+	assert.Equal(t, 8, capacity(1, 8))
+	assert.Equal(t, 8, capacity(8, 8))
+	assert.Equal(t, 16, capacity(9, 8))
+}
+
+func TestCapacityU32(t *testing.T) {
+	assert.Equal(t, 0, int(capacityU32(0, 8)))
+	assert.Equal(t, 8, int(capacityU32(1, 8)))
+	assert.Equal(t, 8, int(capacityU32(8, 8)))
+	assert.Equal(t, 16, int(capacityU32(9, 8)))
+}

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -372,11 +372,13 @@ func TestWorldNewEntities(t *testing.T) {
 	rotID := ComponentID[rotation](&world)
 
 	world.NewEntity(posID, rotID)
+	assert.Equal(t, 2, len(world.entities))
 
 	assert.Panics(t, func() { world.newEntitiesQuery(0, posID, rotID) })
 
 	query := world.newEntitiesQuery(100, posID, rotID)
 	assert.Equal(t, 100, query.Count())
+	assert.Equal(t, 102, len(world.entities))
 	assert.Equal(t, 1, len(events))
 
 	cnt := 0
@@ -400,6 +402,7 @@ func TestWorldNewEntities(t *testing.T) {
 	}
 
 	world.Reset()
+	assert.Equal(t, 1, len(world.entities))
 
 	query = world.newEntitiesQuery(100, posID, rotID)
 	assert.Equal(t, 100, query.Count())
@@ -418,14 +421,17 @@ func TestWorldNewEntities(t *testing.T) {
 		world.RemoveEntity(e)
 	}
 	assert.Equal(t, 301, len(events))
+	assert.Equal(t, 101, len(world.entities))
 
 	query = world.newEntitiesQuery(100, posID, rotID)
 	assert.Equal(t, 301, len(events))
 	query.Close()
 	assert.Equal(t, 401, len(events))
+	assert.Equal(t, 101, len(world.entities))
 
 	world.newEntities(100, posID, rotID)
 	assert.Equal(t, 501, len(events))
+	assert.Equal(t, 201, len(world.entities))
 }
 
 func TestWorldNewEntitiesWith(t *testing.T) {


### PR DESCRIPTION
Reserve sufficient memory for all entities to add ad once, not in increments