### PR TITLE
Simplify/fix relations benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 * Restructure and extend benchmarks (#146, #153, #155, #156)
 * Add an ECS competition benchmark for adding and removing components (#170)
-* Add benchmarks for different ways to implement parent-child relations between entities (#194)
+* Add benchmarks for different ways to implement parent-child relations between entities (#194, #195)
 
 ## [[v0.5.1]](https://github.com/mlange-42/arche/compare/v0.5.0...v0.5.1)
 

--- a/benchmark/arche/relations/parent_array_test.go
+++ b/benchmark/arche/relations/parent_array_test.go
@@ -13,10 +13,9 @@ func benchmarkParentArray(b *testing.B, numParents int) {
 	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
 
 	parentMapper := generic.NewMap1[ParentArr](&world)
-	parentMapperFull := generic.NewMap1[ParentArr](&world)
 	childMapper := generic.NewMap1[Child](&world)
 
-	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	spawnedPar := parentMapper.NewEntitiesQuery(numParents)
 	parents := make([]ecs.Entity, 0, numParents)
 	for spawnedPar.Next() {
 		parents = append(parents, spawnedPar.Entity())

--- a/benchmark/arche/relations/parent_list_test.go
+++ b/benchmark/arche/relations/parent_list_test.go
@@ -13,10 +13,9 @@ func benchmarkParentList(b *testing.B, numParents int) {
 	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
 
 	parentMapper := generic.NewMap1[ParentList](&world)
-	parentMapperFull := generic.NewMap1[ParentList](&world)
 	childMapper := generic.NewMap1[ChildList](&world)
 
-	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	spawnedPar := parentMapper.NewEntitiesQuery(numParents)
 	parents := make([]ecs.Entity, 0, numParents)
 	for spawnedPar.Next() {
 		parents = append(parents, spawnedPar.Entity())

--- a/benchmark/arche/relations/parent_slice_test.go
+++ b/benchmark/arche/relations/parent_slice_test.go
@@ -13,10 +13,9 @@ func benchmarkParentSlice(b *testing.B, numParents int) {
 	world := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
 
 	parentMapper := generic.NewMap1[ParentSlice](&world)
-	parentMapperFull := generic.NewMap1[ParentSlice](&world)
 	childMapper := generic.NewMap1[Child](&world)
 
-	spawnedPar := parentMapperFull.NewEntitiesQuery(numParents)
+	spawnedPar := parentMapper.NewEntitiesQuery(numParents)
 	parents := make([]ecs.Entity, 0, numParents)
 	for spawnedPar.Next() {
 		parents = append(parents, spawnedPar.Entity())


### PR DESCRIPTION
removes additional parent mapper