### PR TITLE
Extend entity docs - copy hint, examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [[v0.6.1] (unpublished)](https://github.com/mlange-42/arche/compare/v0.6.0...main)
+
+### Documentation
+
+* Extend documentation and benchmarks for `Entity` (#201)
+
 ## [[v0.6.0]](https://github.com/mlange-42/arche/compare/v0.5.1...v0.6.0)
 
 Arche v0.6.0 features fast batch entity creation and deletion, cached filters, and many internal optimizations.

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -16,6 +16,8 @@ var entityIndexSize = reflect.TypeOf(entityIndex{}).Size()
 //
 // Entities are only created via the [World], using [World.NewEntity] or [World.NewEntityWith].
 // Batch creation of entities is possible via [World.Batch].
+//
+// Entities are intended to be stored and passed around via copy, not via pointers.
 type Entity struct {
 	id  eid    // Entity ID
 	gen uint16 // Entity generation

--- a/ecs/entity_test.go
+++ b/ecs/entity_test.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,4 +18,37 @@ func TestEntityAsIndex(t *testing.T) {
 func TestZeroEntity(t *testing.T) {
 	assert.True(t, Entity{}.IsZero())
 	assert.False(t, Entity{1, 0}.IsZero())
+}
+
+func BenchmarkEntityIsZero(b *testing.B) {
+	e := Entity{}
+
+	isZero := false
+	for i := 0; i < b.N; i++ {
+		isZero = e.IsZero()
+	}
+	_ = isZero
+}
+
+func ExampleEntity() {
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	e1 := world.NewEntity()
+	e2 := world.NewEntity(posID, velID)
+
+	fmt.Println(e1.IsZero(), e2.IsZero())
+	// Output: false false
+}
+
+func ExampleEntity_IsZero() {
+	world := NewWorld()
+
+	var e1 Entity
+	var e2 Entity = world.NewEntity()
+
+	fmt.Println(e1.IsZero(), e2.IsZero())
+	// Output: true false
 }


### PR DESCRIPTION
- add hint on copy to entity docs
- add doc examples
- benchmark for IsZero
