### PR TITLE
Benchmark entity relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 * Restructure and extend benchmarks (#146, #153, #155, #156)
 * Add an ECS competition benchmark for adding and removing components (#170)
+* Add benchmarks for different ways to implement parent-child relations between entities (#194)
 
 ## [[v0.5.1]](https://github.com/mlange-42/arche/compare/v0.5.0...v0.5.1)
 

--- a/benchmark/arche/relations/child_test.go
+++ b/benchmark/arche/relations/child_test.go
@@ -1,0 +1,73 @@
+package relations
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
+)
+
+func benchmarkChild(b *testing.B, numParents int) {
+	b.StopTimer()
+
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	parentMapper := generic.NewMap1[ParentData](&world)
+	childMapper := generic.NewMap2[ChildData, Child](&world)
+
+	spawnedPar := parentMapper.NewEntitiesQuery(numParents)
+	parents := make([]ecs.Entity, 0, numParents)
+	for spawnedPar.Next() {
+		parents = append(parents, spawnedPar.Entity())
+	}
+
+	spawnedChild := childMapper.NewEntitiesQuery(numParents * numChildren)
+	cnt := 0
+	for spawnedChild.Next() {
+		data, child := spawnedChild.Get()
+		data.Value = 1
+		child.Parent = parents[cnt/numChildren]
+		cnt++
+	}
+
+	parentFilter := generic.NewFilter1[ParentData]()
+	parentFilter.Register(&world)
+	childFilter := generic.NewFilter2[ChildData, Child]()
+	childFilter.Register(&world)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := childFilter.Query(&world)
+		for query.Next() {
+			data, child := query.Get()
+			parData := parentMapper.Get(child.Parent)
+
+			parData.Value += data.Value
+		}
+	}
+
+	b.StopTimer()
+
+	parQuery := parentFilter.Query(&world)
+
+	expected := numChildren * b.N
+	for parQuery.Next() {
+		par := parQuery.Get()
+		if par.Value != expected {
+			panic("wrong number of children")
+		}
+	}
+}
+
+func BenchmarkRelationChild_100_x_10(b *testing.B) {
+	benchmarkChild(b, 100)
+}
+
+func BenchmarkRelationChild_1000_x_10(b *testing.B) {
+	benchmarkChild(b, 1000)
+}
+
+func BenchmarkRelationChild_10000_x_10(b *testing.B) {
+	benchmarkChild(b, 10000)
+}

--- a/benchmark/arche/relations/doc.go
+++ b/benchmark/arche/relations/doc.go
@@ -6,45 +6,41 @@
 //
 // The task is to sum up a value over all children of each parent.
 //
-// Each parent has 10 children. Benchmarks are run for 100, 1000 and 10000 parent entities.
+// The benchmarks are implemented in a way that only one components needs to be fetched for each parent and each child.
+//
+// Each parent has 10 children. Benchmarks are run for 100, 1000 and 10k and 100k parent entities.
 package relations
 
 import "github.com/mlange-42/arche/ecs"
 
 const numChildren = 10
 
-// ParentData component
-type ParentData struct {
-	Value int
-}
-
-// ChildData component
-type ChildData struct {
-	Value int
-}
-
 // Child component
 type Child struct {
 	Parent ecs.Entity
+	Value  int
 }
 
 // ChildList component
 type ChildList struct {
-	Next ecs.Entity
+	Next  ecs.Entity
+	Value int
 }
 
 // ParentArr component
 type ParentArr struct {
 	Children [numChildren]ecs.Entity
+	Value    int
 }
 
 // ParentSlice component
 type ParentSlice struct {
 	Children []ecs.Entity
+	Value    int
 }
 
 // ParentList component
 type ParentList struct {
-	FirstChild  ecs.Entity
-	NumChildren int
+	FirstChild ecs.Entity
+	Value      int
 }

--- a/benchmark/arche/relations/doc.go
+++ b/benchmark/arche/relations/doc.go
@@ -1,0 +1,50 @@
+// Package relations benchmarks different ways to create entity relations:
+//   - Children know their parent entity
+//   - Parents have an array of child entities
+//   - Parents have a slice of child entities
+//   - Children form an implicit linked lists, parents know the first child
+//
+// The task is to sum up a value over all children of each parent.
+//
+// Each parent has 10 children. Benchmarks are run for 100, 1000 and 10000 parent entities.
+package relations
+
+import "github.com/mlange-42/arche/ecs"
+
+const numChildren = 10
+
+// ParentData component
+type ParentData struct {
+	Value int
+}
+
+// ChildData component
+type ChildData struct {
+	Value int
+}
+
+// Child component
+type Child struct {
+	Parent ecs.Entity
+}
+
+// ChildList component
+type ChildList struct {
+	Next ecs.Entity
+}
+
+// ParentArr component
+type ParentArr struct {
+	Children [numChildren]ecs.Entity
+}
+
+// ParentSlice component
+type ParentSlice struct {
+	Children []ecs.Entity
+}
+
+// ParentList component
+type ParentList struct {
+	FirstChild  ecs.Entity
+	NumChildren int
+}

--- a/benchmark/arche/relations/parent_array_test.go
+++ b/benchmark/arche/relations/parent_array_test.go
@@ -1,0 +1,75 @@
+package relations
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
+)
+
+func benchmarkParentArray(b *testing.B, numParents int) {
+	b.StopTimer()
+
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	parentMapper := generic.NewMap1[ParentArr](&world)
+	parentMapperFull := generic.NewMap2[ParentData, ParentArr](&world)
+	childMapper := generic.NewMap1[ChildData](&world)
+
+	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	parents := make([]ecs.Entity, 0, numParents)
+	for spawnedPar.Next() {
+		parents = append(parents, spawnedPar.Entity())
+	}
+
+	spawnedChild := childMapper.NewEntitiesQuery(numParents * numChildren)
+	cnt := 0
+	for spawnedChild.Next() {
+		data := spawnedChild.Get()
+		data.Value = 1
+		par := parentMapper.Get(parents[cnt/numChildren])
+		par.Children[cnt%numChildren] = spawnedChild.Entity()
+		cnt++
+	}
+
+	parentFilter := generic.NewFilter2[ParentData, ParentArr]()
+	parentFilter.Register(&world)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := parentFilter.Query(&world)
+		for query.Next() {
+			data, par := query.Get()
+			for i := 0; i < len(par.Children); i++ {
+				childData := childMapper.Get(par.Children[i])
+				data.Value += childData.Value
+			}
+		}
+	}
+
+	b.StopTimer()
+	parentFilterSimple := generic.NewFilter1[ParentData]()
+	parentFilterSimple.Register(&world)
+	querySimple := parentFilterSimple.Query(&world)
+
+	expected := numChildren * b.N
+	for querySimple.Next() {
+		par := querySimple.Get()
+		if par.Value != expected {
+			panic("wrong number of children")
+		}
+	}
+}
+
+func BenchmarkRelationParentArray_100_x_10(b *testing.B) {
+	benchmarkParentArray(b, 100)
+}
+
+func BenchmarkRelationParentArray_1000_x_10(b *testing.B) {
+	benchmarkParentArray(b, 1000)
+}
+
+func BenchmarkRelationParentArray_10000_x_10(b *testing.B) {
+	benchmarkParentArray(b, 10000)
+}

