### PR TITLE
Fix: Always panic on dead entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Adds method `World.ComponentType(ID)` to get the `reflect.Type` for component IDs (#215)
 
+### Bugfixes
+
+* All world methods with an entity as argument panic on a dead/recycled entity; causes 0.5ns slower `World.Get(Entity)` (#216)
+
 ## [[v0.6.3]](https://github.com/mlange-42/arche/compare/v0.6.2...v0.6.3)
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ In the illustration, the first archetype holds all components for all entities w
 The exact composition of each archetype is encoded in a bitmask for fast comparison.
 Thus, queries can easily identify their relevant archetypes, and then simply iterate entities linearly, which is very fast. Components can be accessed through the query in a very efficient way (&approx;1ns).
 
-For getting components by entity ID, e.g. for hierarchies, the world contains a list that is indexed by the entity ID. For each entity, it references it's current archetype and the index in the archetype. This way, getting components for entity IDs (i.e. random access) is fast, although not as fast as in queries (≈1.5ns vs. 1ns).
+For getting components by entity ID, e.g. for hierarchies, the world contains a list that is indexed by the entity ID. For each entity, it references it's current archetype and the index in the archetype. This way, getting components for entity IDs (i.e. random access) is fast, although not as fast as in queries (≈1.8ns vs. 1ns).
 
 Obviously, archetypes are an optimization for iteration speed.
 But they also come with a downside. Adding or removing components to/from an entity requires moving all the components of the entity to another archetype.

--- a/benchmark/profile/world/main.go
+++ b/benchmark/profile/world/main.go
@@ -44,9 +44,10 @@ func run(rounds, iters, entityCount int) {
 		posID := ecs.ComponentID[position](&world)
 		rotID := ecs.ComponentID[rotation](&world)
 
-		entities := make([]ecs.Entity, entityCount)
-		for i := 0; i < entityCount; i++ {
-			entities[i] = world.NewEntity(posID, rotID)
+		entities := make([]ecs.Entity, 0, entityCount)
+		query := world.Batch().NewEntitiesQuery(entityCount, posID, rotID)
+		for query.Next() {
+			entities = append(entities, query.Entity())
 		}
 
 		for j := 0; j < iters; j++ {

--- a/ecs/pool.go
+++ b/ecs/pool.go
@@ -65,7 +65,7 @@ func (p *entityPool) Reset() {
 	p.available = 0
 }
 
-// Alive return whether an entity is still alive, based on the entity's generations.
+// Alive returns whether an entity is still alive, based on the entity's generations.
 func (p *entityPool) Alive(e Entity) bool {
 	return e.id != 0 && e.gen == p.entities[e.id].gen
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -321,7 +321,7 @@ func (w *World) Alive(entity Entity) bool {
 //
 // See also [github.com/mlange-42/arche/generic.Map.Get] for a generic variant.
 func (w *World) Get(entity Entity, comp ID) unsafe.Pointer {
-	if !w.Alive(entity) {
+	if !w.entityPool.Alive(entity) {
 		panic("can't get component of a dead entity")
 	}
 	index := &w.entities[entity.id]
@@ -334,7 +334,7 @@ func (w *World) Get(entity Entity, comp ID) unsafe.Pointer {
 //
 // See also [github.com/mlange-42/arche/generic.Map.Has] for a generic variant.
 func (w *World) Has(entity Entity, comp ID) bool {
-	if !w.Alive(entity) {
+	if !w.entityPool.Alive(entity) {
 		panic("can't check for component of a dead entity")
 	}
 	return w.entities[entity.id].arch.HasComponent(comp)
@@ -370,7 +370,7 @@ func (w *World) Add(entity Entity, comps ...ID) {
 //
 // See also the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
 func (w *World) Assign(entity Entity, comps ...Component) {
-	if !w.Alive(entity) {
+	if !w.entityPool.Alive(entity) {
 		panic("can't assign to a dead entity")
 	}
 	len := len(comps)
@@ -431,7 +431,7 @@ func (w *World) Remove(entity Entity, comps ...ID) {
 func (w *World) Exchange(entity Entity, add []ID, rem []ID) {
 	w.checkLocked()
 
-	if !w.Alive(entity) {
+	if !w.entityPool.Alive(entity) {
 		panic("can't exchange components on a dead entity")
 	}
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -314,13 +314,16 @@ func (w *World) Alive(entity Entity) bool {
 	return w.entityPool.Alive(entity)
 }
 
-// Get returns a pointer th the given component of an [Entity].
+// Get returns a pointer to the given component of an [Entity].
 //
 // Returns nil if the entity has no such component.
 // Panics when called for an already removed entity.
 //
 // See also [github.com/mlange-42/arche/generic.Map.Get] for a generic variant.
 func (w *World) Get(entity Entity, comp ID) unsafe.Pointer {
+	if !w.Alive(entity) {
+		panic("can't get component of a dead entity")
+	}
 	index := &w.entities[entity.id]
 	return index.arch.Get(index.index, comp)
 }
@@ -331,6 +334,9 @@ func (w *World) Get(entity Entity, comp ID) unsafe.Pointer {
 //
 // See also [github.com/mlange-42/arche/generic.Map.Has] for a generic variant.
 func (w *World) Has(entity Entity, comp ID) bool {
+	if !w.Alive(entity) {
+		panic("can't check for component of a dead entity")
+	}
 	return w.entities[entity.id].arch.HasComponent(comp)
 }
 
@@ -364,6 +370,9 @@ func (w *World) Add(entity Entity, comps ...ID) {
 //
 // See also the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
 func (w *World) Assign(entity Entity, comps ...Component) {
+	if !w.Alive(entity) {
+		panic("can't assign to a dead entity")
+	}
 	len := len(comps)
 	if len == 0 {
 		panic("no components given to assign")
@@ -421,6 +430,10 @@ func (w *World) Remove(entity Entity, comps ...ID) {
 // See also the generic variants under [github.com/mlange-42/arche/generic.Exchange].
 func (w *World) Exchange(entity Entity, add []ID, rem []ID) {
 	w.checkLocked()
+
+	if !w.Alive(entity) {
+		panic("can't exchange components on a dead entity")
+	}
 
 	if len(add) == 0 && len(rem) == 0 {
 		return

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -237,6 +237,10 @@ func TestWorldExchange(t *testing.T) {
 
 	assert.Panics(t, func() { w.Exchange(e1, []ID{velID}, []ID{}) })
 	assert.Panics(t, func() { w.Exchange(e1, []ID{}, []ID{posID}) })
+
+	w.RemoveEntity(e0)
+	_ = w.NewEntity()
+	assert.Panics(t, func() { w.Exchange(e0, []ID{posID}, []ID{}) })
 }
 
 func TestWorldAssignSet(t *testing.T) {
@@ -286,6 +290,10 @@ func TestWorldAssignSet(t *testing.T) {
 	*pos = Position{8, 9}
 	pos = (*Position)(w.Get(e2, posID))
 	assert.Equal(t, 8, pos.X)
+
+	w.RemoveEntity(e0)
+	_ = w.NewEntity()
+	assert.Panics(t, func() { w.Assign(e0, Component{posID, &Position{2, 3}}) })
 }
 
 func TestWorldGetComponents(t *testing.T) {
@@ -317,7 +325,8 @@ func TestWorldGetComponents(t *testing.T) {
 	assert.Equal(t, &Position{100, 101}, pos1)
 
 	w.RemoveEntity(e0)
-
+	assert.Panics(t, func() { w.Get(e0, posID) })
+	_ = w.NewEntity(posID)
 	assert.Panics(t, func() { w.Get(e0, posID) })
 
 	pos1 = (*Position)(w.Get(e1, posID))

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -326,8 +326,11 @@ func TestWorldGetComponents(t *testing.T) {
 
 	w.RemoveEntity(e0)
 	assert.Panics(t, func() { w.Get(e0, posID) })
+	assert.Panics(t, func() { w.Mask(e0) })
+
 	_ = w.NewEntity(posID)
 	assert.Panics(t, func() { w.Get(e0, posID) })
+	assert.Panics(t, func() { w.Mask(e0) })
 
 	pos1 = (*Position)(w.Get(e1, posID))
 	assert.Equal(t, &Position{100, 101}, pos1)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -979,7 +979,7 @@ func printTypeSizeName[T any](name string) {
 	fmt.Printf("%18s: %5d B\n", name, tp.Size())
 }
 
-func BenchmarkEntityAlive(b *testing.B) {
+func BenchmarkEntityAlive_1000(b *testing.B) {
 	b.StopTimer()
 
 	world := NewWorld(NewConfig().WithCapacityIncrement(1024))

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -287,6 +287,7 @@ func TestWorldAssignSet(t *testing.T) {
 	pos = (*Position)(w.Get(e2, posID))
 	assert.Equal(t, 8, pos.X)
 }
+
 func TestWorldGetComponents(t *testing.T) {
 	w := NewWorld()
 
@@ -316,6 +317,8 @@ func TestWorldGetComponents(t *testing.T) {
 	assert.Equal(t, &Position{100, 101}, pos1)
 
 	w.RemoveEntity(e0)
+
+	assert.Panics(t, func() { w.Get(e0, posID) })
 
 	pos1 = (*Position)(w.Get(e1, posID))
 	assert.Equal(t, &Position{100, 101}, pos1)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -967,6 +967,30 @@ func printTypeSizeName[T any](name string) {
 	fmt.Printf("%18s: %5d B\n", name, tp.Size())
 }
 
+func BenchmarkEntityAlive(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld(NewConfig().WithCapacityIncrement(1024))
+	posID := ComponentID[Position](&world)
+
+	entities := make([]Entity, 0, 1000)
+	q := world.newEntitiesQuery(1000, posID)
+	for q.Next() {
+		entities = append(entities, q.Entity())
+	}
+
+	b.StartTimer()
+
+	var alive bool
+	for i := 0; i < b.N; i++ {
+		for _, e := range entities {
+			alive = world.Alive(e)
+		}
+	}
+
+	_ = alive
+}
+
 func BenchmarkGetResource(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
All world methods with an entity as argument panic on a dead/recycled entity; causes 0.5ns slower `World.Get(Entity)`