### PR TITLE
Memory optimizations: Query and internal archetype list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [[v0.7.2]](https://github.com/mlange-42/arche/compare/v0.7.1...v0.7.2)
 
 * Remove go-gameengine-ecs from Arche benchmarks (but not from competition!) (#228)
+* Reduce memory size of `Query` and internal archetype list by 8 bytes (#229)
 
 ## [[v0.7.1]](https://github.com/mlange-42/arche/compare/v0.7.0...v0.7.1)
 

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -30,9 +30,9 @@ func newArchetypeNode(mask Mask) archetypeNode {
 
 // Helper for accessing data from an archetype
 type archetypeAccess struct {
+	Mask          Mask           // Archetype's mask
 	basePointer   unsafe.Pointer // Pointer to the first component column layout.
 	entityPointer unsafe.Pointer // Pointer to the entity storage
-	Mask          Mask           // Archetype's mask
 }
 
 // GetEntity returns the entity at the given index

--- a/ecs/archetypes.go
+++ b/ecs/archetypes.go
@@ -2,8 +2,8 @@ package ecs
 
 // Interface for an iterator over archetypes.
 type archetypes interface {
-	Get(index int) *archetype
-	Len() int
+	Get(index int32) *archetype
+	Len() int32
 }
 
 // Implementation of an archetype iterator for a single archetype.
@@ -16,12 +16,12 @@ type batchArchetype struct {
 }
 
 // Get returns the value at the given index.
-func (s batchArchetype) Get(index int) *archetype {
+func (s batchArchetype) Get(index int32) *archetype {
 	return s.Archetype
 }
 
 // Len returns the current number of items in the paged array.
-func (s batchArchetype) Len() int {
+func (s batchArchetype) Len() int32 {
 	return 1
 }
 
@@ -34,7 +34,7 @@ type archetypePointers struct {
 }
 
 // Get returns the value at the given index.
-func (a *archetypePointers) Get(index int) *archetype {
+func (a *archetypePointers) Get(index int32) *archetype {
 	return a.pointers[index]
 }
 
@@ -44,6 +44,6 @@ func (a *archetypePointers) Add(arch *archetype) {
 }
 
 // Len returns the current number of items in the paged array.
-func (a *archetypePointers) Len() int {
-	return len(a.pointers)
+func (a *archetypePointers) Len() int32 {
+	return int32(len(a.pointers))
 }

--- a/ecs/archetypes_test.go
+++ b/ecs/archetypes_test.go
@@ -18,7 +18,7 @@ func TestArchetypePointers(t *testing.T) {
 	pt.Add(&a2)
 	pt.Add(&a3)
 
-	assert.Equal(t, 3, pt.Len())
+	assert.Equal(t, int32(3), pt.Len())
 
 	for i := 0; i < 45; i++ {
 		pt.Add(&a3)

--- a/ecs/pool.go
+++ b/ecs/pool.go
@@ -10,11 +10,11 @@ type entityPool struct {
 	entities          []Entity
 	next              eid
 	available         uint32
-	capacityIncrement int
+	capacityIncrement uint32
 }
 
 // newEntityPool creates a new, initialized Entity pool.
-func newEntityPool(capacityIncrement int) entityPool {
+func newEntityPool(capacityIncrement uint32) entityPool {
 	entities := make([]Entity, 1, capacityIncrement)
 	entities[0] = Entity{0, math.MaxUint16}
 	return entityPool{
@@ -41,7 +41,7 @@ func (p *entityPool) getNew() Entity {
 	e := newEntity(eid(len(p.entities)))
 	if len(p.entities) == cap(p.entities) {
 		old := p.entities
-		p.entities = make([]Entity, len(p.entities), len(p.entities)+p.capacityIncrement)
+		p.entities = make([]Entity, len(p.entities), len(p.entities)+int(p.capacityIncrement))
 		copy(p.entities, old)
 	}
 	p.entities = append(p.entities, e)

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -62,8 +62,8 @@ func (m *lockMask) Reset() {
 // Implements [archetypes].
 type pagedSlice[T any] struct {
 	pages   [][]T
-	len     int
-	lenLast int
+	len     int32
+	lenLast int32
 }
 
 // newPagedSlice creates a new pagedSlice with the given page size/capacity increment.
@@ -83,11 +83,11 @@ func (p *pagedSlice[T]) Add(value T) {
 }
 
 // Get returns the value at the given index.
-func (p *pagedSlice[T]) Get(index int) *T {
+func (p *pagedSlice[T]) Get(index int32) *T {
 	return &p.pages[index/pageSize][index%pageSize]
 }
 
 // Len returns the current number of items in the paged slice.
-func (p *pagedSlice[T]) Len() int {
+func (p *pagedSlice[T]) Len() int32 {
 	return p.len
 }

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -44,9 +44,10 @@ func TestLockMask(t *testing.T) {
 }
 
 func TestPagedSlice(t *testing.T) {
-	a := newPagedSlice[int]()
+	a := newPagedSlice[int32]()
 
-	for i := 0; i < 66; i++ {
+	var i int32
+	for i = 0; i < 66; i++ {
 		a.Add(i)
 		assert.Equal(t, i, *a.Get(i))
 		assert.Equal(t, i+1, a.Len())
@@ -54,12 +55,13 @@ func TestPagedSlice(t *testing.T) {
 }
 
 func TestPagedSlicePointerPersistence(t *testing.T) {
-	a := newPagedSlice[int]()
+	a := newPagedSlice[int32]()
 
 	a.Add(0)
 	p1 := a.Get(0)
 
-	for i := 1; i < 66; i++ {
+	var i int32
+	for i = 1; i < 66; i++ {
 		a.Add(i)
 		assert.Equal(t, i, *a.Get(i))
 		assert.Equal(t, i+1, a.Len())
@@ -68,7 +70,7 @@ func TestPagedSlicePointerPersistence(t *testing.T) {
 	p2 := a.Get(0)
 	assert.Equal(t, unsafe.Pointer(p1), unsafe.Pointer(p2))
 	*p1 = 100
-	assert.Equal(t, 100, *p2)
+	assert.Equal(t, int32(100), *p2)
 }
 
 func BenchmarkPagedSlice_Get(b *testing.B) {
@@ -85,6 +87,6 @@ func BenchmarkPagedSlice_Get(b *testing.B) {
 
 	sum := 0
 	for i := 0; i < b.N; i++ {
-		sum += *s.Get(i % count)
+		sum += *s.Get(int32(i % count))
 	}
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -98,7 +98,7 @@ func fromConfig(conf Config) World {
 	w := World{
 		config:      conf,
 		entities:    entities,
-		entityPool:  newEntityPool(conf.CapacityIncrement),
+		entityPool:  newEntityPool(uint32(conf.CapacityIncrement)),
 		registry:    newComponentRegistry(),
 		archetypes:  newPagedSlice[archetype](),
 		graph:       newPagedSlice[archetypeNode](),

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -288,7 +288,8 @@ func (w *World) removeEntities(filter Filter) int {
 	lock := w.lock()
 	numArches := w.archetypes.Len()
 	var count uintptr
-	for i := 0; i < numArches; i++ {
+	var i int32
+	for i = 0; i < numArches; i++ {
 		arch := w.archetypes.Get(i)
 
 		if !filter.Matches(arch.Mask) {
@@ -530,7 +531,8 @@ func (w *World) Reset() {
 	w.resources.reset()
 
 	len := w.archetypes.Len()
-	for i := 0; i < len; i++ {
+	var i int32
+	for i = 0; i < len; i++ {
 		w.archetypes.Get(i).Reset()
 	}
 }
@@ -624,14 +626,15 @@ func (w *World) Stats() *stats.WorldStats {
 
 	memory := cap(w.entities)*int(entityIndexSize) + w.entityPool.TotalCap()*int(entitySize)
 
-	cntOld := len(w.stats.Archetypes)
-	cntNew := w.archetypes.Len()
-	for i := 0; i < cntOld; i++ {
+	cntOld := int32(len(w.stats.Archetypes))
+	cntNew := int32(w.archetypes.Len())
+	var i int32
+	for i = 0; i < cntOld; i++ {
 		arch := &w.stats.Archetypes[i]
 		w.archetypes.Get(i).UpdateStats(arch)
 		memory += arch.Memory
 	}
-	for i := cntOld; i < cntNew; i++ {
+	for i = cntOld; i < cntNew; i++ {
 		w.stats.Archetypes = append(w.stats.Archetypes, w.archetypes.Get(i).Stats(&w.registry))
 		memory += w.stats.Archetypes[i].Memory
 	}
@@ -811,7 +814,8 @@ func (w *World) findOrCreateArchetypeSlow(mask Mask) (*archetypeNode, bool) {
 // Searches for an archetype by a mask.
 func (w *World) findArchetypeSlow(mask Mask) (*archetypeNode, bool) {
 	length := w.graph.Len()
-	for i := 0; i < length; i++ {
+	var i int32
+	for i = 0; i < length; i++ {
 		arch := w.graph.Get(i)
 		if arch.mask == mask {
 			return arch, true
@@ -865,8 +869,9 @@ func (w *World) createArchetype(node *archetypeNode, forStorage bool) *archetype
 // Returns all archetypes that match the given filter. Used by [Cache].
 func (w *World) getArchetypes(filter Filter) archetypePointers {
 	arches := []*archetype{}
-	ln := int(w.archetypes.Len())
-	for i := 0; i < ln; i++ {
+	ln := int32(w.archetypes.Len())
+	var i int32
+	for i = 0; i < ln; i++ {
 		a := w.archetypes.Get(i)
 		if filter.Matches(a.Mask) {
 			arches = append(arches, a)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -117,14 +117,14 @@ func TestWorldComponents(t *testing.T) {
 	e1 := w.NewEntity()
 	e2 := w.NewEntity()
 
-	assert.Equal(t, 1, w.archetypes.Len())
+	assert.Equal(t, int32(1), w.archetypes.Len())
 
 	w.Add(e0, posID)
-	assert.Equal(t, 2, w.archetypes.Len())
+	assert.Equal(t, int32(2), w.archetypes.Len())
 	w.Add(e1, posID, rotID)
-	assert.Equal(t, 3, w.archetypes.Len())
+	assert.Equal(t, int32(3), w.archetypes.Len())
 	w.Add(e2, posID, rotID)
-	assert.Equal(t, 3, w.archetypes.Len())
+	assert.Equal(t, int32(3), w.archetypes.Len())
 
 	assert.Equal(t, All(posID), w.Mask(e0))
 	assert.Equal(t, All(posID, rotID), w.Mask(e1))
@@ -728,13 +728,13 @@ func TestArchetypeGraph(t *testing.T) {
 	arch0 := world.findOrCreateArchetype(archEmpty, []ID{posID, velID}, []ID{})
 	archEmpty2 := world.findOrCreateArchetype(arch0, []ID{}, []ID{velID, posID})
 	assert.Equal(t, archEmpty, archEmpty2)
-	assert.Equal(t, 2, world.archetypes.Len())
-	assert.Equal(t, 3, world.graph.Len())
+	assert.Equal(t, int32(2), world.archetypes.Len())
+	assert.Equal(t, int32(3), world.graph.Len())
 
 	archEmpty3 := world.findOrCreateArchetype(arch0, []ID{}, []ID{posID, velID})
 	assert.Equal(t, archEmpty, archEmpty3)
-	assert.Equal(t, 2, world.archetypes.Len())
-	assert.Equal(t, 4, world.graph.Len())
+	assert.Equal(t, int32(2), world.archetypes.Len())
+	assert.Equal(t, int32(4), world.graph.Len())
 
 	arch01 := world.findOrCreateArchetype(arch0, []ID{velID}, []ID{})
 	arch012 := world.findOrCreateArchetype(arch01, []ID{rotID}, []ID{})
@@ -944,7 +944,7 @@ func Test1000Archetypes(t *testing.T) {
 		entity := w.NewEntity()
 		w.Add(entity, add...)
 	}
-	assert.Equal(t, 1024, w.archetypes.Len())
+	assert.Equal(t, int32(1024), w.archetypes.Len())
 
 	cnt := 0
 	query := w.Query(All(0, 7))
@@ -973,7 +973,7 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSizeName[reflect.Value]("reflect.Value")
 	printTypeSize[EntityEvent]()
 	printTypeSize[Cache]()
-	printTypeSizeName[idMap[archetype]]("idMap")
+	printTypeSizeName[idMap[uint32]]("idMap")
 }
 
 func printTypeSize[T any]() {


### PR DESCRIPTION
* Reduce memory size of `Query` and internal archetype list by 8 bytes