### PR TITLE
Simplify archetype pointer lists in filter cache

### DIFF
--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -75,6 +75,25 @@ func (s batchArchetype) Len() int {
 	return 1
 }
 
+type archetypePointers struct {
+	pointers []*archetype
+}
+
+// Get returns the value at the given index.
+func (a *archetypePointers) Get(index int) *archetype {
+	return a.pointers[index]
+}
+
+// Add adds an element.
+func (a *archetypePointers) Add(arch *archetype) {
+	a.pointers = append(a.pointers, arch)
+}
+
+// Len returns the current number of items in the paged array.
+func (a *archetypePointers) Len() int {
+	return len(a.pointers)
+}
+
 // Helper for accessing data from an archetype
 type archetypeAccess struct {
 	basePointer   unsafe.Pointer // Pointer to the first component column layout.

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -239,6 +240,28 @@ func TestArchetypeZero(t *testing.T) {
 	arch.Alloc(newEntity(1))
 	assert.Equal(t, position{0, 0}, *(*position)(arch.Get(0, 0)))
 	assert.Equal(t, position{0, 0}, *(*position)(arch.Get(1, 0)))
+}
+
+func TestArchetypePointers(t *testing.T) {
+	pt := archetypePointers{}
+
+	a1 := archetype{}
+	a2 := archetype{}
+	a3 := archetype{}
+
+	pt.Add(&a1)
+	pt.Add(&a2)
+	pt.Add(&a3)
+
+	assert.Equal(t, 3, pt.Len())
+
+	for i := 0; i < 45; i++ {
+		pt.Add(&a3)
+	}
+
+	assert.Equal(t, unsafe.Pointer(&a1), unsafe.Pointer(pt.Get(0)))
+	assert.Equal(t, unsafe.Pointer(&a2), unsafe.Pointer(pt.Get(1)))
+	assert.Equal(t, unsafe.Pointer(&a3), unsafe.Pointer(pt.Get(2)))
 }
 
 func BenchmarkIterArchetype_1000(b *testing.B) {

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -2,9 +2,9 @@ package ecs
 
 // Cache entry for a [Filter].
 type cacheEntry struct {
-	ID         ID                           // Filter ID.
-	Filter     Filter                       // The underlying filter.
-	Archetypes pagedPointerArr32[archetype] // Archetypes matching the filter.
+	ID         ID                // Filter ID.
+	Filter     Filter            // The underlying filter.
+	Archetypes archetypePointers // Archetypes matching the filter.
 }
 
 // Cache provides [Filter] caching to speed up queries.
@@ -20,10 +20,10 @@ type cacheEntry struct {
 //
 // The overhead of tracking cached filters is very low, as updates are required only when new archetypes are created.
 type Cache struct {
-	indices       []int                                       // Mapping from filter IDs to indices in filters
-	filters       []cacheEntry                                // The cached filters, indexed by indices
-	getArchetypes func(f Filter) pagedPointerArr32[archetype] // Callback for getting archetypes for a new filter from the world
-	bitPool       bitPool                                     // Pool for filter IDs
+	indices       []int                            // Mapping from filter IDs to indices in filters
+	filters       []cacheEntry                     // The cached filters, indexed by indices
+	getArchetypes func(f Filter) archetypePointers // Callback for getting archetypes for a new filter from the world
+	bitPool       bitPool                          // Pool for filter IDs
 }
 
 // newCache creates a new [Cache].

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -34,8 +34,8 @@ func TestFilterCache(t *testing.T) {
 	assert.Panics(t, func() { cache.get(&f1) })
 }
 
-func getArchetypes(f Filter) pagedPointerArr32[archetype] {
-	return pagedPointerArr32[archetype]{}
+func getArchetypes(f Filter) archetypePointers {
+	return archetypePointers{}
 }
 
 func benchmarkCachedFilters(b *testing.B, arches int, count int, cached bool) {

--- a/ecs/paged.go
+++ b/ecs/paged.go
@@ -13,13 +13,14 @@ type pagedSlice[T any] struct {
 	pageSize int
 }
 
+// newPagedSlice creates a new pagedSlice with the given page size/capacity increment.
 func newPagedSlice[T any](pageSize int) pagedSlice[T] {
 	return pagedSlice[T]{
 		pageSize: pageSize,
 	}
 }
 
-// Add adds a value to the paged array.
+// Add adds a value to the paged slice.
 func (p *pagedSlice[T]) Add(value T) {
 	if p.len == 0 || p.lenLast == fixedPageSize {
 		p.pages = append(p.pages, make([]T, fixedPageSize))
@@ -35,37 +36,7 @@ func (p *pagedSlice[T]) Get(index int) *T {
 	return &p.pages[index/fixedPageSize][index%fixedPageSize]
 }
 
-// Len returns the current number of items in the paged array.
+// Len returns the current number of items in the paged slice.
 func (p *pagedSlice[T]) Len() int {
-	return p.len
-}
-
-// pagedPointerArr32 is a paged collection working with pages of length 32 arrays.
-//
-// Implements [archetypes].
-type pagedPointerArr32[T any] struct {
-	pages   [][]*T
-	len     int
-	lenLast int
-}
-
-// Add adds a value to the paged array.
-func (p *pagedPointerArr32[T]) Add(value *T) {
-	if p.len == 0 || p.lenLast == fixedPageSize {
-		p.pages = append(p.pages, make([]*T, fixedPageSize))
-		p.lenLast = 0
-	}
-	p.pages[len(p.pages)-1][p.lenLast] = value
-	p.len++
-	p.lenLast++
-}
-
-// Get returns the value at the given index.
-func (p *pagedPointerArr32[T]) Get(index int) *T {
-	return p.pages[index/fixedPageSize][index%fixedPageSize]
-}
-
-// Len returns the current number of items in the paged array.
-func (p *pagedPointerArr32[T]) Len() int {
 	return p.len
 }

--- a/ecs/paged_test.go
+++ b/ecs/paged_test.go
@@ -30,9 +30,7 @@ func TestPagedArrPointerPersistence(t *testing.T) {
 	}
 
 	p2 := a.Get(0)
-
 	assert.Equal(t, unsafe.Pointer(p1), unsafe.Pointer(p2))
-
 	*p1 = 100
 	assert.Equal(t, 100, *p2)
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -794,16 +795,17 @@ func (w *World) createArchetype(node *archetypeNode, forStorage bool) *archetype
 }
 
 // Returns all archetypes that match the given filter. Used by [Cache].
-func (w *World) getArchetypes(filter Filter) pagedPointerArr32[archetype] {
-	arches := pagedPointerArr32[archetype]{}
-	len := int(w.archetypes.Len())
-	for i := 0; i < len; i++ {
+func (w *World) getArchetypes(filter Filter) archetypePointers {
+	arches := []*archetype{}
+	ln := int(w.archetypes.Len())
+	for i := 0; i < ln; i++ {
 		a := w.archetypes.Get(i)
 		if filter.Matches(a.Mask) {
-			arches.Add(a)
+			arches = append(arches, a)
 		}
 	}
-	return arches
+	fmt.Println(len(arches))
+	return archetypePointers{arches}
 }
 
 // componentID returns the ID for a component type, and registers it if not already registered.


### PR DESCRIPTION
Use a simple wrapped slice for storing archetype pointers in filter cache.