### PR TITLE
Query cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Do not clear memory when adding entities to archetypes, not required anymore as of #147 (#165)
 * Speed up copying entity to archetype by getting entity pointer without reflection (#166)
 * Avoid slice allocations in generic mapper methods (#170)
+* Avoid type checks in query when iterating archetypes (#179)
 
 ### Bugfixes
 

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -56,13 +56,15 @@ func (f *CachedFilter) Matches(bits Mask) bool {
 // [github.com/mlange-42/arche/generic.Query2], etc.
 // For advanced filtering, see package [github.com/mlange-42/arche/filter]
 type Query struct {
-	archetypeIter
-	filter     Filter
-	world      *World
-	archetypes archetypes
-	index      int
-	lockBit    uint8
-	count      int
+	filter         Filter
+	world          *World
+	archetypes     archetypes
+	access         *archetypeAccess
+	index          int
+	lockBit        uint8
+	count          int
+	entityIndex    uintptr
+	entityIndexMax uintptr
 }
 
 // newQuery creates a new Filter
@@ -80,16 +82,16 @@ func newQuery(world *World, filter Filter, lockBit uint8, archetypes archetypes)
 // newQuery creates a query on a single archetype
 func newArchQuery(world *World, lockBit uint8, archetype *archetype, start uint32) Query {
 	if start > 0 {
-		iter := newArchetypeIter(archetype)
-		iter.index = uintptr(start - 1)
 		return Query{
-			filter:        dummyFilter{true},
-			world:         world,
-			archetypes:    batchArchetype{archetype, start},
-			index:         0,
-			lockBit:       lockBit,
-			count:         int(archetype.Len() - start),
-			archetypeIter: iter,
+			filter:         dummyFilter{true},
+			world:          world,
+			archetypes:     batchArchetype{archetype, start},
+			access:         &archetype.archetypeAccess,
+			index:          0,
+			lockBit:        lockBit,
+			count:          int(archetype.Len() - start),
+			entityIndex:    uintptr(start - 1),
+			entityIndexMax: uintptr(archetype.Len()) - 1,
 		}
 	}
 	return Query{
@@ -104,11 +106,27 @@ func newArchQuery(world *World, lockBit uint8, archetype *archetype, start uint3
 
 // Next proceeds to the next [Entity] in the Query.
 func (q *Query) Next() bool {
-	if q.archetypeIter.Next() {
+	if q.entityIndex < q.entityIndexMax {
+		q.entityIndex++
 		return true
 	}
 	// outline to allow inlining of the fast path
 	return q.nextArchetype()
+}
+
+// Has returns whether the current entity has the given component.
+func (q *Query) Has(comp ID) bool {
+	return q.access.HasComponent(comp)
+}
+
+// Get returns the pointer to the given component at the iterator's position.
+func (q *Query) Get(comp ID) unsafe.Pointer {
+	return q.access.Get(q.entityIndex, comp)
+}
+
+// Entity returns the entity at the iterator's position.
+func (q *Query) Entity() Entity {
+	return q.access.GetEntity(q.entityIndex)
 }
 
 // Step advances the query iterator by the given number of entities.
@@ -122,7 +140,7 @@ func (q *Query) Step(step int) bool {
 	}
 	var ok bool
 	for {
-		step, ok = q.archetypeIter.Step(uint32(step))
+		step, ok = q.stepArchetype(uint32(step))
 		if ok {
 			return true
 		}
@@ -147,18 +165,6 @@ func (q *Query) Count() int {
 	return q.count
 }
 
-func (q *Query) countEntities() int {
-	len := int(q.archetypes.Len())
-	count := uint32(0)
-	for i := 0; i < len; i++ {
-		a := q.archetypes.Get(i)
-		if q.filter.Matches(a.Mask) {
-			count += a.Len()
-		}
-	}
-	return int(count)
-}
-
 // Mask returns the archetype [BitMask] for the [Entity] at the iterator's current position.
 //
 // Can be used for fast checks of the entity composition, e.g. using a [Filter].
@@ -174,6 +180,26 @@ func (q *Query) Close() {
 	q.world.closeQuery(q)
 }
 
+func (q *Query) stepArchetype(step uint32) (int, bool) {
+	q.entityIndex += uintptr(step)
+	if q.entityIndex <= q.entityIndexMax {
+		return 0, true
+	}
+	return int(q.entityIndex) - int(q.entityIndexMax) - 1, false
+}
+
+func (q *Query) countEntities() int {
+	len := int(q.archetypes.Len())
+	count := uint32(0)
+	for i := 0; i < len; i++ {
+		a := q.archetypes.Get(i)
+		if q.filter.Matches(a.Mask) {
+			count += a.Len()
+		}
+	}
+	return int(count)
+}
+
 // nextArchetype proceeds to the next archetype, and returns whether this was successful/possible.
 func (q *Query) nextArchetype() bool {
 	switch q.filter.(type) {
@@ -186,80 +212,36 @@ func (q *Query) nextArchetype() bool {
 
 // nextArchetypeCached is called if the query is cached.
 func (q *Query) nextArchetypeCached() bool {
-	len := int(q.archetypes.Len())
-	for i := q.index + 1; i < len; i++ {
-		a := q.archetypes.Get(i)
-		if a.Len() > 0 {
-			q.index = i
-			q.archetypeIter = newArchetypeIter(a)
+	len := int(q.archetypes.Len()) - 1
+	for q.index < len {
+		q.index++
+		a := q.archetypes.Get(q.index)
+		aLen := a.Len()
+		if aLen > 0 {
+			q.access = &a.archetypeAccess
+			q.entityIndex = 0
+			q.entityIndexMax = uintptr(aLen) - 1
 			return true
 		}
 	}
-	q.index = len
 	q.world.closeQuery(q)
 	return false
 }
 
 // nextArchetypeFilter is called if the query is not cached.
 func (q *Query) nextArchetypeFilter() bool {
-	len := int(q.archetypes.Len())
-	for i := q.index + 1; i < len; i++ {
-		a := q.archetypes.Get(i)
-		if q.filter.Matches(a.Mask) && a.Len() > 0 {
-			q.index = i
-			q.archetypeIter = newArchetypeIter(a)
+	len := int(q.archetypes.Len()) - 1
+	for q.index < len {
+		q.index++
+		a := q.archetypes.Get(q.index)
+		aLen := a.Len()
+		if q.filter.Matches(a.Mask) && aLen > 0 {
+			q.access = &a.archetypeAccess
+			q.entityIndex = 0
+			q.entityIndexMax = uintptr(aLen) - 1
 			return true
 		}
 	}
-	q.index = len
 	q.world.closeQuery(q)
 	return false
-}
-
-// archetypeIter is an iterator ovr a single archetype.
-type archetypeIter struct {
-	access *archetypeAccess
-	length uintptr
-	index  uintptr
-}
-
-// newArchetypeIter creates a new archetypeIter.
-func newArchetypeIter(arch *archetype) archetypeIter {
-	return archetypeIter{
-		access: &arch.archetypeAccess,
-		length: uintptr(arch.Len()),
-	}
-}
-
-// Next proceeds to the next entity in the archetype, and returns whether this was successful/possible.
-func (it *archetypeIter) Next() bool {
-	it.index++
-	return it.index < it.length
-}
-
-// Step proceeds/steps by the given number of entities.
-func (it *archetypeIter) Step(count uint32) (int, bool) {
-	if it.length == 0 {
-		return int(count - 1), false
-	}
-	it.index += uintptr(count)
-	if it.index < it.length {
-		return 0, true
-	}
-	return int(it.index) - int(it.length), false
-}
-
-// Has returns whether the current entity has the given component.
-func (it *archetypeIter) Has(comp ID) bool {
-	return it.access.HasComponent(comp)
-}
-
-// Get returns the pointer to the given component at the iterator's position.
-func (it *archetypeIter) Get(comp ID) unsafe.Pointer {
-	return it.access.Get(it.index, comp)
-}
-
-// Entity returns the entity at the iterator's position.
-func (it *archetypeIter) Entity() Entity {
-	return it.access.GetEntity(it.index)
 }

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -327,3 +327,17 @@ func TestQueryNextArchetype(t *testing.T) {
 	assert.False(t, query.nextArchetype())
 	assert.Panics(t, func() { query.nextArchetype() })
 }
+
+func TestFilters(t *testing.T) {
+	f1 := dummyFilter{true}
+	f2 := dummyFilter{false}
+
+	assert.True(t, f1.Matches(All(1, 2, 3)))
+	assert.False(t, f2.Matches(All(1, 2, 3)))
+
+	f3 := All(1, 2, 3)
+	f3c := CachedFilter{filter: f3, id: 0}
+
+	assert.Equal(t, f3.Matches(All(1, 2, 3)), f3c.Matches(All(1, 2, 3)))
+	assert.Equal(t, f3.Matches(All(1, 2)), f3c.Matches(All(1, 2)))
+}

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -494,10 +494,10 @@ func (w *World) Query(filter Filter) Query {
 	l := w.lock()
 	if cached, ok := filter.(*CachedFilter); ok {
 		archetypes := &w.filterCache.get(cached).Archetypes
-		return newQuery(w, cached, l, archetypes)
+		return newQuery(w, cached, l, archetypes, true)
 	}
 
-	return newQuery(w, filter, l, &w.archetypes)
+	return newQuery(w, filter, l, &w.archetypes, false)
 }
 
 // Resources of the world.
@@ -809,7 +809,7 @@ func (w *World) resourceID(tp reflect.Type) ResID {
 
 // closeQuery closes a query and unlocks the world.
 func (w *World) closeQuery(query *Query) {
-	query.index = -2
+	query.archIndex = -2
 	w.unlock(query.lockBit)
 
 	if w.listener != nil {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -917,7 +917,6 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSizeName[componentRegistry[ID]]("componentRegistry")
 	printTypeSize[bitPool]()
 	printTypeSize[Query]()
-	printTypeSize[archetypeIter]()
 	printTypeSize[Resources]()
 	printTypeSizeName[reflect.Value]("reflect.Value")
 	printTypeSize[EntityEvent]()


### PR DESCRIPTION
* Avoid type checks in iteration over archetypes
* Merge `archetypeIter` into `Query`