### PR TITLE
Archetype size optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Support for entity relations that can be queries like components (#231)
 
+### Performance
+
+* Reduce memory footprint of archetypes by moving properties to nodes (#237)
+
 ### Other
 
 * Remove go-gameengine-ecs from Arche benchmarks (but not from competition!) (#228)

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -13,9 +13,9 @@ func TestArchetype(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, false, Entity{}, -1, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -71,13 +71,13 @@ func TestNewArchetype(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 32, true, Entity{}, -1, comps...)
+	arch.Init(&node, true, Entity{}, -1, comps...)
 	assert.Equal(t, 32, int(arch.Cap()))
 
 	arch = archetype{}
-	arch.Init(&node, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, false, Entity{}, -1, comps...)
 	assert.Equal(t, 1, int(arch.Cap()))
 
 	comps = []componentType{
@@ -85,9 +85,9 @@ func TestNewArchetype(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 	}
 	assert.Panics(t, func() {
-		node := newArchetypeNode(All(0, 1), -1)
+		node := newArchetypeNode(All(0, 1), -1, 32)
 		arch := archetype{}
-		arch.Init(&node, 32, true, Entity{}, -1, comps...)
+		arch.Init(&node, true, Entity{}, -1, comps...)
 	})
 }
 
@@ -97,9 +97,9 @@ func TestArchetypeExtend(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 8)
 	arch := archetype{}
-	arch.Init(&node, 8, true, Entity{}, -1, comps...)
+	arch.Init(&node, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -119,9 +119,9 @@ func TestArchetypeAlloc(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 8)
 	arch := archetype{}
-	arch.Init(&node, 8, true, Entity{}, -1, comps...)
+	arch.Init(&node, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -144,9 +144,9 @@ func TestArchetypeAddGetSet(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(label{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 1)
 	a := archetype{}
-	a.Init(&node, 1, true, Entity{}, -1, comps...)
+	a.Init(&node, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 1, int(a.Cap()))
 	assert.Equal(t, 0, int(a.Len()))
@@ -179,9 +179,9 @@ func TestArchetypeReset(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, false, Entity{}, -1, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -225,9 +225,9 @@ func TestArchetypeZero(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
-	node := newArchetypeNode(All(0, 1), -1)
+	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, false, Entity{}, -1, comps...)
 
 	arch.Alloc(newEntity(0))
 	arch.Alloc(newEntity(1))
@@ -257,9 +257,9 @@ func BenchmarkIterArchetype_1000(b *testing.B) {
 		{ID: 0, Type: reflect.TypeOf(testStruct0{})},
 	}
 
-	node := newArchetypeNode(All(0), -1)
+	node := newArchetypeNode(All(0), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 32, true, Entity{}, -1, comps...)
+	arch.Init(&node, true, Entity{}, -1, comps...)
 
 	for i := 0; i < 1000; i++ {
 		arch.Alloc(newEntity(eid(i)))

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -13,8 +13,9 @@ func TestArchetype(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, 32, false, Entity{}, -1, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -69,12 +70,14 @@ func TestNewArchetype(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
+
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 32, true, Entity{}, -1, comps...)
+	arch.Init(&node, 32, true, Entity{}, -1, comps...)
 	assert.Equal(t, 32, int(arch.Cap()))
 
 	arch = archetype{}
-	arch.Init(nil, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, 32, false, Entity{}, -1, comps...)
 	assert.Equal(t, 1, int(arch.Cap()))
 
 	comps = []componentType{
@@ -82,8 +85,9 @@ func TestNewArchetype(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 	}
 	assert.Panics(t, func() {
+		node := newArchetypeNode(All(0, 1), -1)
 		arch := archetype{}
-		arch.Init(nil, 32, true, Entity{}, -1, comps...)
+		arch.Init(&node, 32, true, Entity{}, -1, comps...)
 	})
 }
 
@@ -92,8 +96,10 @@ func TestArchetypeExtend(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
+
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 8, true, Entity{}, -1, comps...)
+	arch.Init(&node, 8, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -113,8 +119,9 @@ func TestArchetypeAlloc(t *testing.T) {
 		{ID: 0, Type: reflect.TypeOf(Position{})},
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 8, true, Entity{}, -1, comps...)
+	arch.Init(&node, 8, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -132,13 +139,14 @@ func TestArchetypeAlloc(t *testing.T) {
 }
 
 func TestArchetypeAddGetSet(t *testing.T) {
-	a := archetype{}
-
 	comps := []componentType{
 		{ID: 0, Type: reflect.TypeOf(testStruct0{})},
 		{ID: 1, Type: reflect.TypeOf(label{})},
 	}
-	a.Init(nil, 1, true, Entity{}, -1, comps...)
+
+	node := newArchetypeNode(All(0, 1), -1)
+	a := archetype{}
+	a.Init(&node, 1, true, Entity{}, -1, comps...)
 
 	assert.Equal(t, 1, int(a.Cap()))
 	assert.Equal(t, 0, int(a.Len()))
@@ -171,8 +179,9 @@ func TestArchetypeReset(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, 32, false, Entity{}, -1, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -216,8 +225,9 @@ func TestArchetypeZero(t *testing.T) {
 		{ID: 1, Type: reflect.TypeOf(rotation{})},
 	}
 
+	node := newArchetypeNode(All(0, 1), -1)
 	arch := archetype{}
-	arch.Init(nil, 32, false, Entity{}, -1, comps...)
+	arch.Init(&node, 32, false, Entity{}, -1, comps...)
 
 	arch.Alloc(newEntity(0))
 	arch.Alloc(newEntity(1))
@@ -247,8 +257,9 @@ func BenchmarkIterArchetype_1000(b *testing.B) {
 		{ID: 0, Type: reflect.TypeOf(testStruct0{})},
 	}
 
+	node := newArchetypeNode(All(0), -1)
 	arch := archetype{}
-	arch.Init(nil, 32, true, Entity{}, -1, comps...)
+	arch.Init(&node, 32, true, Entity{}, -1, comps...)
 
 	for i := 0; i < 1000; i++ {
 		arch.Alloc(newEntity(eid(i)))

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -897,7 +897,7 @@ func (w *World) findArchetypeSlow(mask Mask) (*archetypeNode, bool) {
 
 // Creates a node in the archetype graph.
 func (w *World) createArchetypeNode(mask Mask, relation int8) *archetypeNode {
-	w.graph.Add(newArchetypeNode(mask, relation))
+	w.graph.Add(newArchetypeNode(mask, relation, w.config.CapacityIncrement))
 	node := w.graph.Get(w.graph.Len() - 1)
 	return node
 }
@@ -930,7 +930,7 @@ func (w *World) createArchetype(node *archetypeNode, target Entity, targetCompon
 
 	w.archetypes.Add(archetype{})
 	arch := w.archetypes.Get(w.archetypes.Len() - 1)
-	arch.Init(node, w.config.CapacityIncrement, forStorage, target, targetComponent, types...)
+	arch.Init(node, forStorage, target, targetComponent, types...)
 
 	node.SetArchetype(target, arch)
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -139,7 +139,7 @@ func (w *World) NewEntity(comps ...ID) Entity {
 	entity := w.createEntity(arch)
 
 	if w.listener != nil {
-		w.listener(&EntityEvent{entity, Mask{}, arch.Mask, comps, nil, arch.Ids, 1})
+		w.listener(&EntityEvent{entity, Mask{}, arch.Mask, comps, nil, arch.graphNode.Ids, 1})
 	}
 	return entity
 }
@@ -176,7 +176,7 @@ func (w *World) NewEntityWith(comps ...Component) Entity {
 	}
 
 	if w.listener != nil {
-		w.listener(&EntityEvent{entity, Mask{}, arch.Mask, ids, nil, arch.Ids, 1})
+		w.listener(&EntityEvent{entity, Mask{}, arch.Mask, ids, nil, arch.graphNode.Ids, 1})
 	}
 	return entity
 }
@@ -192,7 +192,7 @@ func (w *World) newEntities(count int, comps ...ID) (*archetype, uint32) {
 		for i = 0; i < cnt; i++ {
 			idx := startIdx + i
 			entity := arch.GetEntity(uintptr(idx))
-			w.listener(&EntityEvent{entity, Mask{}, arch.Mask, comps, nil, arch.Ids, 1})
+			w.listener(&EntityEvent{entity, Mask{}, arch.Mask, comps, nil, arch.graphNode.Ids, 1})
 		}
 	}
 
@@ -223,7 +223,7 @@ func (w *World) newEntitiesWith(count int, comps ...Component) (*archetype, uint
 		for i = 0; i < cnt; i++ {
 			idx := startIdx + i
 			entity := arch.GetEntity(uintptr(idx))
-			w.listener(&EntityEvent{entity, Mask{}, arch.Mask, ids, nil, arch.Ids, 1})
+			w.listener(&EntityEvent{entity, Mask{}, arch.Mask, ids, nil, arch.graphNode.Ids, 1})
 		}
 	}
 
@@ -261,7 +261,7 @@ func (w *World) RemoveEntity(entity Entity) {
 
 	if w.listener != nil {
 		lock := w.lock()
-		w.listener(&EntityEvent{entity, oldArch.Mask, Mask{}, nil, oldArch.Ids, nil, -1})
+		w.listener(&EntityEvent{entity, oldArch.Mask, Mask{}, nil, oldArch.graphNode.Ids, nil, -1})
 		w.unlock(lock)
 	}
 
@@ -304,7 +304,7 @@ func (w *World) removeEntities(filter Filter) int {
 		for j = 0; j < len; j++ {
 			entity := arch.GetEntity(j)
 			if w.listener != nil {
-				w.listener(&EntityEvent{entity, arch.Mask, Mask{}, nil, arch.Ids, nil, -1})
+				w.listener(&EntityEvent{entity, arch.Mask, Mask{}, nil, arch.graphNode.Ids, nil, -1})
 			}
 			w.entities[entity.id].arch = nil
 			w.entityPool.Recycle(entity)
@@ -513,7 +513,7 @@ func (w *World) Exchange(entity Entity, add []ID, rem []ID) {
 	w.entities[entity.id] = entityIndex{arch: arch, index: newIndex}
 
 	if w.listener != nil {
-		w.listener(&EntityEvent{entity, oldMask, arch.Mask, add, rem, arch.Ids, 0})
+		w.listener(&EntityEvent{entity, oldMask, arch.Mask, add, rem, arch.graphNode.Ids, 0})
 	}
 }
 
@@ -562,7 +562,7 @@ func (w *World) SetRelation(entity Entity, comp ID, target Entity) {
 	}
 
 	newIndex := arch.Alloc(entity)
-	for _, id := range oldArch.Ids {
+	for _, id := range oldArch.graphNode.Ids {
 		comp := oldArch.Get(index.index, id)
 		arch.SetPointer(newIndex, id, comp)
 	}
@@ -979,7 +979,7 @@ func (w *World) notifyQuery(batchArch *batchArchetype) {
 	arch := batchArch.Archetype
 	var i uintptr
 	len := uintptr(arch.Len())
-	event := EntityEvent{Entity{}, Mask{}, arch.Mask, arch.Ids, nil, arch.Ids, 1}
+	event := EntityEvent{Entity{}, Mask{}, arch.Mask, arch.graphNode.Ids, nil, arch.graphNode.Ids, 1}
 
 	for i = uintptr(batchArch.StartIndex); i < len; i++ {
 		entity := arch.GetEntity(i)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -863,7 +863,7 @@ func TestArchetypeGraph(t *testing.T) {
 	arch01 := world.findOrCreateArchetype(arch0, []ID{velID}, []ID{}, Entity{}, -1)
 	arch012 := world.findOrCreateArchetype(arch01, []ID{rotID}, []ID{}, Entity{}, -1)
 
-	assert.Equal(t, []ID{0, 1, 2}, arch012.Ids)
+	assert.Equal(t, []ID{0, 1, 2}, arch012.graphNode.Ids)
 
 	archEmpty4 := world.findOrCreateArchetype(arch012, []ID{}, []ID{posID, rotID, velID}, Entity{}, -1)
 	assert.Equal(t, archEmpty, archEmpty4)


### PR DESCRIPTION
Moved properties shared by relation archetypes to the parent node.

Fixes #236 