### PR TITLE
Cached filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 * Generic mappers (`Map1`, ...) have methods `NewEntities`, `NewEntitiesWith` and `RemoveEntities` for batch operations (#151)
 * Batch-creation methods (ID-based and generic) have variants like `NewEntitiesQuery` that return a query over the created entities (#152)
 * Notification during batch-creation is delayed until the resp. query is closed (#157)
-* Match-remove methods (`RemoveEntities()`) return the number of removed entities (#173)
+* Batch-remove methods (`RemoveEntities()`) return the number of removed entities (#173)
+* Filters can be cached and tracked by the `World` to speed up queries when there are many archetypes (#178)
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Nevertheless, *Arche* can also be used for game development.
 
 The `ecs.World` object is a pure and minimal ECS implementation in the sense of a data store
 for entities and components, with query and iteration capabilities.
-The core package `ecs` consists of less than 1500 lines of easy-to-read, clean and well-documented Go code.
+The core package `ecs` consists of only 1500 lines of easy-to-read, clean and well-documented Go code.
 
 There is neither an update loop nor systems.
 These should be implemented by the user.

--- a/benchmark/arche/common/components.go
+++ b/benchmark/arche/common/components.go
@@ -21,6 +21,7 @@ type TestStruct6 struct{ Val int32 }
 type TestStruct7 struct{ Val int32 }
 type TestStruct8 struct{ Val int32 }
 type TestStruct9 struct{ Val int32 }
+type TestStruct10 struct{ Val int32 }
 
 func RegisterAll(w *ecs.World) []ecs.ID {
 	_ = TestStruct0{1}
@@ -33,8 +34,9 @@ func RegisterAll(w *ecs.World) []ecs.ID {
 	_ = TestStruct7{1}
 	_ = TestStruct8{1}
 	_ = TestStruct9{1}
+	_ = TestStruct10{1}
 
-	ids := make([]ecs.ID, 10)
+	ids := make([]ecs.ID, 11)
 	ids[0] = ecs.ComponentID[TestStruct0](w)
 	ids[1] = ecs.ComponentID[TestStruct1](w)
 	ids[2] = ecs.ComponentID[TestStruct2](w)
@@ -45,6 +47,7 @@ func RegisterAll(w *ecs.World) []ecs.ID {
 	ids[7] = ecs.ComponentID[TestStruct7](w)
 	ids[8] = ecs.ComponentID[TestStruct8](w)
 	ids[9] = ecs.ComponentID[TestStruct9](w)
+	ids[10] = ecs.ComponentID[TestStruct10](w)
 
 	return ids
 }

--- a/benchmark/arche/iterate/arche_test.go
+++ b/benchmark/arche/iterate/arche_test.go
@@ -323,6 +323,77 @@ func runArcheFilter1kArch(b *testing.B, count int) {
 	}
 }
 
+func runArcheQuery1Of1kArch(b *testing.B, count int) {
+	b.StopTimer()
+	world := ecs.NewWorld()
+	c.RegisterAll(&world)
+
+	perArch := 2 * count / 1000
+
+	for i := 0; i < 1024; i++ {
+		mask := i
+		add := make([]ecs.ID, 0, 10)
+		for j := 0; j < 10; j++ {
+			id := ecs.ID(j)
+			m := 1 << j
+			if mask&m == m {
+				add = append(add, id)
+			}
+		}
+		for j := 0; j < perArch; j++ {
+			entity := world.NewEntity()
+			world.Add(entity, add...)
+		}
+	}
+	world.Batch().NewEntities(count, 10)
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := world.Query(ecs.All(10))
+		b.StartTimer()
+		for query.Next() {
+			pos := (*c.TestStruct6)(query.Get(10))
+			pos.Val = 1
+		}
+	}
+}
+
+func runArcheQuery1Of1kArchCached(b *testing.B, count int) {
+	b.StopTimer()
+	world := ecs.NewWorld()
+	c.RegisterAll(&world)
+
+	perArch := 2 * count / 1000
+
+	for i := 0; i < 1024; i++ {
+		mask := i
+		add := make([]ecs.ID, 0, 10)
+		for j := 0; j < 10; j++ {
+			id := ecs.ID(j)
+			m := 1 << j
+			if mask&m == m {
+				add = append(add, id)
+			}
+		}
+		for j := 0; j < perArch; j++ {
+			entity := world.NewEntity()
+			world.Add(entity, add...)
+		}
+	}
+	world.Batch().NewEntities(count, 10)
+	var filter ecs.Filter = world.Cache().Register(ecs.All(10))
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := world.Query(filter)
+		b.StartTimer()
+		for query.Next() {
+			pos := (*c.TestStruct10)(query.Get(10))
+			pos.Val = 1
+		}
+	}
+}
+
 func runArcheWorldGet(b *testing.B, count int) {
 	b.StopTimer()
 	world := ecs.NewWorld()
@@ -533,4 +604,28 @@ func BenchmarkArcheFilter1kArchID_10_000(b *testing.B) {
 
 func BenchmarkArcheFilter1kArchID_100_000(b *testing.B) {
 	runArcheFilter1kArch(b, 100000)
+}
+
+func BenchmarkArcheIter1Of1kArch_1_000(b *testing.B) {
+	runArcheQuery1Of1kArch(b, 1000)
+}
+
+func BenchmarkArcheIter1Of1kArch_10_000(b *testing.B) {
+	runArcheQuery1Of1kArch(b, 10000)
+}
+
+func BenchmarkArcheIter1Of1kArch_100_000(b *testing.B) {
+	runArcheQuery1Of1kArch(b, 100000)
+}
+
+func BenchmarkArcheIter1Of1kArchCached_1_000(b *testing.B) {
+	runArcheQuery1Of1kArchCached(b, 1000)
+}
+
+func BenchmarkArcheIter1Of1kArchCached_10_000(b *testing.B) {
+	runArcheQuery1Of1kArchCached(b, 10000)
+}
+
+func BenchmarkArcheIter1Of1kArchCached_100_000(b *testing.B) {
+	runArcheQuery1Of1kArchCached(b, 100000)
 }

--- a/benchmark/arche/iterate/arche_test.go
+++ b/benchmark/arche/iterate/arche_test.go
@@ -112,7 +112,8 @@ func runArcheQueryCached(b *testing.B, count int) {
 
 	world.Batch().NewEntities(count, posID, rotID)
 
-	var filter ecs.Filter = world.Cache().Register(ecs.All(posID, rotID))
+	cf := world.Cache().Register(ecs.All(posID, rotID))
+	var filter ecs.Filter = &cf
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -276,7 +277,8 @@ func runArcheQuery1kArchCached(b *testing.B, count int) {
 		}
 	}
 
-	var filter ecs.Filter = world.Cache().Register(ecs.All(6))
+	cf := world.Cache().Register(ecs.All(6))
+	var filter ecs.Filter = &cf
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -381,7 +383,9 @@ func runArcheQuery1Of1kArchCached(b *testing.B, count int) {
 		}
 	}
 	world.Batch().NewEntities(count, 10)
-	var filter ecs.Filter = world.Cache().Register(ecs.All(10))
+
+	cf := world.Cache().Register(ecs.All(10))
+	var filter ecs.Filter = &cf
 
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()

--- a/benchmark/arche/iterate/ggecs_test.go
+++ b/benchmark/arche/iterate/ggecs_test.go
@@ -18,6 +18,7 @@ const (
 	TestStruct7ID
 	TestStruct8ID
 	TestStruct9ID
+	TestStruct10ID
 	PositionComponentID
 	RotationComponentID
 )
@@ -115,6 +116,53 @@ func runGameEngineEcs1kArch(b *testing.B, count int) {
 	}
 }
 
+func runGameEngineEcs1Of1kArch(b *testing.B, count int) {
+	b.StopTimer()
+	world := ecs.NewWorld(1024)
+	world.Register(ecs.NewComponentRegistry[c.TestStruct0](TestStruct0ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct1](TestStruct1ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct2](TestStruct2ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct3](TestStruct3ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct4](TestStruct4ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct5](TestStruct5ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct6](TestStruct6ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct7](TestStruct7ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct8](TestStruct8ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct9](TestStruct9ID))
+	world.Register(ecs.NewComponentRegistry[c.TestStruct10](TestStruct10ID))
+
+	perArch := 2 * count / 1000
+
+	for i := 0; i < 1024; i++ {
+		mask := i
+		add := make([]uint, 0, 10)
+		for j := 0; j < 10; j++ {
+			id := uint(j)
+			m := 1 << j
+			if mask&m == m {
+				add = append(add, id)
+			}
+		}
+		for j := 0; j < perArch; j++ {
+			_ = world.NewEntity(add...)
+		}
+	}
+	for i := 0; i < count; i++ {
+		world.NewEntity(TestStruct10ID)
+	}
+
+	mask := ecs.MakeComponentMask(TestStruct10ID)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := world.Query(mask)
+		for query.Next() {
+			t1 := (*c.TestStruct10)(query.Component(TestStruct10ID))
+			t1.Val = 1
+		}
+	}
+}
+
 func BenchmarkGGEcsIter_1_000(b *testing.B) {
 	runGameEngineEcs(b, 1000)
 }
@@ -149,4 +197,16 @@ func BenchmarkGGEcsIter1kArch_10_000(b *testing.B) {
 
 func BenchmarkGGEcsIter1kArch_100_000(b *testing.B) {
 	runGameEngineEcs1kArch(b, 100000)
+}
+
+func BenchmarkGGEcsIter1Of1kArch_1_000(b *testing.B) {
+	runGameEngineEcs1Of1kArch(b, 1000)
+}
+
+func BenchmarkGGEcsIter1Of1kArch_10_000(b *testing.B) {
+	runGameEngineEcs1Of1kArch(b, 10000)
+}
+
+func BenchmarkGGEcsIter1Of1kArch_100_000(b *testing.B) {
+	runGameEngineEcs1Of1kArch(b, 100000)
 }

--- a/benchmark/profile/many_arch/main.go
+++ b/benchmark/profile/many_arch/main.go
@@ -50,7 +50,7 @@ func run(rounds, iters, entities int) {
 			}
 		}
 
-		filter := ecs.All(6)
+		var filter ecs.Filter = ecs.All(6)
 		for j := 0; j < iters; j++ {
 			query := world.Query(filter)
 			for query.Next() {

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -75,6 +75,18 @@ func (s batchArchetype) Len() int {
 	return 1
 }
 
+type archetypeSlice []*archetype
+
+// Get returns the value at the given index.
+func (s archetypeSlice) Get(index int) *archetype {
+	return s[index]
+}
+
+// Len returns the current number of items in the paged array.
+func (s archetypeSlice) Len() int {
+	return len(s)
+}
+
 // Helper for accessing data from an archetype
 type archetypeAccess struct {
 	basePointer   unsafe.Pointer

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -75,18 +75,6 @@ func (s batchArchetype) Len() int {
 	return 1
 }
 
-type archetypeSlice []*archetype
-
-// Get returns the value at the given index.
-func (s archetypeSlice) Get(index int) *archetype {
-	return s[index]
-}
-
-// Len returns the current number of items in the paged array.
-func (s archetypeSlice) Len() int {
-	return len(s)
-}
-
 // Helper for accessing data from an archetype
 type archetypeAccess struct {
 	basePointer   unsafe.Pointer

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -7,6 +7,8 @@ type cacheEntry struct {
 }
 
 // Cache provides filter caching to speed up queries.
+//
+// Access it using [World.Cache].
 type Cache struct {
 	bitPool       bitPool
 	indices       []int
@@ -27,6 +29,11 @@ func newCache() Cache {
 }
 
 // Register registers a new filter.
+//
+// Use the returned [CachedFilter] to construct queries:
+//
+//	filter := world.Cache().Register(ecs.All(10))
+//	query := world.Query(filter)
 func (c *Cache) Register(f Filter) CachedFilter {
 	id := c.bitPool.Get()
 	c.filters = append(c.filters,

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -37,12 +37,12 @@ func newCache() Cache {
 	}
 }
 
-// Register registers a new filter.
+// Register a [Filter].
 //
 // Use the returned [CachedFilter] to construct queries:
 //
 //	filter := world.Cache().Register(ecs.All(posID, velID))
-//	query := world.Query(filter)
+//	query := world.Query(&filter)
 func (c *Cache) Register(f Filter) CachedFilter {
 	id := c.bitPool.Get()
 	c.filters = append(c.filters,
@@ -55,7 +55,7 @@ func (c *Cache) Register(f Filter) CachedFilter {
 	return CachedFilter{f, id}
 }
 
-// Unregister un-registers a filter.
+// Unregister a filter.
 //
 // Returns the original filter.
 func (c *Cache) Unregister(f *CachedFilter) Filter {

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -25,6 +25,7 @@ type Cache struct {
 	getArchetypes func(f Filter) pagedPointerArr32[archetype]
 }
 
+// newCache creates a new [Cache].
 func newCache() Cache {
 	indices := make([]int, MaskTotalBits)
 	for i := 0; i < MaskTotalBits; i++ {

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -1,0 +1,55 @@
+package ecs
+
+type cacheEntry struct {
+	Filter     Filter
+	Archetypes []*archetype
+}
+
+// Cache provides filter caching to speed up queries.
+type Cache struct {
+	// TODO write a better data structure!
+	filters       map[int]*cacheEntry
+	counter       int
+	getArchetypes func(f Filter) []*archetype
+}
+
+func newCache() Cache {
+	return Cache{
+		filters: map[int]*cacheEntry{},
+		counter: 0,
+	}
+}
+
+// Register registers a new filter.
+func (c *Cache) Register(f Filter) CachedFilter {
+	id := c.counter
+	c.filters[id] = &cacheEntry{
+		Filter:     f,
+		Archetypes: c.getArchetypes(f),
+	}
+	c.counter++
+	return CachedFilter{f, id}
+}
+
+// Unregister unregisters a.
+func (c *Cache) Unregister(f *CachedFilter) {
+	if _, ok := c.filters[f.id]; !ok {
+		panic("no filter for id found to unregister")
+	}
+	delete(c.filters, f.id)
+}
+
+func (c *Cache) get(f *CachedFilter) *cacheEntry {
+	if e, ok := c.filters[f.id]; ok {
+		return e
+	}
+	panic("no filter for id found")
+}
+
+func (c *Cache) addArchetype(arch *archetype) {
+	for _, e := range c.filters {
+		if e.Filter.Matches(arch.Mask) {
+			e.Archetypes = append(e.Archetypes, arch)
+		}
+	}
+}

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -47,11 +47,14 @@ func (c *Cache) Register(f Filter) CachedFilter {
 }
 
 // Unregister un-registers a filter.
-func (c *Cache) Unregister(f *CachedFilter) {
+//
+// Returns the original filter.
+func (c *Cache) Unregister(f *CachedFilter) Filter {
 	idx := c.indices[f.id]
 	if idx >= MaskTotalBits {
 		panic("no filter for id found to unregister")
 	}
+	filter := c.filters[idx].Filter
 	c.indices[f.id] = MaskTotalBits
 
 	last := len(c.filters) - 1
@@ -61,6 +64,8 @@ func (c *Cache) Unregister(f *CachedFilter) {
 	}
 	c.filters[last] = cacheEntry{}
 	c.filters = c.filters[:last]
+
+	return filter
 }
 
 func (c *Cache) get(f *CachedFilter) *cacheEntry {

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -1,53 +1,73 @@
 package ecs
 
 type cacheEntry struct {
+	ID         ID
 	Filter     Filter
 	Archetypes pagedPointerArr32[archetype]
 }
 
 // Cache provides filter caching to speed up queries.
 type Cache struct {
-	// TODO write a better data structure!
-	filters       map[int]*cacheEntry
-	counter       int
+	bitPool       bitPool
+	indices       []int
+	filters       []cacheEntry
 	getArchetypes func(f Filter) pagedPointerArr32[archetype]
 }
 
 func newCache() Cache {
+	indices := make([]int, MaskTotalBits)
+	for i := 0; i < MaskTotalBits; i++ {
+		indices[i] = MaskTotalBits
+	}
 	return Cache{
-		filters: map[int]*cacheEntry{},
-		counter: 0,
+		bitPool: bitPool{},
+		indices: indices,
+		filters: []cacheEntry{},
 	}
 }
 
 // Register registers a new filter.
 func (c *Cache) Register(f Filter) CachedFilter {
-	id := c.counter
-	c.filters[id] = &cacheEntry{
-		Filter:     f,
-		Archetypes: c.getArchetypes(f),
-	}
-	c.counter++
+	id := c.bitPool.Get()
+	c.filters = append(c.filters,
+		cacheEntry{
+			ID:         id,
+			Filter:     f,
+			Archetypes: c.getArchetypes(f),
+		})
+	c.indices[id] = len(c.filters) - 1
 	return CachedFilter{f, id}
 }
 
-// Unregister unregisters a.
+// Unregister un-registers a filter.
 func (c *Cache) Unregister(f *CachedFilter) {
-	if _, ok := c.filters[f.id]; !ok {
+	idx := c.indices[f.id]
+	if idx >= MaskTotalBits {
 		panic("no filter for id found to unregister")
 	}
-	delete(c.filters, f.id)
+	c.indices[f.id] = MaskTotalBits
+
+	last := len(c.filters) - 1
+	if idx != last {
+		c.filters[idx], c.filters[last] = c.filters[last], c.filters[idx]
+		c.indices[c.filters[idx].ID] = idx
+	}
+	c.filters[last] = cacheEntry{}
+	c.filters = c.filters[:last]
 }
 
 func (c *Cache) get(f *CachedFilter) *cacheEntry {
-	if e, ok := c.filters[f.id]; ok {
-		return e
+	idx := c.indices[f.id]
+	if idx < MaskTotalBits {
+		return &c.filters[idx]
 	}
 	panic("no filter for id found")
 }
 
 func (c *Cache) addArchetype(arch *archetype) {
-	for _, e := range c.filters {
+	ln := len(c.filters)
+	for i := 0; i < ln; i++ {
+		e := &c.filters[i]
 		if e.Filter.Matches(arch.Mask) {
 			e.Archetypes.Add(arch)
 		}

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -2,7 +2,7 @@ package ecs
 
 type cacheEntry struct {
 	Filter     Filter
-	Archetypes []*archetype
+	Archetypes pagedPointerArr32[archetype]
 }
 
 // Cache provides filter caching to speed up queries.
@@ -10,7 +10,7 @@ type Cache struct {
 	// TODO write a better data structure!
 	filters       map[int]*cacheEntry
 	counter       int
-	getArchetypes func(f Filter) []*archetype
+	getArchetypes func(f Filter) pagedPointerArr32[archetype]
 }
 
 func newCache() Cache {
@@ -49,7 +49,7 @@ func (c *Cache) get(f *CachedFilter) *cacheEntry {
 func (c *Cache) addArchetype(arch *archetype) {
 	for _, e := range c.filters {
 		if e.Filter.Matches(arch.Mask) {
-			e.Archetypes = append(e.Archetypes, arch)
+			e.Archetypes.Add(arch)
 		}
 	}
 }

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -31,3 +31,207 @@ func TestFilterCache(t *testing.T) {
 func getArchetypes(f Filter) pagedPointerArr32[archetype] {
 	return pagedPointerArr32[archetype]{}
 }
+
+func benchmarkCachedFilters(b *testing.B, arches int, count int, cached bool) {
+	b.StopTimer()
+	world := NewWorld()
+
+	ids := []ID{
+		ComponentID[testStruct0](&world),
+		ComponentID[testStruct1](&world),
+		ComponentID[testStruct2](&world),
+		ComponentID[testStruct3](&world),
+		ComponentID[testStruct4](&world),
+		ComponentID[testStruct5](&world),
+		ComponentID[testStruct6](&world),
+		ComponentID[testStruct7](&world),
+		ComponentID[testStruct8](&world),
+		ComponentID[testStruct9](&world),
+		ComponentID[testStruct10](&world),
+	}
+	id := ids[10]
+
+	perArch := 25
+
+	for i := 0; i < arches; i++ {
+		mask := i
+		add := make([]ID, 0, 10)
+		for j := 0; j < 10; j++ {
+			id := ids[j]
+			m := 1 << j
+			if mask&m == m {
+				add = append(add, id)
+			}
+		}
+		for j := 0; j < perArch; j++ {
+			world.NewEntity(add...)
+		}
+	}
+
+	world.Batch().NewEntities(count, id)
+
+	var filter Filter = All(id)
+	if cached {
+		filter = world.Cache().Register(filter)
+	}
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := world.Query(filter)
+		for query.Next() {
+			st := (*testStruct0)(query.Get(id))
+			st.Val++
+		}
+	}
+}
+
+// 1 of 1
+func BenchmarkFilterUncached_1of1_100(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 100, false)
+}
+
+func BenchmarkFilterUncached_1of1_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of1_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 10000, false)
+}
+
+func BenchmarkFilterCached_1of1_100(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 100, true)
+}
+
+func BenchmarkFilterCached_1of1_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 1000, true)
+}
+
+func BenchmarkFilterCached_1of1_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1, 10000, true)
+}
+
+// 1 of 4
+func BenchmarkFilterUncached_1of4_100(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 100, false)
+}
+
+func BenchmarkFilterUncached_1of4_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of4_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 10000, false)
+}
+
+func BenchmarkFilterCached_1of4_100(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 100, true)
+}
+
+func BenchmarkFilterCached_1of4_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 1000, true)
+}
+
+func BenchmarkFilterCached_1of4_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 4, 10000, true)
+}
+
+// 1 of 16
+func BenchmarkFilterUncached_1of16_100(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 100, false)
+}
+
+func BenchmarkFilterUncached_1of16_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of16_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 10000, false)
+}
+
+func BenchmarkFilterCached_1of16_100(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 100, true)
+}
+
+func BenchmarkFilterCached_1of16_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 1000, true)
+}
+
+func BenchmarkFilterCached_1of16_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 16, 10000, true)
+}
+
+// 1 of 64
+func BenchmarkFilterUncached_1of64_100(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 100, false)
+}
+
+func BenchmarkFilterUncached_1of64_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of64_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 10000, false)
+}
+
+func BenchmarkFilterCached_1of64_100(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 100, true)
+}
+
+func BenchmarkFilterCached_1of64_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 1000, true)
+}
+
+func BenchmarkFilterCached_1of64_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 64, 10000, true)
+}
+
+// 1 of 256
+func BenchmarkFilterUncached_1of256_100(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 100, false)
+}
+
+func BenchmarkFilterUncached_1of256_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of256_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 10000, false)
+}
+
+func BenchmarkFilterCached_1of256_100(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 100, true)
+}
+
+func BenchmarkFilterCached_1of256_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 1000, true)
+}
+
+func BenchmarkFilterCached_1of256_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 256, 10000, true)
+}
+
+// 1 of 1024
+func BenchmarkFilterUncached_1of1024_100(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 100, false)
+}
+
+func BenchmarkFilterUncached_1of1024_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 1000, false)
+}
+
+func BenchmarkFilterUncached_1of1024_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 10000, false)
+}
+
+func BenchmarkFilterCached_1of1024_100(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 100, true)
+}
+
+func BenchmarkFilterCached_1of1024_1_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 1000, true)
+}
+
+func BenchmarkFilterCached_1of1024_10_000(b *testing.B) {
+	benchmarkCachedFilters(b, 1024, 10000, true)
+}

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -1,0 +1,33 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterCache(t *testing.T) {
+	cache := newCache()
+	cache.getArchetypes = getArchetypes
+
+	f1 := cache.Register(All(0, 1))
+	f2 := cache.Register(All(0, 1, 2))
+	assert.Equal(t, 0, f1.id)
+	assert.Equal(t, 1, f2.id)
+
+	e1 := cache.get(&f1)
+	e2 := cache.get(&f2)
+
+	assert.Equal(t, f1.Filter, e1.Filter)
+	assert.Equal(t, f2.Filter, e2.Filter)
+
+	cache.Unregister(&f1)
+	cache.Unregister(&f2)
+
+	assert.Panics(t, func() { cache.Unregister(&f1) })
+	assert.Panics(t, func() { cache.get(&f1) })
+}
+
+func getArchetypes(f Filter) []*archetype {
+	return []*archetype{}
+}

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -10,8 +10,11 @@ func TestFilterCache(t *testing.T) {
 	cache := newCache()
 	cache.getArchetypes = getArchetypes
 
-	f1 := cache.Register(All(0, 1))
-	f2 := cache.Register(All(0, 1, 2))
+	all1 := All(0, 1)
+	all2 := All(0, 1, 2)
+
+	f1 := cache.Register(all1)
+	f2 := cache.Register(all2)
 	assert.Equal(t, 0, int(f1.id))
 	assert.Equal(t, 1, int(f2.id))
 
@@ -21,8 +24,11 @@ func TestFilterCache(t *testing.T) {
 	assert.Equal(t, f1.Filter, e1.Filter)
 	assert.Equal(t, f2.Filter, e2.Filter)
 
-	cache.Unregister(&f1)
-	cache.Unregister(&f2)
+	ff1 := cache.Unregister(&f1)
+	ff2 := cache.Unregister(&f2)
+
+	assert.Equal(t, all1, ff1)
+	assert.Equal(t, all2, ff2)
 
 	assert.Panics(t, func() { cache.Unregister(&f1) })
 	assert.Panics(t, func() { cache.get(&f1) })

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -12,8 +12,8 @@ func TestFilterCache(t *testing.T) {
 
 	f1 := cache.Register(All(0, 1))
 	f2 := cache.Register(All(0, 1, 2))
-	assert.Equal(t, 0, f1.id)
-	assert.Equal(t, 1, f2.id)
+	assert.Equal(t, 0, int(f1.id))
+	assert.Equal(t, 1, int(f2.id))
 
 	e1 := cache.get(&f1)
 	e2 := cache.get(&f2)

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -28,6 +28,6 @@ func TestFilterCache(t *testing.T) {
 	assert.Panics(t, func() { cache.get(&f1) })
 }
 
-func getArchetypes(f Filter) []*archetype {
-	return []*archetype{}
+func getArchetypes(f Filter) pagedPointerArr32[archetype] {
+	return pagedPointerArr32[archetype]{}
 }

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -21,8 +21,8 @@ func TestFilterCache(t *testing.T) {
 	e1 := cache.get(&f1)
 	e2 := cache.get(&f2)
 
-	assert.Equal(t, f1.Filter, e1.Filter)
-	assert.Equal(t, f2.Filter, e2.Filter)
+	assert.Equal(t, f1.filter, e1.Filter)
+	assert.Equal(t, f2.filter, e2.Filter)
 
 	ff1 := cache.Unregister(&f1)
 	ff2 := cache.Unregister(&f2)
@@ -78,7 +78,8 @@ func benchmarkCachedFilters(b *testing.B, arches int, count int, cached bool) {
 
 	var filter Filter = All(id)
 	if cached {
-		filter = world.Cache().Register(filter)
+		f := world.Cache().Register(filter)
+		filter = &f
 	}
 
 	b.StartTimer()

--- a/ecs/paged.go
+++ b/ecs/paged.go
@@ -31,3 +31,33 @@ func (p *pagedArr32[T]) Get(index int) *T {
 func (p *pagedArr32[T]) Len() int {
 	return p.len
 }
+
+// pagedPointerArr32 is a paged collection working with pages of length 32 arrays.
+//
+// Implements [archetypes].
+type pagedPointerArr32[T any] struct {
+	pages   [][fixedPageSize]*T
+	len     int
+	lenLast int
+}
+
+// Add adds a value to the paged array.
+func (p *pagedPointerArr32[T]) Add(value *T) {
+	if p.len == 0 || p.lenLast == fixedPageSize {
+		p.pages = append(p.pages, [fixedPageSize]*T{})
+		p.lenLast = 0
+	}
+	p.pages[len(p.pages)-1][p.lenLast] = value
+	p.len++
+	p.lenLast++
+}
+
+// Get returns the value at the given index.
+func (p *pagedPointerArr32[T]) Get(index int) *T {
+	return p.pages[index/fixedPageSize][index%fixedPageSize]
+}
+
+// Len returns the current number of items in the paged array.
+func (p *pagedPointerArr32[T]) Len() int {
+	return p.len
+}

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -176,13 +176,9 @@ func (q *Query) Close() {
 
 // nextArchetype proceeds to the next archetype, and returns whether this was successful/possible.
 func (q *Query) nextArchetype() bool {
-	switch t := q.filter.(type) {
+	switch q.filter.(type) {
 	case *CachedFilter:
 		return q.nextArchetypeCached()
-	case Mask:
-		return q.nextArchetypeMask(t)
-	case *MaskFilter:
-		return q.nextArchetypeMaskFilter(t)
 	default:
 		return q.nextArchetypeFilter()
 	}
@@ -193,36 +189,6 @@ func (q *Query) nextArchetypeCached() bool {
 	for i := q.index + 1; i < len; i++ {
 		a := q.archetypes.Get(i)
 		if a.Len() > 0 {
-			q.index = i
-			q.archetypeIter = newArchetypeIter(a)
-			return true
-		}
-	}
-	q.index = len
-	q.world.closeQuery(q)
-	return false
-}
-
-func (q *Query) nextArchetypeMask(f Mask) bool {
-	len := int(q.archetypes.Len())
-	for i := q.index + 1; i < len; i++ {
-		a := q.archetypes.Get(i)
-		if f.Matches(a.Mask) && a.Len() > 0 {
-			q.index = i
-			q.archetypeIter = newArchetypeIter(a)
-			return true
-		}
-	}
-	q.index = len
-	q.world.closeQuery(q)
-	return false
-}
-
-func (q *Query) nextArchetypeMaskFilter(f *MaskFilter) bool {
-	len := int(q.archetypes.Len())
-	for i := q.index + 1; i < len; i++ {
-		a := q.archetypes.Get(i)
-		if f.Matches(a.Mask) && a.Len() > 0 {
 			q.index = i
 			q.archetypeIter = newArchetypeIter(a)
 			return true

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -171,16 +171,16 @@ func (q *Query) Close() {
 
 // nextArchetype proceeds to the next archetype, and returns whether this was successful/possible.
 func (q *Query) nextArchetype() bool {
-	if _, ok := q.filter.(CachedFilter); ok {
+	switch t := q.filter.(type) {
+	case CachedFilter:
 		return q.nextArchetypeCached()
+	case Mask:
+		return q.nextArchetypeMask(t)
+	case *MaskFilter:
+		return q.nextArchetypeMaskFilter(t)
+	default:
+		return q.nextArchetypeFilter()
 	}
-	if mask, ok := q.filter.(Mask); ok {
-		return q.nextArchetypeMask(mask)
-	}
-	if mask, ok := q.filter.(*MaskFilter); ok {
-		return q.nextArchetypeMaskFilter(mask)
-	}
-	return q.nextArchetypeFilter()
 }
 
 func (q *Query) nextArchetypeCached() bool {

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -40,7 +40,7 @@ func (f dummyFilter) Matches(bits Mask) bool {
 // CachedFilter is a filter that is cached by the world.
 type CachedFilter struct {
 	Filter
-	id int
+	id ID
 }
 
 // Query is an iterator to iterate entities, filtered by a [Filter].

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -184,6 +184,7 @@ func (q *Query) nextArchetype() bool {
 	}
 }
 
+// nextArchetypeCached is called if the query is cached.
 func (q *Query) nextArchetypeCached() bool {
 	len := int(q.archetypes.Len())
 	for i := q.index + 1; i < len; i++ {
@@ -199,6 +200,7 @@ func (q *Query) nextArchetypeCached() bool {
 	return false
 }
 
+// nextArchetypeFilter is called if the query is not cached.
 func (q *Query) nextArchetypeFilter() bool {
 	len := int(q.archetypes.Len())
 	for i := q.index + 1; i < len; i++ {

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -39,8 +39,13 @@ func (f dummyFilter) Matches(bits Mask) bool {
 
 // CachedFilter is a filter that is cached by the world.
 type CachedFilter struct {
-	Filter
-	id ID
+	filter Filter
+	id     ID
+}
+
+// Matches matches a filter against a mask.
+func (f *CachedFilter) Matches(bits Mask) bool {
+	return f.filter.Matches(bits)
 }
 
 // Query is an iterator to iterate entities, filtered by a [Filter].
@@ -172,7 +177,7 @@ func (q *Query) Close() {
 // nextArchetype proceeds to the next archetype, and returns whether this was successful/possible.
 func (q *Query) nextArchetype() bool {
 	switch t := q.filter.(type) {
-	case CachedFilter:
+	case *CachedFilter:
 		return q.nextArchetypeCached()
 	case Mask:
 		return q.nextArchetypeMask(t)

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -144,6 +144,10 @@ func TestQueryCached(t *testing.T) {
 	for q.Next() {
 	}
 
+	filterVel := w.Cache().Register(All(velID))
+	q = w.Query(filterVel)
+	assert.Equal(t, 20, q.Count())
+	q.Close()
 }
 
 func TestQueryCount(t *testing.T) {

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -116,11 +116,11 @@ func TestQueryCached(t *testing.T) {
 	filterPos := w.Cache().Register(All(posID))
 	filterPosVel := w.Cache().Register(All(posID, velID))
 
-	q := w.Query(filterPos)
+	q := w.Query(&filterPos)
 	assert.Equal(t, 0, q.Count())
 	q.Close()
 
-	q = w.Query(filterPosVel)
+	q = w.Query(&filterPosVel)
 	assert.Equal(t, 0, q.Count())
 	q.Close()
 
@@ -128,24 +128,24 @@ func TestQueryCached(t *testing.T) {
 	w.Batch().NewEntities(10, velID)
 	w.Batch().NewEntities(10, posID, velID)
 
-	q = w.Query(filterPos)
+	q = w.Query(&filterPos)
 	assert.Equal(t, 20, q.Count())
 	q.Close()
 
-	q = w.Query(filterPosVel)
+	q = w.Query(&filterPosVel)
 	assert.Equal(t, 10, q.Count())
 	q.Close()
 
 	w.Batch().NewEntities(10, posID)
 
-	q = w.Query(filterPos)
+	q = w.Query(&filterPos)
 	assert.Equal(t, 30, q.Count())
 
 	for q.Next() {
 	}
 
 	filterVel := w.Cache().Register(All(velID))
-	q = w.Query(filterVel)
+	q = w.Query(&filterVel)
 	assert.Equal(t, 20, q.Count())
 	q.Close()
 }

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -107,6 +107,45 @@ func TestQuery(t *testing.T) {
 	assert.Equal(t, 0, cnt)
 }
 
+func TestQueryCached(t *testing.T) {
+	w := NewWorld()
+
+	posID := ComponentID[position](&w)
+	velID := ComponentID[velocity](&w)
+
+	filterPos := w.Cache().Register(All(posID))
+	filterPosVel := w.Cache().Register(All(posID, velID))
+
+	q := w.Query(filterPos)
+	assert.Equal(t, 0, q.Count())
+	q.Close()
+
+	q = w.Query(filterPosVel)
+	assert.Equal(t, 0, q.Count())
+	q.Close()
+
+	w.Batch().NewEntities(10, posID)
+	w.Batch().NewEntities(10, velID)
+	w.Batch().NewEntities(10, posID, velID)
+
+	q = w.Query(filterPos)
+	assert.Equal(t, 20, q.Count())
+	q.Close()
+
+	q = w.Query(filterPosVel)
+	assert.Equal(t, 10, q.Count())
+	q.Close()
+
+	w.Batch().NewEntities(10, posID)
+
+	q = w.Query(filterPos)
+	assert.Equal(t, 30, q.Count())
+
+	for q.Next() {
+	}
+
+}
+
 func TestQueryCount(t *testing.T) {
 	w := NewWorld()
 

--- a/ecs/resources.go
+++ b/ecs/resources.go
@@ -6,6 +6,7 @@ import (
 )
 
 // Resources manage a world's resources.
+//
 // Access it using [World.Resources].
 type Resources struct {
 	registry  componentRegistry[ResID]

--- a/ecs/types_test.go
+++ b/ecs/types_test.go
@@ -26,3 +26,4 @@ type testStruct6 struct{ val int32 }
 type testStruct7 struct{ val int32 }
 type testStruct8 struct{ val int32 }
 type testStruct9 struct{ val int32 }
+type testStruct10 struct{ val int32 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -479,7 +479,7 @@ func (w *World) Reset() {
 //
 // Example:
 //
-//	filter := All(idA, idB).Without(idC)
+//	filter := ecs.All(idA, idB).Without(idC)
 //	query := world.Query(filter)
 //	for query.Next() {
 //	    pos := (*position)(query.Get(posID))
@@ -498,18 +498,6 @@ func (w *World) Query(filter Filter) Query {
 	}
 
 	return newQuery(w, filter, l, &w.archetypes)
-}
-
-func (w *World) getArchetypes(filter Filter) pagedPointerArr32[archetype] {
-	arches := pagedPointerArr32[archetype]{}
-	len := int(w.archetypes.Len())
-	for i := 0; i < len; i++ {
-		a := w.archetypes.Get(i)
-		if filter.Matches(a.Mask) {
-			arches.Add(a)
-		}
-	}
-	return arches
 }
 
 // Resources of the world.
@@ -792,6 +780,18 @@ func (w *World) createArchetype(node *archetypeNode, forStorage bool) *archetype
 
 	w.filterCache.addArchetype(arch)
 	return arch
+}
+
+func (w *World) getArchetypes(filter Filter) pagedPointerArr32[archetype] {
+	arches := pagedPointerArr32[archetype]{}
+	len := int(w.archetypes.Len())
+	for i := 0; i < len; i++ {
+		a := w.archetypes.Get(i)
+		if filter.Matches(a.Mask) {
+			arches.Add(a)
+		}
+	}
+	return arches
 }
 
 // componentID returns the ID for a component type, and registers it if not already registered.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -492,8 +492,8 @@ func (w *World) Reset() {
 // Locks the world to prevent changes to component compositions.
 func (w *World) Query(filter Filter) Query {
 	l := w.lock()
-	if cached, ok := filter.(CachedFilter); ok {
-		archetypes := &w.filterCache.get(&cached).Archetypes
+	if cached, ok := filter.(*CachedFilter); ok {
+		archetypes := &w.filterCache.get(cached).Archetypes
 		return newQuery(w, cached, l, archetypes)
 	}
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -516,6 +516,8 @@ func (w *World) Batch() *Batch {
 }
 
 // Cache returns the [Cache] of the world, for registering filters.
+//
+// See [Cache] for details.
 func (w *World) Cache() *Cache {
 	if w.filterCache.getArchetypes == nil {
 		w.filterCache.getArchetypes = w.getArchetypes

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -784,6 +784,7 @@ func (w *World) createArchetype(node *archetypeNode, forStorage bool) *archetype
 	return arch
 }
 
+// Returns all archetypes that match the given filter. Used by [Cache].
 func (w *World) getArchetypes(filter Filter) pagedPointerArr32[archetype] {
 	arches := pagedPointerArr32[archetype]{}
 	len := int(w.archetypes.Len())

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -493,20 +493,20 @@ func (w *World) Reset() {
 func (w *World) Query(filter Filter) Query {
 	l := w.lock()
 	if cached, ok := filter.(CachedFilter); ok {
-		archetypes := w.filterCache.get(&cached).Archetypes
-		return newQuery(w, cached, l, archetypeSlice(archetypes))
+		archetypes := &w.filterCache.get(&cached).Archetypes
+		return newQuery(w, cached, l, archetypes)
 	}
 
 	return newQuery(w, filter, l, &w.archetypes)
 }
 
-func (w *World) getArchetypes(filter Filter) []*archetype {
-	arches := []*archetype{}
+func (w *World) getArchetypes(filter Filter) pagedPointerArr32[archetype] {
+	arches := pagedPointerArr32[archetype]{}
 	len := int(w.archetypes.Len())
 	for i := 0; i < len; i++ {
 		a := w.archetypes.Get(i)
 		if filter.Matches(a.Mask) {
-			arches = append(arches, a)
+			arches.Add(a)
 		}
 	}
 	return arches

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -494,7 +494,7 @@ func (w *World) Query(filter Filter) Query {
 	l := w.lock()
 	if cached, ok := filter.(CachedFilter); ok {
 		archetypes := w.filterCache.get(&cached).Archetypes
-		return newQuery(w, filter, l, archetypeSlice(archetypes))
+		return newQuery(w, cached, l, archetypeSlice(archetypes))
 	}
 
 	return newQuery(w, filter, l, &w.archetypes)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -865,6 +865,7 @@ func Test1000Archetypes(t *testing.T) {
 	_ = testStruct7{1}
 	_ = testStruct8{1}
 	_ = testStruct9{1}
+	_ = testStruct10{1}
 
 	w := NewWorld()
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -921,6 +921,7 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSize[Resources]()
 	printTypeSizeName[reflect.Value]("reflect.Value")
 	printTypeSize[EntityEvent]()
+	printTypeSize[Cache]()
 }
 
 func printTypeSize[T any]() {

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -6,9 +6,10 @@ import (
 
 // compiledQuery is a helper for compiling a generic filter into a [ecs.Filter].
 type compiledQuery struct {
-	filter   ecs.MaskFilter
-	Ids      []ecs.ID
-	compiled bool
+	maskFilter ecs.MaskFilter
+	filter     ecs.Filter
+	Ids        []ecs.ID
+	compiled   bool
 }
 
 // Compile compiles a generic filter.
@@ -17,10 +18,11 @@ func (q *compiledQuery) Compile(w *ecs.World, include, optional, exclude []Comp)
 		return
 	}
 	q.Ids = toIds(w, include)
-	q.filter = ecs.MaskFilter{
+	q.maskFilter = ecs.MaskFilter{
 		Include: toMaskOptional(w, q.Ids, optional),
 		Exclude: toMask(w, exclude),
 	}
+	q.filter = &q.maskFilter
 	q.compiled = true
 }
 

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -6,10 +6,11 @@ import (
 
 // compiledQuery is a helper for compiling a generic filter into a [ecs.Filter].
 type compiledQuery struct {
-	maskFilter ecs.MaskFilter
-	filter     ecs.Filter
-	Ids        []ecs.ID
-	compiled   bool
+	maskFilter   ecs.MaskFilter
+	cachedFilter ecs.CachedFilter
+	filter       ecs.Filter
+	Ids          []ecs.ID
+	compiled     bool
 }
 
 // Compile compiles a generic filter.

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -58,9 +58,9 @@ func (q *Filter{{ .Index }}{{ .Types }}) Query(w *ecs.World) Query{{ .Index }}{{
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter{{ .Index }}.Query].
-func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -49,7 +49,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) Without(mask ...Comp) *Filter{{ .Index 
 func (q *Filter{{ .Index }}{{ .Types }}) Query(w *ecs.World) Query{{ .Index }}{{ .Types }} {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query{{ .Index }}{{ .Types }}{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		{{ .IDAssign }}
 	}
 }
@@ -58,9 +58,26 @@ func (q *Filter{{ .Index }}{{ .Types }}) Query(w *ecs.World) Query{{ .Index }}{{
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter{{ .Index }}.Query].
-func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter{{ .Index }}{{ .Types }}) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter{{ .Index }}{{ .Types }}) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query{{ .Index }} is a generic query iterator for {{ .NumberStr }} components.

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -63,15 +63,17 @@ func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter{{ .Index }}{{ .Types }}) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter{{ .Index }}{{ .Types }}) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -68,18 +68,19 @@ func (q *Filter{{ .Index }}{{ .Types }}) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter{{ .Index }}{{ .Types }}) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter{{ .Index }}{{ .Types }}) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query{{ .Index }} is a generic query iterator for {{ .NumberStr }} components.

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -51,9 +51,9 @@ func (q *Filter0) Query(w *ecs.World) Query0 {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter0.Query].
-func (q *Filter0) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter0) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -143,9 +143,9 @@ func (q *Filter1[A]) Query(w *ecs.World) Query1[A] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter1.Query].
-func (q *Filter1[A]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter1[A]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -245,9 +245,9 @@ func (q *Filter2[A, B]) Query(w *ecs.World) Query2[A, B] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter2.Query].
-func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -351,9 +351,9 @@ func (q *Filter3[A, B, C]) Query(w *ecs.World) Query3[A, B, C] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter3.Query].
-func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -461,9 +461,9 @@ func (q *Filter4[A, B, C, D]) Query(w *ecs.World) Query4[A, B, C, D] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter4.Query].
-func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -575,9 +575,9 @@ func (q *Filter5[A, B, C, D, E]) Query(w *ecs.World) Query5[A, B, C, D, E] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter5.Query].
-func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -693,9 +693,9 @@ func (q *Filter6[A, B, C, D, E, F]) Query(w *ecs.World) Query6[A, B, C, D, E, F]
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter6.Query].
-func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -815,9 +815,9 @@ func (q *Filter7[A, B, C, D, E, F, G]) Query(w *ecs.World) Query7[A, B, C, D, E,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter7.Query].
-func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.
@@ -941,9 +941,9 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Query(w *ecs.World) Query8[A, B, C, D,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter8.Query].
-func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.Filter {
+func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.MaskFilter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	return q.compiled.filter
+	return q.compiled.maskFilter
 }
 
 // Register the filter for caching.

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -56,15 +56,17 @@ func (q *Filter0) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter0) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter0) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -146,15 +148,17 @@ func (q *Filter1[A]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter1[A]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter1[A]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -246,15 +250,17 @@ func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter2[A, B]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter2[A, B]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -350,15 +356,17 @@ func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter3[A, B, C]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter3[A, B, C]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -458,15 +466,17 @@ func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter4[A, B, C, D]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter4[A, B, C, D]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -570,15 +580,17 @@ func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter5[A, B, C, D, E]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter5[A, B, C, D, E]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -686,15 +698,17 @@ func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter6[A, B, C, D, E, F]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter6[A, B, C, D, E, F]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -806,15 +820,17 @@ func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter7[A, B, C, D, E, F, G]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter7[A, B, C, D, E, F, G]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)
@@ -930,15 +946,17 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.Filter {
 	return q.compiled.filter
 }
 
-// Register registers the filter for caching.
+// Register the filter for caching.
 //
-// See also [ecs.World.Cache].
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter8[A, B, C, D, E, F, G, H]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	q.compiled.filter = w.Cache().Register(q.compiled.filter)
 }
 
-// Unregister un-registers the filter from caching.
+// Unregister the filter from caching.
+//
+// See [ecs.Cache] for details on filter caching.
 func (q *Filter8[A, B, C, D, E, F, G, H]) Unregister(w *ecs.World) {
 	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
 		q.compiled.filter = w.Cache().Unregister(&cached)

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -43,7 +43,7 @@ func (q *Filter0) Without(mask ...Comp) *Filter0 {
 func (q *Filter0) Query(w *ecs.World) Query0 {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query0{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 	}
 }
 
@@ -51,9 +51,26 @@ func (q *Filter0) Query(w *ecs.World) Query0 {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter0.Query].
-func (q *Filter0) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter0) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter0) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter0) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query0 is a generic query iterator for zero components.
@@ -115,7 +132,7 @@ func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
 func (q *Filter1[A]) Query(w *ecs.World) Query1[A] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query1[A]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 	}
 }
@@ -124,9 +141,26 @@ func (q *Filter1[A]) Query(w *ecs.World) Query1[A] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter1.Query].
-func (q *Filter1[A]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter1[A]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter1[A]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter1[A]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query1 is a generic query iterator for one components.
@@ -197,7 +231,7 @@ func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
 func (q *Filter2[A, B]) Query(w *ecs.World) Query2[A, B] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query2[A, B]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 	}
@@ -207,9 +241,26 @@ func (q *Filter2[A, B]) Query(w *ecs.World) Query2[A, B] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter2.Query].
-func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter2[A, B]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter2[A, B]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query2 is a generic query iterator for two components.
@@ -283,7 +334,7 @@ func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
 func (q *Filter3[A, B, C]) Query(w *ecs.World) Query3[A, B, C] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query3[A, B, C]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -294,9 +345,26 @@ func (q *Filter3[A, B, C]) Query(w *ecs.World) Query3[A, B, C] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter3.Query].
-func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter3[A, B, C]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter3[A, B, C]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query3 is a generic query iterator for three components.
@@ -373,7 +441,7 @@ func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
 func (q *Filter4[A, B, C, D]) Query(w *ecs.World) Query4[A, B, C, D] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query4[A, B, C, D]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -385,9 +453,26 @@ func (q *Filter4[A, B, C, D]) Query(w *ecs.World) Query4[A, B, C, D] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter4.Query].
-func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter4[A, B, C, D]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter4[A, B, C, D]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query4 is a generic query iterator for four components.
@@ -467,7 +552,7 @@ func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
 func (q *Filter5[A, B, C, D, E]) Query(w *ecs.World) Query5[A, B, C, D, E] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query5[A, B, C, D, E]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -480,9 +565,26 @@ func (q *Filter5[A, B, C, D, E]) Query(w *ecs.World) Query5[A, B, C, D, E] {
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter5.Query].
-func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter5[A, B, C, D, E]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter5[A, B, C, D, E]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query5 is a generic query iterator for five components.
@@ -565,7 +667,7 @@ func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E
 func (q *Filter6[A, B, C, D, E, F]) Query(w *ecs.World) Query6[A, B, C, D, E, F] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query6[A, B, C, D, E, F]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -579,9 +681,26 @@ func (q *Filter6[A, B, C, D, E, F]) Query(w *ecs.World) Query6[A, B, C, D, E, F]
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter6.Query].
-func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter6[A, B, C, D, E, F]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter6[A, B, C, D, E, F]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query6 is a generic query iterator for six components.
@@ -667,7 +786,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D
 func (q *Filter7[A, B, C, D, E, F, G]) Query(w *ecs.World) Query7[A, B, C, D, E, F, G] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query7[A, B, C, D, E, F, G]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -682,9 +801,26 @@ func (q *Filter7[A, B, C, D, E, F, G]) Query(w *ecs.World) Query7[A, B, C, D, E,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter7.Query].
-func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter7[A, B, C, D, E, F, G]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter7[A, B, C, D, E, F, G]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query7 is a generic query iterator for seven components.
@@ -773,7 +909,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C
 func (q *Filter8[A, B, C, D, E, F, G, H]) Query(w *ecs.World) Query8[A, B, C, D, E, F, G, H] {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return Query8[A, B, C, D, E, F, G, H]{
-		Query: w.Query(&q.compiled.filter),
+		Query: w.Query(q.compiled.filter),
 		id0:   q.compiled.Ids[0],
 		id1:   q.compiled.Ids[1],
 		id2:   q.compiled.Ids[2],
@@ -789,9 +925,26 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Query(w *ecs.World) Query8[A, B, C, D,
 //
 // Can be passed to [ecs.World.Query].
 // For the intended generic use, however, generate a generic query with [Filter8.Query].
-func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.MaskFilter {
+func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.Filter {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
 	return q.compiled.filter
+}
+
+// Register registers the filter for caching.
+//
+// See also [ecs.World.Cache].
+func (q *Filter8[A, B, C, D, E, F, G, H]) Register(w *ecs.World) {
+	q.compiled.Compile(w, q.include, q.optional, q.exclude)
+	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+}
+
+// Unregister un-registers the filter from caching.
+func (q *Filter8[A, B, C, D, E, F, G, H]) Unregister(w *ecs.World) {
+	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(&cached)
+		return
+	}
+	panic("can't unregister a filter that is not cached")
 }
 
 // Query8 is a generic query iterator for eight components.

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -61,18 +61,19 @@ func (q *Filter0) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter0) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter0) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query0 is a generic query iterator for zero components.
@@ -153,18 +154,19 @@ func (q *Filter1[A]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter1[A]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter1[A]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query1 is a generic query iterator for one components.
@@ -255,18 +257,19 @@ func (q *Filter2[A, B]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter2[A, B]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter2[A, B]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query2 is a generic query iterator for two components.
@@ -361,18 +364,19 @@ func (q *Filter3[A, B, C]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter3[A, B, C]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter3[A, B, C]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query3 is a generic query iterator for three components.
@@ -471,18 +475,19 @@ func (q *Filter4[A, B, C, D]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter4[A, B, C, D]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter4[A, B, C, D]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query4 is a generic query iterator for four components.
@@ -585,18 +590,19 @@ func (q *Filter5[A, B, C, D, E]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter5[A, B, C, D, E]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter5[A, B, C, D, E]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query5 is a generic query iterator for five components.
@@ -703,18 +709,19 @@ func (q *Filter6[A, B, C, D, E, F]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter6[A, B, C, D, E, F]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter6[A, B, C, D, E, F]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query6 is a generic query iterator for six components.
@@ -825,18 +832,19 @@ func (q *Filter7[A, B, C, D, E, F, G]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter7[A, B, C, D, E, F, G]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter7[A, B, C, D, E, F, G]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query7 is a generic query iterator for seven components.
@@ -951,18 +959,19 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Filter(w *ecs.World) ecs.MaskFilter {
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter8[A, B, C, D, E, F, G, H]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude)
-	q.compiled.filter = w.Cache().Register(q.compiled.filter)
+	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
+	q.compiled.filter = &q.compiled.cachedFilter
 }
 
 // Unregister the filter from caching.
 //
 // See [ecs.Cache] for details on filter caching.
 func (q *Filter8[A, B, C, D, E, F, G, H]) Unregister(w *ecs.World) {
-	if cached, ok := q.compiled.filter.(ecs.CachedFilter); ok {
-		q.compiled.filter = w.Cache().Unregister(&cached)
-		return
+	if cf, ok := q.compiled.filter.(*ecs.CachedFilter); ok {
+		q.compiled.filter = w.Cache().Unregister(cf)
+	} else {
+		panic("can't unregister a filter that is not cached")
 	}
-	panic("can't unregister a filter that is not cached")
 }
 
 // Query8 is a generic query iterator for eight components.

--- a/generic/query_test.go
+++ b/generic/query_test.go
@@ -101,7 +101,10 @@ func TestQuery0(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(8).Without(9), filter.Filter(&w))
+	f := ecs.All(8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		_ = query.Entity()
@@ -109,6 +112,8 @@ func TestQuery0(t *testing.T) {
 	}
 	assert.Equal(t, 1, cnt)
 
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery1(t *testing.T) {
@@ -136,7 +141,10 @@ func TestQuery1(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c0 := query.Get()
@@ -144,6 +152,9 @@ func TestQuery1(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery2(t *testing.T) {
@@ -173,7 +184,9 @@ func TestQuery2(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
 
 	for i := 0; i < 10; i++ {
 		cnt := 0
@@ -186,6 +199,9 @@ func TestQuery2(t *testing.T) {
 		}
 		assert.Equal(t, 1, cnt)
 	}
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery3(t *testing.T) {
@@ -220,7 +236,10 @@ func TestQuery3(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3 := query.Get()
@@ -230,6 +249,9 @@ func TestQuery3(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery4(t *testing.T) {
@@ -268,7 +290,10 @@ func TestQuery4(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 3, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 3, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3, c4 := query.Get()
@@ -279,6 +304,9 @@ func TestQuery4(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery5(t *testing.T) {
@@ -321,7 +349,10 @@ func TestQuery5(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 3, 4, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 3, 4, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3, c4, c5 := query.Get()
@@ -333,6 +364,9 @@ func TestQuery5(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery6(t *testing.T) {
@@ -379,7 +413,10 @@ func TestQuery6(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 3, 4, 5, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 3, 4, 5, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3, c4, c5, c6 := query.Get()
@@ -392,6 +429,9 @@ func TestQuery6(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery7(t *testing.T) {
@@ -445,7 +485,10 @@ func TestQuery7(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 3, 4, 5, 6, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 3, 4, 5, 6, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3, c4, c5, c6, c7 := query.Get()
@@ -459,6 +502,9 @@ func TestQuery7(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQuery8(t *testing.T) {
@@ -508,7 +554,10 @@ func TestQuery8(t *testing.T) {
 			With(T[testStruct8]()).
 			Without(T[testStruct9]())
 
-	assert.Equal(t, ecs.All(0, 2, 3, 4, 5, 6, 7, 8).Without(9), filter.Filter(&w))
+	f := ecs.All(0, 2, 3, 4, 5, 6, 7, 8).Without(9)
+	assert.Equal(t, &f, filter.Filter(&w))
+	filter.Register(&w)
+
 	query := filter.Query(&w)
 	for query.Next() {
 		c1, c2, c3, c4, c5, c6, c7, c8 := query.Get()
@@ -523,6 +572,9 @@ func TestQuery8(t *testing.T) {
 		cnt++
 	}
 	assert.Equal(t, 1, cnt)
+
+	filter.Unregister(&w)
+	assert.Panics(t, func() { filter.Unregister(&w) })
 }
 
 func TestQueryGeneric(t *testing.T) {

--- a/generic/query_test.go
+++ b/generic/query_test.go
@@ -102,7 +102,7 @@ func TestQuery0(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -142,7 +142,7 @@ func TestQuery1(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -185,7 +185,7 @@ func TestQuery2(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	for i := 0; i < 10; i++ {
@@ -237,7 +237,7 @@ func TestQuery3(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -291,7 +291,7 @@ func TestQuery4(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 3, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -350,7 +350,7 @@ func TestQuery5(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 3, 4, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -414,7 +414,7 @@ func TestQuery6(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 3, 4, 5, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -486,7 +486,7 @@ func TestQuery7(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 3, 4, 5, 6, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)
@@ -555,7 +555,7 @@ func TestQuery8(t *testing.T) {
 			Without(T[testStruct9]())
 
 	f := ecs.All(0, 2, 3, 4, 5, 6, 7, 8).Without(9)
-	assert.Equal(t, &f, filter.Filter(&w))
+	assert.Equal(t, f, filter.Filter(&w))
 	filter.Register(&w)
 
 	query := filter.Query(&w)


### PR DESCRIPTION
Introduces cached filters.

Filters are registered to the world, and the world keeps track of the relevant archetypes. When a query is created from a cached filter, the managed list of archetypes is used, and no mask checks are required during iteration.

However, this brings a performance advantage only for this case:
* many archetypes
* only a few entities to iterate, that are only in a few archetypes (or a single one)

Not sure if this is really worth the additional API and code.

Fixes #177

### Benchmarks

```
BenchmarkFilterUncached_1of16_100-2        	 3118692	       384.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of16_1_000-2      	  507350	      2312 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of16_10_000-2     	   55030	     22013 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of16_100-2          	 4105543	       294.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of16_1_000-2        	  529378	      2222 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of16_10_000-2       	   54590	     22141 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of64_100-2        	 1766755	       677.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of64_1_000-2      	  459115	      2607 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of64_10_000-2     	   54856	     22341 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of64_100-2          	 4016372	       294.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of64_1_000-2        	  539553	      2233 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of64_10_000-2       	   54658	     21707 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of256_100-2       	  650193	      1842 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of256_1_000-2     	  317648	      3767 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of256_10_000-2    	   51051	     23442 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of256_100-2         	 4092333	       295.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of256_1_000-2       	  535809	      2229 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of256_10_000-2      	   55857	     21792 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of1024_100-2      	  183807	      6509 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of1024_1_000-2    	  142125	      8458 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterUncached_1of1024_10_000-2   	   42786	     28018 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of1024_100-2        	 4111138	       291.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of1024_1_000-2      	  540202	      2229 ns/op	       0 B/op	       0 allocs/op
BenchmarkFilterCached_1of1024_10_000-2     	   54086	     21874 ns/op	       0 B/op	       0 allocs/op
```