### PR TITLE
Optimize entity alive check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [[v0.6.4]](https://github.com/mlange-42/arche/compare/v0.6.3...v0.6.4)
+## [[v0.7.0]](https://github.com/mlange-42/arche/compare/v0.6.3...v0.7.0)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 ### Features
 
 * Adds method `World.ComponentType(ID)` to get the `reflect.Type` for component IDs (#215)
-* Adds methods `World.GetUnchecked` and `World.HasUnchecked` as optimized variants for known static entities (#217, #218)
-* Adds method `MapX.GetUnchecked` to all generic mappers, as equivalent to previous point (#217, #218)
-* Adds methods `Map.GetUnchecked` and `Map.HasUnchecked` to generic `Map`, as equivalent to previous points (#217, #218)
+* Adds methods `World.GetUnchecked` and `World.HasUnchecked` as optimized variants for known static entities (#217, #219)
+* Adds method `MapX.GetUnchecked` to all generic mappers, as equivalent to previous point (#217, #219)
+* Adds methods `Map.GetUnchecked` and `Map.HasUnchecked` to generic `Map`, as equivalent to previous points (#217, #219)
+
+### Performance
+
+* Optimize `World.Alive(Entity)` by only checking the entity generation, but not `id == 0` (#220)
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ In the illustration, the first archetype holds all components for all entities w
 The exact composition of each archetype is encoded in a bitmask for fast comparison.
 Thus, queries can easily identify their relevant archetypes, and then simply iterate entities linearly, which is very fast. Components can be accessed through the query in a very efficient way (&approx;1ns).
 
-For getting components by entity ID, e.g. for hierarchies, the world contains a list that is indexed by the entity ID. For each entity, it references it's current archetype and the index in the archetype. This way, getting components for entity IDs (i.e. random access) is fast, although not as fast as in queries (≈1.8ns vs. 1ns).
+For getting components by entity ID, e.g. for hierarchies, the world contains a list that is indexed by the entity ID. For each entity, it references it's current archetype and the index in the archetype. This way, getting components for entity IDs (i.e. random access) is fast, although not as fast as in queries (≈1.5ns vs. 1ns).
 
 Obviously, archetypes are an optimization for iteration speed.
 But they also come with a downside. Adding or removing components to/from an entity requires moving all the components of the entity to another archetype.

--- a/benchmark/profile/world/main.go
+++ b/benchmark/profile/world/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/generic"
 	"github.com/pkg/profile"
 )
 
@@ -50,9 +51,11 @@ func run(rounds, iters, entityCount int) {
 			entities = append(entities, query.Entity())
 		}
 
+		mapper := generic.NewMap1[position](&world)
+
 		for j := 0; j < iters; j++ {
 			for _, e := range entities {
-				pos := (*position)(world.Get(e, posID))
+				pos := mapper.Get(e)
 				pos.X = 1
 			}
 		}

--- a/ecs/pool.go
+++ b/ecs/pool.go
@@ -67,7 +67,7 @@ func (p *entityPool) Reset() {
 
 // Alive returns whether an entity is still alive, based on the entity's generations.
 func (p *entityPool) Alive(e Entity) bool {
-	return e.id != 0 && e.gen == p.entities[e.id].gen
+	return e.gen == p.entities[e.id].gen
 }
 
 // Len returns the current number of used entities.

--- a/ecs/pool_test.go
+++ b/ecs/pool_test.go
@@ -50,6 +50,7 @@ func TestEntityPool(t *testing.T) {
 	}
 
 	assert.False(t, p.Alive(e0Old), "Recycled entity of old generation should not be alive")
+	assert.False(t, p.Alive(Entity{}), "Zero entity should not be alive")
 }
 
 func TestEntityPoolStochastic(t *testing.T) {


### PR DESCRIPTION
* Optimize entity alive check by only comparing the generation, but don't check for zero entity ID
* Set next version in CHANGELOG to v0.7.0

Fixes #218