--- a/benchmark/arche/relations/parent_list_test.go
+++ b/benchmark/arche/relations/parent_list_test.go
@@ -1,0 +1,84 @@
+package relations
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
+)
+
+func benchmarkParentList(b *testing.B, numParents int) {
+	b.StopTimer()
+
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	parentMapper := generic.NewMap1[ParentList](&world)
+	parentMapperFull := generic.NewMap2[ParentData, ParentList](&world)
+	childMapper := generic.NewMap2[ChildData, ChildList](&world)
+
+	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	parents := make([]ecs.Entity, 0, numParents)
+	for spawnedPar.Next() {
+		parents = append(parents, spawnedPar.Entity())
+	}
+
+	spawnedChild := childMapper.NewEntitiesQuery(numParents * numChildren)
+	cnt := 0
+	for spawnedChild.Next() {
+		childEntity := spawnedChild.Entity()
+		data, child := spawnedChild.Get()
+		data.Value = 1
+		par := parentMapper.Get(parents[cnt/numChildren])
+
+		if !par.FirstChild.IsZero() {
+			child.Next = par.FirstChild
+		}
+		par.FirstChild = childEntity
+		par.NumChildren++
+
+		cnt++
+	}
+
+	parentFilter := generic.NewFilter2[ParentData, ParentList]()
+	parentFilter.Register(&world)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := parentFilter.Query(&world)
+		for query.Next() {
+			data, par := query.Get()
+			child := par.FirstChild
+			for !child.IsZero() {
+				childData, childList := childMapper.Get(child)
+				data.Value += childData.Value
+				child = childList.Next
+			}
+		}
+	}
+
+	b.StopTimer()
+	parentFilterSimple := generic.NewFilter1[ParentData]()
+	parentFilterSimple.Register(&world)
+	querySimple := parentFilterSimple.Query(&world)
+
+	expected := numChildren * b.N
+	for querySimple.Next() {
+		par := querySimple.Get()
+		if par.Value != expected {
+			panic("wrong number of children")
+		}
+	}
+}
+
+func BenchmarkRelationParentList_100_x_10(b *testing.B) {
+	benchmarkParentList(b, 100)
+}
+
+func BenchmarkRelationParentList_1000_x_10(b *testing.B) {
+	benchmarkParentList(b, 1000)
+}
+
+func BenchmarkRelationParentList_10000_x_10(b *testing.B) {
+	benchmarkParentList(b, 10000)
+}

