### PR TITLE
Efficient data structure for mapping from component IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Avoid slice allocations in generic mapper methods (#170)
 * Avoid type checks in query when iterating archetypes (#179)
 * Speed up counting entities in queries with a cached filter (#182)
+* Implements a fast and memory-efficient lookup data structure for components ID keys, to reduce the memory footprint of archetypes and the archetype graph (#192)
 
 ### Bugfixes
 

--- a/benchmark/arche/build/arche_test.go
+++ b/benchmark/arche/build/arche_test.go
@@ -1,0 +1,31 @@
+package iterate
+
+import (
+	"testing"
+
+	c "github.com/mlange-42/arche/benchmark/arche/common"
+	"github.com/mlange-42/arche/ecs"
+)
+
+func BenchmarkBuild1kArch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		world := ecs.NewWorld()
+		c.RegisterAll(&world)
+		b.StartTimer()
+
+		for i := 0; i < 1024; i++ {
+			mask := i
+			add := make([]ecs.ID, 0, 10)
+			for j := 0; j < 10; j++ {
+				id := ecs.ID(j)
+				m := 1 << j
+				if mask&m == m {
+					add = append(add, id)
+				}
+			}
+			entity := world.NewEntity()
+			world.Add(entity, add...)
+		}
+	}
+}

--- a/ecs/id_map.go
+++ b/ecs/id_map.go
@@ -1,0 +1,50 @@
+package ecs
+
+const (
+	numChunks = 8
+	chunkSize = 16
+)
+
+// idMap maps component IDs.
+type idMap[T any] struct {
+	chunks    [][]*T
+	used      Mask
+	chunkUsed []uint8
+}
+
+func newIDMap[T any]() idMap[T] {
+	return idMap[T]{
+		chunks:    make([][]*T, numChunks),
+		used:      Mask{},
+		chunkUsed: make([]uint8, numChunks),
+	}
+}
+
+func (m *idMap[T]) Get(index uint8) (*T, bool) {
+	if !m.used.Get(index) {
+		return nil, false
+	}
+	chunk := index / chunkSize
+	subIndex := index % chunkSize
+	return m.chunks[chunk][subIndex], true
+}
+
+func (m *idMap[T]) Set(index uint8, value *T) {
+	chunk := index / chunkSize
+	subIndex := index % chunkSize
+	if m.chunks[chunk] == nil {
+		m.chunks[chunk] = make([]*T, chunkSize)
+	}
+	m.chunks[chunk][subIndex] = value
+	m.used.Set(index, true)
+	m.chunkUsed[chunk]++
+}
+
+func (m *idMap[T]) Remove(index uint8) {
+	chunk := index / chunkSize
+	m.used.Set(index, false)
+	m.chunkUsed[chunk]--
+	if m.chunkUsed[chunk] == 0 {
+		m.chunks[chunk] = nil
+	}
+}

--- a/ecs/id_map.go
+++ b/ecs/id_map.go
@@ -5,41 +5,64 @@ const (
 	chunkSize = 16
 )
 
-// idMap maps component IDs.
+// idMap maps component IDs to values.
+//
+// Is is a data structure meant for fast lookup while being memory-efficient.
+// Access time is around 2ns, compared to 0.5ns for array access and 20ns for map[int]T.
+//
+// The memory footprint is reduced by using chunks, and only allocating chunks if they contain a key.
+//
+// The range of keys is limited from 0 to [MaskTotalBits]-1.
 type idMap[T any] struct {
-	chunks    [][]*T
+	chunks    [][]T
 	used      Mask
 	chunkUsed []uint8
+	zeroValue T
 }
 
+// newIDMap creates a new idMap
 func newIDMap[T any]() idMap[T] {
 	return idMap[T]{
-		chunks:    make([][]*T, numChunks),
+		chunks:    make([][]T, numChunks),
 		used:      Mask{},
 		chunkUsed: make([]uint8, numChunks),
 	}
 }
 
-func (m *idMap[T]) Get(index uint8) (*T, bool) {
+// Get returns the value at the given key and whether the key is present.
+func (m *idMap[T]) Get(index uint8) (T, bool) {
 	if !m.used.Get(index) {
-		return nil, false
+		return m.zeroValue, false
 	}
 	chunk := index / chunkSize
 	subIndex := index % chunkSize
 	return m.chunks[chunk][subIndex], true
 }
 
-func (m *idMap[T]) Set(index uint8, value *T) {
+// Get returns a pointer to the value at the given key and whether the key is present.
+func (m *idMap[T]) GetPointer(index uint8) (*T, bool) {
+	if !m.used.Get(index) {
+		return nil, false
+	}
+	chunk := index / chunkSize
+	subIndex := index % chunkSize
+	return &m.chunks[chunk][subIndex], true
+}
+
+// Set sets the value at the given key.
+func (m *idMap[T]) Set(index uint8, value T) {
 	chunk := index / chunkSize
 	subIndex := index % chunkSize
 	if m.chunks[chunk] == nil {
-		m.chunks[chunk] = make([]*T, chunkSize)
+		m.chunks[chunk] = make([]T, chunkSize)
 	}
 	m.chunks[chunk][subIndex] = value
 	m.used.Set(index, true)
 	m.chunkUsed[chunk]++
 }
 
+// Remove removes the value at the given key.
+// It de-allocates empty chunks.
 func (m *idMap[T]) Remove(index uint8) {
 	chunk := index / chunkSize
 	m.used.Set(index, false)

--- a/ecs/id_map_test.go
+++ b/ecs/id_map_test.go
@@ -1,0 +1,104 @@
+package ecs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIDMap(t *testing.T) {
+	m := newIDMap[Entity]()
+
+	e0 := Entity{0, 0}
+	e1 := Entity{1, 0}
+	e121 := Entity{121, 0}
+
+	m.Set(0, &e0)
+	m.Set(1, &e1)
+	m.Set(121, &e121)
+
+	e, ok := m.Get(0)
+	assert.True(t, ok)
+	assert.Equal(t, e0, *e)
+
+	e, ok = m.Get(1)
+	assert.True(t, ok)
+	assert.Equal(t, e1, *e)
+
+	e, ok = m.Get(121)
+	assert.True(t, ok)
+	assert.Equal(t, e121, *e)
+
+	e, ok = m.Get(15)
+	assert.False(t, ok)
+	assert.Nil(t, e)
+
+	m.Remove(0)
+	m.Remove(1)
+
+	e, ok = m.Get(0)
+	assert.False(t, ok)
+	assert.Nil(t, e)
+
+	assert.Nil(t, m.chunks[0])
+}
+
+func BenchmarkIdMapping_IDMap(b *testing.B) {
+	b.StopTimer()
+
+	entities := [MaskTotalBits]Entity{}
+	m := newIDMap[Entity]()
+
+	for i := 0; i < MaskTotalBits; i++ {
+		entities[i] = Entity{eid(i), 0}
+		m.Set(ID(i), &entities[i])
+	}
+
+	b.StartTimer()
+
+	var ptr *Entity = nil
+	for i := 0; i < b.N; i++ {
+		ptr, _ = m.Get(ID(i % MaskTotalBits))
+	}
+	_ = ptr
+}
+
+func BenchmarkIdMapping_Array(b *testing.B) {
+	b.StopTimer()
+
+	entities := [MaskTotalBits]Entity{}
+	m := [MaskTotalBits]*Entity{}
+
+	for i := 0; i < MaskTotalBits; i++ {
+		entities[i] = Entity{eid(i), 0}
+		m[i] = &entities[i]
+	}
+
+	b.StartTimer()
+
+	var ptr *Entity = nil
+	for i := 0; i < b.N; i++ {
+		ptr = m[i%MaskTotalBits]
+	}
+	_ = ptr
+}
+
+func BenchmarkIdMapping_HashMap(b *testing.B) {
+	b.StopTimer()
+
+	entities := [MaskTotalBits]Entity{}
+	m := make(map[uint8]*Entity, MaskTotalBits)
+
+	for i := 0; i < MaskTotalBits; i++ {
+		entities[i] = Entity{eid(i), 0}
+		m[ID(i)] = &entities[i]
+	}
+
+	b.StartTimer()
+
+	var ptr *Entity = nil
+	for i := 0; i < b.N; i++ {
+		ptr, _ = m[ID(i%MaskTotalBits)]
+	}
+	_ = ptr
+}

--- a/ecs/id_map_test.go
+++ b/ecs/id_map_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestIDMap(t *testing.T) {
-	m := newIDMap[Entity]()
+	m := newIDMap[*Entity]()
 
 	e0 := Entity{0, 0}
 	e1 := Entity{1, 0}
@@ -43,11 +43,48 @@ func TestIDMap(t *testing.T) {
 	assert.Nil(t, m.chunks[0])
 }
 
+func TestIDMapPointers(t *testing.T) {
+	m := newIDMap[Entity]()
+
+	e0 := Entity{0, 0}
+	e1 := Entity{1, 0}
+	e121 := Entity{121, 0}
+
+	m.Set(0, e0)
+	m.Set(1, e1)
+	m.Set(121, e121)
+
+	e, ok := m.GetPointer(0)
+	assert.True(t, ok)
+	assert.Equal(t, e0, *e)
+
+	e, ok = m.GetPointer(1)
+	assert.True(t, ok)
+	assert.Equal(t, e1, *e)
+
+	e, ok = m.GetPointer(121)
+	assert.True(t, ok)
+	assert.Equal(t, e121, *e)
+
+	e, ok = m.GetPointer(15)
+	assert.False(t, ok)
+	assert.Nil(t, e)
+
+	m.Remove(0)
+	m.Remove(1)
+
+	e, ok = m.GetPointer(0)
+	assert.False(t, ok)
+	assert.Nil(t, e)
+
+	assert.Nil(t, m.chunks[0])
+}
+
 func BenchmarkIdMapping_IDMap(b *testing.B) {
 	b.StopTimer()
 
 	entities := [MaskTotalBits]Entity{}
-	m := newIDMap[Entity]()
+	m := newIDMap[*Entity]()
 
 	for i := 0; i < MaskTotalBits; i++ {
 		entities[i] = Entity{eid(i), 0}
@@ -98,7 +135,7 @@ func BenchmarkIdMapping_HashMap(b *testing.B) {
 
 	var ptr *Entity = nil
 	for i := 0; i < b.N; i++ {
-		ptr, _ = m[ID(i%MaskTotalBits)]
+		ptr = m[ID(i%MaskTotalBits)]
 	}
 	_ = ptr
 }

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -921,6 +921,7 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSizeName[reflect.Value]("reflect.Value")
 	printTypeSize[EntityEvent]()
 	printTypeSize[Cache]()
+	printTypeSizeName[idMap[archetype]]("idMap")
 }
 
 func printTypeSize[T any]() {


### PR DESCRIPTION
`idMap ` is a data structure meant for fast lookup by component ID keys, while being memory-efficient.
Access time is around 2ns, compared to 0.5ns for array access and 20ns for `map[int]T`.

The memory footprint is reduced by using chunks, and only allocating chunks if they contain a key.