### PR TITLE
No alloc in generics, add/remove benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,3 +41,4 @@ jobs:
         run: |
           cd benchmark
           go test -benchmem -run=^$ -bench ^.*$ ./competition/pos_vel/... --count 5
+          go test -benchmem -run=^$ -bench ^.*$ ./competition/add_remove/... --count 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * More efficiently clear the memory of removed components, with 2-3x speedup (#165)
 * Do not clear memory when adding entities to archetypes, not required anymore as of #147 (#165)
 * Speed up copying entity to archetype by getting entity pointer without reflection (#166)
+* Avoid slice allocations in generic mapper methods (#170)
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ### Other
 
 * Restructure and extend benchmarks (#146, #153, #155, #156)
+* Add an ECS competition benchmark for adding and removing components (#170)
 
 ## [[v0.5.1]](https://github.com/mlange-42/arche/compare/v0.5.0...v0.5.1)
 

--- a/README.md
+++ b/README.md
@@ -204,15 +204,34 @@ Feel free to open an issue if you have suggestions for improvements on the bench
 
 #### Position/Velocity
 
-* 1000 entities with `Pos{float64, float64}` and `Vel{float64, float64}`.
-* 9000 entities with only `Pos{float64, float64}`.
+Build:
+* Create 1000 entities with `Pos{float64, float64}` and `Vel{float64, float64}`.
+* Create 9000 entities with only `Pos{float64, float64}`.
+
+Iterate:
 * Iterate all entities with `Pos` and `Vel`, and add `Vel` to `Pos`.
 
 <div align="center" width="100%">
 
-![Benchmark vs. Go ECSs](https://user-images.githubusercontent.com/44003176/227774391-702d7ada-643e-4543-b50d-e7cb9420e7fd.svg)  
-*CPU benchmarks of Arche (left-most) vs. other Go ECS implementations.
+![Benchmark vs. Go ECSs - Pos/Vel](https://user-images.githubusercontent.com/44003176/227774391-702d7ada-643e-4543-b50d-e7cb9420e7fd.svg)  
+*Position/Velocity benchmarks of Arche (left-most) vs. other Go ECS implementations.
 Left panel: query iteration (log scale), right panel: world setup and entity creation.*
+</div>
+
+#### Add/remove component
+
+Build:
+* Create 1000 entities with `Pos{float64, float64}`.
+
+Iterate:
+* Get all entities with `Pos`, and add `Vel{float64, float64}` component.
+* Get all entities with `Pos` and `Vel`, and remove `Vel` component.
+
+<div align="center" width="100%">
+
+![Benchmark vs. Go ECSs - Add/remove](https://user-images.githubusercontent.com/44003176/227783106-e0af9bfa-a4ed-4de4-aa17-1b3c7cb1cf70.svg)  
+*Add/remove component benchmarks of Arche (left-most) vs. other Go ECS implementations.
+Left panel: iteration, right panel: world setup and entity creation.*
 </div>
 
 ### Arche vs. Array of Structs

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Feel free to open an issue if you have suggestions for improvements on the bench
 
 <div align="center" width="100%">
 
-![Benchmark vs. Go ECSs](https://user-images.githubusercontent.com/44003176/227750005-22ef44e3-ab83-41f1-9d32-910ff0ca51d5.svg)  
+![Benchmark vs. Go ECSs](https://user-images.githubusercontent.com/44003176/227774391-702d7ada-643e-4543-b50d-e7cb9420e7fd.svg)  
 *CPU benchmarks of Arche (left-most) vs. other Go ECS implementations.
 Left panel: query iteration (log scale), right panel: world setup and entity creation.*
 </div>

--- a/benchmark/competition/add_remove/arche_test.go
+++ b/benchmark/competition/add_remove/arche_test.go
@@ -1,0 +1,118 @@
+package addremove
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
+)
+
+func BenchmarkIterArche(b *testing.B) {
+	b.StopTimer()
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	posID := ecs.ComponentID[Position](&world)
+	velID := ecs.ComponentID[Velocity](&world)
+	ids := []ecs.ID{velID}
+
+	world.Batch().NewEntities(nEntities, posID)
+
+	var filterPos ecs.Filter = ecs.All(posID)
+	var filterPosVel ecs.Filter = ecs.All(posID, velID)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		entities := make([]ecs.Entity, 0, nEntities)
+		query := world.Query(filterPos)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+
+		for _, e := range entities {
+			world.Add(e, ids...)
+		}
+
+		entities = entities[:0]
+		query = world.Query(filterPosVel)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+
+		for _, e := range entities {
+			world.Remove(e, ids...)
+		}
+	}
+}
+
+func BenchmarkBuildArche(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+		posID := ecs.ComponentID[Position](&world)
+		velID := ecs.ComponentID[Velocity](&world)
+		ids := []ecs.ID{velID}
+
+		for i := 0; i < nEntities; i++ {
+			world.NewEntity(ids...)
+		}
+
+		var filterPos ecs.Filter = ecs.All(posID)
+		var filterPosVel ecs.Filter = ecs.All(posID, velID)
+
+		_ = filterPos
+		_ = filterPosVel
+	}
+}
+
+func BenchmarkIterArcheGeneric(b *testing.B) {
+	b.StopTimer()
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	posMapper := generic.NewMap1[Position](&world)
+	velMapper := generic.NewMap1[Velocity](&world)
+
+	posMapper.NewEntities(nEntities)
+
+	filterPos := generic.NewFilter1[Position]()
+	filterPosVel := generic.NewFilter2[Position, Velocity]()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		entities := make([]ecs.Entity, 0, nEntities)
+		query := filterPos.Query(&world)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+
+		for _, e := range entities {
+			velMapper.Add(e)
+		}
+
+		entities = entities[:0]
+		query2 := filterPosVel.Query(&world)
+		for query2.Next() {
+			entities = append(entities, query2.Entity())
+		}
+
+		for _, e := range entities {
+			velMapper.Remove(e)
+		}
+	}
+}
+
+func BenchmarkBuildArcheGeneric(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+		posID := ecs.ComponentID[Position](&world)
+		velID := ecs.ComponentID[Velocity](&world)
+
+		world.Batch().NewEntities(nEntities, posID)
+
+		var filterPos ecs.Filter = ecs.All(posID)
+		var filterPosVel ecs.Filter = ecs.All(posID, velID)
+
+		_ = filterPos
+		_ = filterPosVel
+	}
+}

--- a/benchmark/competition/add_remove/doc.go
+++ b/benchmark/competition/add_remove/doc.go
@@ -1,0 +1,23 @@
+// Package addremove benchmarks adding and removing components
+//
+// Setup:
+//   - 1000 entities with Position{f64, f64}
+//
+// Benchmark:
+//   - Iterate all entities with Position, and add Velocity
+//   - Iterate all entities with Position and Velocity, and remove Velocity
+package addremove
+
+const nEntities = 1000
+
+// Position component
+type Position struct {
+	X float64
+	Y float64
+}
+
+// Velocity component
+type Velocity struct {
+	X float64
+	Y float64
+}

--- a/benchmark/competition/add_remove/donburi_test.go
+++ b/benchmark/competition/add_remove/donburi_test.go
@@ -1,0 +1,44 @@
+package addremove
+
+import (
+	"testing"
+
+	"github.com/yohamta/donburi"
+	"github.com/yohamta/donburi/filter"
+)
+
+func BenchmarkIterDonburi(b *testing.B) {
+	b.StopTimer()
+	world := donburi.NewWorld()
+
+	var position = donburi.NewComponentType[Position]()
+	var velocity = donburi.NewComponentType[Velocity]()
+
+	for i := 0; i < nEntities; i++ {
+		world.Create(position)
+	}
+
+	queryPos := donburi.NewQuery(filter.Contains(position))
+	queryPosVel := donburi.NewQuery(filter.Contains(position, velocity))
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		queryPos.Each(world, func(entry *donburi.Entry) {
+			entry.AddComponent(velocity)
+		})
+		queryPosVel.Each(world, func(entry *donburi.Entry) {
+			entry.RemoveComponent(velocity)
+		})
+	}
+}
+
+func BenchmarkBuildDonburi(b *testing.B) {
+	var position = donburi.NewComponentType[Position]()
+
+	for i := 0; i < b.N; i++ {
+		world := donburi.NewWorld()
+		for i := 0; i < nEntities; i++ {
+			world.Create(position)
+		}
+	}
+}

--- a/benchmark/competition/add_remove/ento_test.go
+++ b/benchmark/competition/add_remove/ento_test.go
@@ -1,0 +1,63 @@
+package addremove
+
+import (
+	"testing"
+
+	"github.com/wfranczyk/ento"
+)
+
+func BenchmarkIterEnto(b *testing.B) {
+	b.StopTimer()
+	world := ento.NewWorldBuilder().
+		WithDenseComponents(Position{}).
+		WithSparseComponents(Velocity{}).
+		Build(1024)
+
+	add := AddVelSystem{}
+	rem := RemVelSystem{}
+	world.AddSystems(&add, &rem)
+
+	for i := 0; i < nEntities; i++ {
+		world.AddEntity(Position{})
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		world.Update()
+	}
+}
+
+func BenchmarkBuildEnto(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		world := ento.NewWorldBuilder().
+			WithDenseComponents(Position{}).
+			WithSparseComponents(Velocity{}).
+			Build(1024)
+
+		add := AddVelSystem{}
+		rem := RemVelSystem{}
+		world.AddSystems(&add, &rem)
+
+		for i := 0; i < nEntities; i++ {
+			world.AddEntity(Position{})
+		}
+	}
+}
+
+type AddVelSystem struct {
+	Pos *Position `ento:"required"`
+}
+
+func (s *AddVelSystem) Update(entity *ento.Entity) {
+	entity.Set(Position{})
+}
+
+type RemVelSystem struct {
+	Pos *Position `ento:"required"`
+	Vel *Velocity `ento:"required"`
+}
+
+func (s *RemVelSystem) Update(entity *ento.Entity) {
+	entity.Rem(Position{})
+}

--- a/benchmark/competition/add_remove/ggecs_test.go
+++ b/benchmark/competition/add_remove/ggecs_test.go
@@ -1,0 +1,61 @@
+package addremove
+
+import (
+	"testing"
+
+	ecs "github.com/marioolofo/go-gameengine-ecs"
+)
+
+const (
+	PositionComponentID ecs.ComponentID = iota
+	VelocityComponentID
+)
+
+func BenchmarkIterGGEcs(b *testing.B) {
+	b.StopTimer()
+	world := ecs.NewWorld(1024)
+	world.Register(ecs.NewComponentRegistry[Position](PositionComponentID))
+	world.Register(ecs.NewComponentRegistry[Velocity](VelocityComponentID))
+
+	for i := 0; i < nEntities; i++ {
+		_ = world.NewEntity(PositionComponentID)
+	}
+
+	posMask := ecs.MakeComponentMask(PositionComponentID)
+	posVelMask := ecs.MakeComponentMask(PositionComponentID, VelocityComponentID)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		entities := make([]ecs.EntityID, 0, nEntities)
+		query := world.Query(posMask)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+
+		for _, e := range entities {
+			world.AddComponent(e, VelocityComponentID)
+		}
+
+		entities = entities[:0]
+		query = world.Query(posVelMask)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+
+		for _, e := range entities {
+			world.RemComponent(e, VelocityComponentID)
+		}
+	}
+}
+
+func BenchmarkBuildGGEcs(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		world := ecs.NewWorld(1024)
+		world.Register(ecs.NewComponentRegistry[Position](PositionComponentID))
+		world.Register(ecs.NewComponentRegistry[Velocity](VelocityComponentID))
+
+		for i := 0; i < nEntities; i++ {
+			_ = world.NewEntity(PositionComponentID)
+		}
+	}
+}

--- a/benchmark/competition/add_remove/plot.py
+++ b/benchmark/competition/add_remove/plot.py
@@ -1,0 +1,65 @@
+"""Plots benchmarking results of Arche vs. AoS and AoP"""
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+
+iter_prefix = "BenchmarkIter"
+build_prefix = "BenchmarkBuild"
+
+if __name__ == "__main__":
+    data = pd.read_csv("results.csv", sep=";")
+
+    models = [
+        ("Arche", ("Arche\n(IDs)", "Arche\n")),
+        ("ArcheGeneric", ("Arche\n(generic)", "Arche\n(batch)")),
+        ("GGEcs", ("go-\ngameengine-\necs", "go-\ngameengine-\necs")),
+        ("Donburi", ("Donburi", "Donburi")),
+        ("Entitas", ("Entitas-Go", "Entitas-Go")),
+        ("Ento", ("Ento", "Ento")),
+    ]
+
+    plt.rcParams["svg.fonttype"] = "none"
+    plt.rcParams["font.family"] = "Arial"
+
+    fig, axes = plt.subplots(ncols=2, figsize=(10, 4))
+
+    iter = (
+        axes[0],
+        iter_prefix,
+        None,
+        1000,
+        "linear",
+        "Time per iteration [μs]",
+    )
+    build = (axes[1], build_prefix, None, 1000, "linear", "Time per run [μs]")
+
+    for stat, (ax, prefix, yticks, factor, scale, title) in enumerate([iter, build]):
+        ax.set_title("Add/remove component -- " + prefix.replace("Benchmark", ""))
+        ax.set_ylabel(title, fontsize=11)
+
+        bench_data = data[data["Model"].str.startswith(prefix)]
+
+        series = []
+        for model in models:
+            extr = bench_data[
+                bench_data["Model"].str.startswith(prefix + model[0] + "-")
+            ]
+            series.append(extr["Time"] / factor)
+
+        ax.violinplot(
+            series, vert=True, showmeans=True, showextrema=False, bw_method=0.5
+        )
+
+        ax.set_xticks(range(1, len(models) + 1))
+        ax.set_xticklabels([n[stat] for _, n in models])
+
+        ax.set_ylim((yticks or [0])[0], np.max(bench_data["Time"]) * 1.1 / factor)
+        ax.set_yscale(scale)
+
+        if yticks is not None:
+            ax.set_yticks(yticks)
+            ax.set_yticklabels(yticks)
+
+    fig.tight_layout()
+    fig.savefig("results.svg")
+    plt.show()

--- a/benchmark/competition/pos_vel/plot.py
+++ b/benchmark/competition/pos_vel/plot.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
         [1, 2, 5, 10, 20, 50, 100, 200],
         1000,
         "log",
-        "Time per iteration [us]",
+        "Time per iteration [μs]",
     )
     build = (axes[1], build_prefix, None, 1000000, "linear", "Time per run [ms]")
 