--- a/benchmark/arche/relations/parent_slice_test.go
+++ b/benchmark/arche/relations/parent_slice_test.go
@@ -1,0 +1,75 @@
+package relations
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
+)
+
+func benchmarkParentSlice(b *testing.B, numParents int) {
+	b.StopTimer()
+
+	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	parentMapper := generic.NewMap1[ParentSlice](&world)
+	parentMapperFull := generic.NewMap2[ParentData, ParentSlice](&world)
+	childMapper := generic.NewMap1[ChildData](&world)
+
+	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	parents := make([]ecs.Entity, 0, numParents)
+	for spawnedPar.Next() {
+		parents = append(parents, spawnedPar.Entity())
+	}
+
+	spawnedChild := childMapper.NewEntitiesQuery(numParents * numChildren)
+	cnt := 0
+	for spawnedChild.Next() {
+		data := spawnedChild.Get()
+		data.Value = 1
+		par := parentMapper.Get(parents[cnt/numChildren])
+		par.Children = append(par.Children, spawnedChild.Entity())
+		cnt++
+	}
+
+	parentFilter := generic.NewFilter2[ParentData, ParentSlice]()
+	parentFilter.Register(&world)
+
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := parentFilter.Query(&world)
+		for query.Next() {
+			data, par := query.Get()
+			for i := 0; i < len(par.Children); i++ {
+				childData := childMapper.Get(par.Children[i])
+				data.Value += childData.Value
+			}
+		}
+	}
+
+	b.StopTimer()
+	parentFilterSimple := generic.NewFilter1[ParentData]()
+	parentFilterSimple.Register(&world)
+	querySimple := parentFilterSimple.Query(&world)
+
+	expected := numChildren * b.N
+	for querySimple.Next() {
+		par := querySimple.Get()
+		if par.Value != expected {
+			panic("wrong number of children")
+		}
+	}
+}
+
+func BenchmarkRelationParentSlice_100_x_10(b *testing.B) {
+	benchmarkParentSlice(b, 100)
+}
+
+func BenchmarkRelationParentSlice_1000_x_10(b *testing.B) {
+	benchmarkParentSlice(b, 1000)
+}
+
+func BenchmarkRelationParentSlice_10000_x_10(b *testing.B) {
+	benchmarkParentSlice(b, 10000)
+}

--- a/benchmark/arche/relations/parent_slice_test.go
+++ b/benchmark/arche/relations/parent_slice_test.go
@@ -13,8 +13,8 @@ func benchmarkParentSlice(b *testing.B, numParents int) {
 	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
 
 	parentMapper := generic.NewMap1[ParentSlice](&world)
-	parentMapperFull := generic.NewMap2[ParentData, ParentSlice](&world)
-	childMapper := generic.NewMap1[ChildData](&world)
+	parentMapperFull := generic.NewMap1[ParentSlice](&world)
+	childMapper := generic.NewMap1[Child](&world)
 
 	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
 	parents := make([]ecs.Entity, 0, numParents)
@@ -32,7 +32,7 @@ func benchmarkParentSlice(b *testing.B, numParents int) {
 		cnt++
 	}
 
-	parentFilter := generic.NewFilter2[ParentData, ParentSlice]()
+	parentFilter := generic.NewFilter1[ParentSlice]()
 	parentFilter.Register(&world)
 
 	b.StartTimer()
@@ -40,22 +40,20 @@ func benchmarkParentSlice(b *testing.B, numParents int) {
 	for i := 0; i < b.N; i++ {
 		query := parentFilter.Query(&world)
 		for query.Next() {
-			data, par := query.Get()
+			par := query.Get()
 			for i := 0; i < len(par.Children); i++ {
 				childData := childMapper.Get(par.Children[i])
-				data.Value += childData.Value
+				par.Value += childData.Value
 			}
 		}
 	}
 
 	b.StopTimer()
-	parentFilterSimple := generic.NewFilter1[ParentData]()
-	parentFilterSimple.Register(&world)
-	querySimple := parentFilterSimple.Query(&world)
+	query := parentFilter.Query(&world)
 
 	expected := numChildren * b.N
-	for querySimple.Next() {
-		par := querySimple.Get()
+	for query.Next() {
+		par := query.Get()
 		if par.Value != expected {
 			panic("wrong number of children")
 		}
@@ -72,4 +70,8 @@ func BenchmarkRelationParentSlice_1000_x_10(b *testing.B) {
 
 func BenchmarkRelationParentSlice_10000_x_10(b *testing.B) {
 	benchmarkParentSlice(b, 10000)
+}
+
+func BenchmarkRelationParentSlice_100000_x_10(b *testing.B) {
+	benchmarkParentSlice(b, 100000)
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -492,6 +492,7 @@ func (w *World) Reset() {
 // Further, it can be chained with [Mask.Without] (see the examples) to exclude components.
 //
 // Locks the world to prevent changes to component compositions.
+// The lock is released automatically when the query finishes iteration, or when [Query.Close] is called.
 // The number of simultaneous locks (and thus open queries) at a given time is limited to [MaskTotalBits].
 //
 // For type-safe generics queries, see package [github.com/mlange-42/arche/generic].


### PR DESCRIPTION
Add benchmarks for different ways to implement entity relationships:

- Children know their parent entity
- Parents have an array of child entities
- Parents have a slice of child entities
- Children form an implicit linked lists, parents know the first child
