### PR TITLE
Filter API cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Generic mappers do no longer return all components when creating entities or components (#145)
 * Resources API moved out of the world, to a helper to get by `World.Resources()` (#150)
 * `World.Reset()` does no longer remove the component change listener (#157)
+* Removes methods `filter.ALL.Not()` and `filter.ANY.Not()`, use `NoneOf()` and `AnyNot()` instead (#160)
 
 ### Features
 

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -4,24 +4,11 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
-// ALL matches entities that have all the given components.
-type ALL ecs.Mask
-
 // All matches entities that have all the given components.
 //
 // Like [And] for combining individual components.
-func All(comps ...ecs.ID) ALL {
-	return ALL(ecs.All(comps...))
-}
-
-// Not inverts this filter to exclude entities with all the given components
-func (f ALL) Not() NoneOF {
-	return NoneOF(f)
-}
-
-// Matches matches a filter against a bitmask
-func (f ALL) Matches(bits ecs.Mask) bool {
-	return bits.Contains(ecs.Mask(f))
+func All(comps ...ecs.ID) ecs.Mask {
+	return ecs.All(comps...)
 }
 
 // ANY matches entities that have any of the given components.
@@ -30,11 +17,6 @@ type ANY ecs.Mask
 // Any matches entities that have any of the given components.
 func Any(comps ...ecs.ID) ANY {
 	return ANY(ecs.All(comps...))
-}
-
-// Not inverts this filter to exclude entities with any of the given components
-func (f ANY) Not() AnyNOT {
-	return AnyNOT(f)
 }
 
 // Matches matches a filter against a bitmask

--- a/filter/filter_test.go
+++ b/filter/filter_test.go
@@ -113,9 +113,6 @@ func TestLogicFilters(t *testing.T) {
 	assert.True(t, match(filter, hasA))
 	assert.True(t, match(filter, hasB))
 	assert.True(t, match(filter, hasNone))
-
-	assert.Equal(t, AnyNot(0, 1), Any(0, 1).Not())
-	assert.Equal(t, NoneOf(0, 1), All(0, 1).Not())
 }
 
 func TestFilter(t *testing.T) {


### PR DESCRIPTION
Removes inversion methods `filter.ALL.Not()` and `filter.ANY.Not()`, for consistency with `Mask.Not`.