@@ -46,7 +46,9 @@ if __name__ == "__main__":
             ]
             series.append(extr["Time"] / factor)
 
-        ax.violinplot(series, vert=True, showmeans=True, showextrema=False, bw_method=0.5)
+        ax.violinplot(
+            series, vert=True, showmeans=True, showextrema=False, bw_method=0.5
+        )
 
         ax.set_xticks(range(1, len(models) + 1))
         ax.set_xticklabels([n[stat] for _, n in models])

--- a/generic/generate/map.go.txt
+++ b/generic/generate/map.go.txt
@@ -5,6 +5,7 @@
 type Map{{ .Index }}{{ .TypesFull }} struct {
 	world *ecs.World
 	mask ecs.Mask
+	ids []ecs.ID
 	{{ .IDTypes }}
 }
 
@@ -14,7 +15,8 @@ func NewMap{{ .Index }}{{ .TypesFull }}(w *ecs.World) Map{{ .Index }}{{ .Types }
 		world: w,
 		{{ .IDAssign }}
 	}
-	m.mask = ecs.All({{ .IDList }})
+	m.ids = []ecs.ID{ {{ .IDList }} }
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -29,7 +31,7 @@ func (m *Map{{ .Index }}{{ .Types }}) Get(entity ecs.Entity) ({{ .TypesReturn }}
 //
 // See also [ecs.World.NewEntity].
 func (m *Map{{ .Index }}{{ .Types }}) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity({{ .IDList }})
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -37,7 +39,7 @@ func (m *Map{{ .Index }}{{ .Types }}) NewEntity() ecs.Entity {
 //
 // See also [Map{{ .Index }}.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map{{ .Index }}{{ .Types }}) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, {{ .IDList }})
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map{{ .Index }}'s components.
@@ -47,7 +49,7 @@ func (m *Map{{ .Index }}{{ .Types }}) NewEntities(count int) {
 //
 // See also [Map{{ .Index }}.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map{{ .Index }}{{ .Types }}) NewEntitiesQuery(count int) Query{{ .Index }}{{ .Types }} {
-	query := m.world.Batch().NewEntitiesQuery(count, {{ .IDList }})
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query{{ .Index }}{{ .Types }}{
 		Query: query,
 		{{ .IDAssign2 }}
@@ -90,7 +92,7 @@ func (m *Map{{ .Index }}{{ .Types }}) NewEntitiesWithQuery(count int, {{ .Argume
 //
 // See also [ecs.World.Add].
 func (m *Map{{ .Index }}{{ .Types }}) Add(entity ecs.Entity) {
-	m.world.Add(entity, {{ .IDList }})
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map{{ .Index }}'s components to the given entity, using the supplied values.
@@ -107,7 +109,7 @@ func (m *Map{{ .Index }}{{ .Types }}) Assign(entity ecs.Entity, {{ .Arguments }}
 //
 // See also [ecs.World.Remove].
 func (m *Map{{ .Index }}{{ .Types }}) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, {{ .IDList }})
+	m.world.Remove(entity, m.ids...)
 }
 
 

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -12,6 +12,7 @@ import (
 type Map1[A any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 }
 
@@ -21,7 +22,8 @@ func NewMap1[A any](w *ecs.World) Map1[A] {
 		world: w,
 		id0:   ecs.ComponentID[A](w),
 	}
-	m.mask = ecs.All(m.id0)
+	m.ids = []ecs.ID{m.id0}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -36,7 +38,7 @@ func (m *Map1[A]) Get(entity ecs.Entity) *A {
 //
 // See also [ecs.World.NewEntity].
 func (m *Map1[A]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -44,7 +46,7 @@ func (m *Map1[A]) NewEntity() ecs.Entity {
 //
 // See also [Map1.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map1[A]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map1's components.
@@ -54,7 +56,7 @@ func (m *Map1[A]) NewEntities(count int) {
 //
 // See also [Map1.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map1[A]) NewEntitiesQuery(count int) Query1[A] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query1[A]{
 		Query: query,
 		id0:   m.id0,
@@ -96,7 +98,7 @@ func (m *Map1[A]) NewEntitiesWithQuery(count int, a *A) Query1[A] {
 //
 // See also [ecs.World.Add].
 func (m *Map1[A]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map1's components to the given entity, using the supplied values.
@@ -112,7 +114,7 @@ func (m *Map1[A]) Assign(entity ecs.Entity, a *A) {
 //
 // See also [ecs.World.Remove].
 func (m *Map1[A]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map1's components.
@@ -133,6 +135,7 @@ func (m *Map1[A]) RemoveEntities(exact bool) {
 type Map2[A any, B any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 }
@@ -144,7 +147,8 @@ func NewMap2[A any, B any](w *ecs.World) Map2[A, B] {
 		id0:   ecs.ComponentID[A](w),
 		id1:   ecs.ComponentID[B](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1)
+	m.ids = []ecs.ID{m.id0, m.id1}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -160,7 +164,7 @@ func (m *Map2[A, B]) Get(entity ecs.Entity) (*A, *B) {
 //
 // See also [ecs.World.NewEntity].
 func (m *Map2[A, B]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -168,7 +172,7 @@ func (m *Map2[A, B]) NewEntity() ecs.Entity {
 //
 // See also [Map2.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map2[A, B]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map2's components.
@@ -178,7 +182,7 @@ func (m *Map2[A, B]) NewEntities(count int) {
 //
 // See also [Map2.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map2[A, B]) NewEntitiesQuery(count int) Query2[A, B] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query2[A, B]{
 		Query: query,
 		id0:   m.id0,
@@ -227,7 +231,7 @@ func (m *Map2[A, B]) NewEntitiesWithQuery(count int, a *A, b *B) Query2[A, B] {
 //
 // See also [ecs.World.Add].
 func (m *Map2[A, B]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map2's components to the given entity, using the supplied values.
@@ -244,7 +248,7 @@ func (m *Map2[A, B]) Assign(entity ecs.Entity, a *A, b *B) {
 //
 // See also [ecs.World.Remove].
 func (m *Map2[A, B]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map2's components.
@@ -265,6 +269,7 @@ func (m *Map2[A, B]) RemoveEntities(exact bool) {
 type Map3[A any, B any, C any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -278,7 +283,8 @@ func NewMap3[A any, B any, C any](w *ecs.World) Map3[A, B, C] {
 		id1:   ecs.ComponentID[B](w),
 		id2:   ecs.ComponentID[C](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -295,7 +301,7 @@ func (m *Map3[A, B, C]) Get(entity ecs.Entity) (*A, *B, *C) {
 //
 // See also [ecs.World.NewEntity].
 func (m *Map3[A, B, C]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -303,7 +309,7 @@ func (m *Map3[A, B, C]) NewEntity() ecs.Entity {
 //
 // See also [Map3.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map3[A, B, C]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map3's components.
@@ -313,7 +319,7 @@ func (m *Map3[A, B, C]) NewEntities(count int) {
 //
 // See also [Map3.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map3[A, B, C]) NewEntitiesQuery(count int) Query3[A, B, C] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query3[A, B, C]{
 		Query: query,
 		id0:   m.id0,
@@ -367,7 +373,7 @@ func (m *Map3[A, B, C]) NewEntitiesWithQuery(count int, a *A, b *B, c *C) Query3
 //
 // See also [ecs.World.Add].
 func (m *Map3[A, B, C]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map3's components to the given entity, using the supplied values.
@@ -385,7 +391,7 @@ func (m *Map3[A, B, C]) Assign(entity ecs.Entity, a *A, b *B, c *C) {
 //
 // See also [ecs.World.Remove].
 func (m *Map3[A, B, C]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map3's components.
@@ -406,6 +412,7 @@ func (m *Map3[A, B, C]) RemoveEntities(exact bool) {
 type Map4[A any, B any, C any, D any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -421,7 +428,8 @@ func NewMap4[A any, B any, C any, D any](w *ecs.World) Map4[A, B, C, D] {
 		id2:   ecs.ComponentID[C](w),
 		id3:   ecs.ComponentID[D](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2, m.id3)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2, m.id3}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -439,7 +447,7 @@ func (m *Map4[A, B, C, D]) Get(entity ecs.Entity) (*A, *B, *C, *D) {
 //
 // See also [ecs.World.NewEntity].
 func (m *Map4[A, B, C, D]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2, m.id3)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -447,7 +455,7 @@ func (m *Map4[A, B, C, D]) NewEntity() ecs.Entity {
 //
 // See also [Map4.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map4[A, B, C, D]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2, m.id3)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map4's components.
@@ -457,7 +465,7 @@ func (m *Map4[A, B, C, D]) NewEntities(count int) {
 //
 // See also [Map4.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map4[A, B, C, D]) NewEntitiesQuery(count int) Query4[A, B, C, D] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2, m.id3)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query4[A, B, C, D]{
 		Query: query,
 		id0:   m.id0,
@@ -516,7 +524,7 @@ func (m *Map4[A, B, C, D]) NewEntitiesWithQuery(count int, a *A, b *B, c *C, d *
 //
 // See also [ecs.World.Add].
 func (m *Map4[A, B, C, D]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2, m.id3)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map4's components to the given entity, using the supplied values.
@@ -535,7 +543,7 @@ func (m *Map4[A, B, C, D]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D) {
 //
 // See also [ecs.World.Remove].
 func (m *Map4[A, B, C, D]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2, m.id3)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map4's components.
@@ -556,6 +564,7 @@ func (m *Map4[A, B, C, D]) RemoveEntities(exact bool) {
 type Map5[A any, B any, C any, D any, E any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -573,7 +582,8 @@ func NewMap5[A any, B any, C any, D any, E any](w *ecs.World) Map5[A, B, C, D, E
 		id3:   ecs.ComponentID[D](w),
 		id4:   ecs.ComponentID[E](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2, m.id3, m.id4)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2, m.id3, m.id4}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -592,7 +602,7 @@ func (m *Map5[A, B, C, D, E]) Get(entity ecs.Entity) (*A, *B, *C, *D, *E) {
 //
 // See also [ecs.World.NewEntity].
 func (m *Map5[A, B, C, D, E]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2, m.id3, m.id4)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -600,7 +610,7 @@ func (m *Map5[A, B, C, D, E]) NewEntity() ecs.Entity {
 //
 // See also [Map5.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map5[A, B, C, D, E]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2, m.id3, m.id4)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map5's components.
@@ -610,7 +620,7 @@ func (m *Map5[A, B, C, D, E]) NewEntities(count int) {
 //
 // See also [Map5.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map5[A, B, C, D, E]) NewEntitiesQuery(count int) Query5[A, B, C, D, E] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2, m.id3, m.id4)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query5[A, B, C, D, E]{
 		Query: query,
 		id0:   m.id0,
@@ -674,7 +684,7 @@ func (m *Map5[A, B, C, D, E]) NewEntitiesWithQuery(count int, a *A, b *B, c *C, 
 //
 // See also [ecs.World.Add].
 func (m *Map5[A, B, C, D, E]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2, m.id3, m.id4)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map5's components to the given entity, using the supplied values.
@@ -694,7 +704,7 @@ func (m *Map5[A, B, C, D, E]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, 
 //
 // See also [ecs.World.Remove].
 func (m *Map5[A, B, C, D, E]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2, m.id3, m.id4)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map5's components.
@@ -715,6 +725,7 @@ func (m *Map5[A, B, C, D, E]) RemoveEntities(exact bool) {
 type Map6[A any, B any, C any, D any, E any, F any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -734,7 +745,8 @@ func NewMap6[A any, B any, C any, D any, E any, F any](w *ecs.World) Map6[A, B, 
 		id4:   ecs.ComponentID[E](w),
 		id5:   ecs.ComponentID[F](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2, m.id3, m.id4, m.id5}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -754,7 +766,7 @@ func (m *Map6[A, B, C, D, E, F]) Get(entity ecs.Entity) (*A, *B, *C, *D, *E, *F)
 //
 // See also [ecs.World.NewEntity].
 func (m *Map6[A, B, C, D, E, F]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -762,7 +774,7 @@ func (m *Map6[A, B, C, D, E, F]) NewEntity() ecs.Entity {
 //
 // See also [Map6.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map6[A, B, C, D, E, F]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map6's components.
@@ -772,7 +784,7 @@ func (m *Map6[A, B, C, D, E, F]) NewEntities(count int) {
 //
 // See also [Map6.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map6[A, B, C, D, E, F]) NewEntitiesQuery(count int) Query6[A, B, C, D, E, F] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query6[A, B, C, D, E, F]{
 		Query: query,
 		id0:   m.id0,
@@ -841,7 +853,7 @@ func (m *Map6[A, B, C, D, E, F]) NewEntitiesWithQuery(count int, a *A, b *B, c *
 //
 // See also [ecs.World.Add].
 func (m *Map6[A, B, C, D, E, F]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map6's components to the given entity, using the supplied values.
@@ -862,7 +874,7 @@ func (m *Map6[A, B, C, D, E, F]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *
 //
 // See also [ecs.World.Remove].
 func (m *Map6[A, B, C, D, E, F]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map6's components.
@@ -883,6 +895,7 @@ func (m *Map6[A, B, C, D, E, F]) RemoveEntities(exact bool) {
 type Map7[A any, B any, C any, D any, E any, F any, G any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -904,7 +917,8 @@ func NewMap7[A any, B any, C any, D any, E any, F any, G any](w *ecs.World) Map7
 		id5:   ecs.ComponentID[F](w),
 		id6:   ecs.ComponentID[G](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -925,7 +939,7 @@ func (m *Map7[A, B, C, D, E, F, G]) Get(entity ecs.Entity) (*A, *B, *C, *D, *E, 
 //
 // See also [ecs.World.NewEntity].
 func (m *Map7[A, B, C, D, E, F, G]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -933,7 +947,7 @@ func (m *Map7[A, B, C, D, E, F, G]) NewEntity() ecs.Entity {
 //
 // See also [Map7.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map7[A, B, C, D, E, F, G]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map7's components.
@@ -943,7 +957,7 @@ func (m *Map7[A, B, C, D, E, F, G]) NewEntities(count int) {
 //
 // See also [Map7.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map7[A, B, C, D, E, F, G]) NewEntitiesQuery(count int) Query7[A, B, C, D, E, F, G] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query7[A, B, C, D, E, F, G]{
 		Query: query,
 		id0:   m.id0,
@@ -1017,7 +1031,7 @@ func (m *Map7[A, B, C, D, E, F, G]) NewEntitiesWithQuery(count int, a *A, b *B, 
 //
 // See also [ecs.World.Add].
 func (m *Map7[A, B, C, D, E, F, G]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map7's components to the given entity, using the supplied values.
@@ -1039,7 +1053,7 @@ func (m *Map7[A, B, C, D, E, F, G]) Assign(entity ecs.Entity, a *A, b *B, c *C, 
 //
 // See also [ecs.World.Remove].
 func (m *Map7[A, B, C, D, E, F, G]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map7's components.
@@ -1060,6 +1074,7 @@ func (m *Map7[A, B, C, D, E, F, G]) RemoveEntities(exact bool) {
 type Map8[A any, B any, C any, D any, E any, F any, G any, H any] struct {
 	world *ecs.World
 	mask  ecs.Mask
+	ids   []ecs.ID
 	id0   ecs.ID
 	id1   ecs.ID
 	id2   ecs.ID
@@ -1083,7 +1098,8 @@ func NewMap8[A any, B any, C any, D any, E any, F any, G any, H any](w *ecs.Worl
 		id6:   ecs.ComponentID[G](w),
 		id7:   ecs.ComponentID[H](w),
 	}
-	m.mask = ecs.All(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	m.ids = []ecs.ID{m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7}
+	m.mask = ecs.All(m.ids...)
 	return m
 }
 
@@ -1105,7 +1121,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) Get(entity ecs.Entity) (*A, *B, *C, *D, *
 //
 // See also [ecs.World.NewEntity].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewEntity() ecs.Entity {
-	entity := m.world.NewEntity(m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	entity := m.world.NewEntity(m.ids...)
 	return entity
 }
 
@@ -1113,7 +1129,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewEntity() ecs.Entity {
 //
 // See also [Map8.NewEntitiesQuery] and [ecs.Batch.NewEntities].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewEntities(count int) {
-	m.world.Batch().NewEntities(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	m.world.Batch().NewEntities(count, m.ids...)
 }
 
 // NewEntities creates entities with the Map8's components.
@@ -1123,7 +1139,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewEntities(count int) {
 //
 // See also [Map8.NewEntities] and [ecs.Batch.NewEntitiesQuery].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewEntitiesQuery(count int) Query8[A, B, C, D, E, F, G, H] {
-	query := m.world.Batch().NewEntitiesQuery(count, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	query := m.world.Batch().NewEntitiesQuery(count, m.ids...)
 	return Query8[A, B, C, D, E, F, G, H]{
 		Query: query,
 		id0:   m.id0,
@@ -1202,7 +1218,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewEntitiesWithQuery(count int, a *A, b *
 //
 // See also [ecs.World.Add].
 func (m *Map8[A, B, C, D, E, F, G, H]) Add(entity ecs.Entity) {
-	m.world.Add(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	m.world.Add(entity, m.ids...)
 }
 
 // Assign the Map8's components to the given entity, using the supplied values.
@@ -1225,7 +1241,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) Assign(entity ecs.Entity, a *A, b *B, c *
 //
 // See also [ecs.World.Remove].
 func (m *Map8[A, B, C, D, E, F, G, H]) Remove(entity ecs.Entity) {
-	m.world.Remove(entity, m.id0, m.id1, m.id2, m.id3, m.id4, m.id5, m.id6, m.id7)
+	m.world.Remove(entity, m.ids...)
 }
 
 // RemoveEntities removes all components from the world that match the Map8's components.


### PR DESCRIPTION
* Avoid slice allocations in generic mapper methods that use varags
* Add a competition benchmark for adding and removing components