### PR TITLE
Lock registered filters, partial recompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * Remove go-gameengine-ecs from Arche benchmarks (but not from competition!) (#228)
 * Reduce memory size of `Query` and internal archetype list by 8 bytes (#230)
+* Generic filters are locked when registered for caching (#241)
 
 ## [[v0.7.1]](https://github.com/mlange-42/arche/compare/v0.7.0...v0.7.1)
 

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -11,25 +11,30 @@ var relationType = reflect.TypeOf((*ecs.Relation)(nil)).Elem()
 
 // compiledQuery is a helper for compiling a generic filter into a [ecs.Filter].
 type compiledQuery struct {
-	maskFilter   ecs.MaskFilter
-	cachedFilter ecs.CachedFilter
-	filter       ecs.Filter
-	Ids          []ecs.ID
-	TargetID     int8
-	compiled     bool
-	locked       bool
+	maskFilter     ecs.MaskFilter
+	cachedFilter   ecs.CachedFilter
+	filter         ecs.Filter
+	Ids            []ecs.ID
+	TargetID       int8
+	compiled       bool
+	targetCompiled bool
+	locked         bool
 }
 
 // Compile compiles a generic filter.
 func (q *compiledQuery) Compile(w *ecs.World, include, optional, exclude []Comp, targetType Comp, target ecs.Entity) {
-	if q.compiled {
+	if q.targetCompiled {
 		return
 	}
-	q.Ids = toIds(w, include)
-	q.maskFilter = ecs.MaskFilter{
-		Include: toMaskOptional(w, q.Ids, optional),
-		Exclude: toMask(w, exclude),
+
+	if !q.compiled {
+		q.Ids = toIds(w, include)
+		q.maskFilter = ecs.MaskFilter{
+			Include: toMaskOptional(w, q.Ids, optional),
+			Exclude: toMask(w, exclude),
+		}
 	}
+
 	if targetType == nil {
 		q.filter = &q.maskFilter
 		q.TargetID = -1
@@ -54,10 +59,14 @@ func (q *compiledQuery) Compile(w *ecs.World, include, optional, exclude []Comp,
 			Target: target,
 		}
 	}
+	q.targetCompiled = true
 	q.compiled = true
 }
 
 // Reset sets the compiledQuery to not compiled.
-func (q *compiledQuery) Reset() {
-	q.compiled = false
+func (q *compiledQuery) Reset(targetOnly bool) {
+	q.targetCompiled = false
+	if !targetOnly {
+		q.compiled = false
+	}
 }

--- a/generic/compiled.go
+++ b/generic/compiled.go
@@ -17,6 +17,7 @@ type compiledQuery struct {
 	Ids          []ecs.ID
 	TargetID     int8
 	compiled     bool
+	locked       bool
 }
 
 // Compile compiles a generic filter.

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -34,6 +34,9 @@ func NewFilter{{ .Index }}{{ .TypesFull }}() *Filter{{ .Index }}{{ .Types }} {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter{{ .Index }}{{ .Types }}) Optional(mask ...Comp) *Filter{{ .Index }}{{ .Types }} {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -44,6 +47,9 @@ func (q *Filter{{ .Index }}{{ .Types }}) Optional(mask ...Comp) *Filter{{ .Index
 //
 // Create the required mask items with [T].
 func (q *Filter{{ .Index }}{{ .Types }}) With(mask ...Comp) *Filter{{ .Index }}{{ .Types }} {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -53,6 +59,9 @@ func (q *Filter{{ .Index }}{{ .Types }}) With(mask ...Comp) *Filter{{ .Index }}{
 //
 // Create the required mask items with [T].
 func (q *Filter{{ .Index }}{{ .Types }}) Without(mask ...Comp) *Filter{{ .Index }}{{ .Types }} {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -62,6 +71,9 @@ func (q *Filter{{ .Index }}{{ .Types }}) Without(mask ...Comp) *Filter{{ .Index 
 //
 // Create the required component ID with [T].
 func (q *Filter{{ .Index }}{{ .Types }}) WithRelation(comp Comp, target ecs.Entity) *Filter{{ .Index }}{{ .Types }} {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -94,6 +106,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -105,6 +118,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query{{ .Index }} is a generic query iterator for {{ .NumberStr }} components.

--- a/generic/generate/query.go.txt
+++ b/generic/generate/query.go.txt
@@ -38,7 +38,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) Optional(mask ...Comp) *Filter{{ .Index
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 {{ end }}
@@ -51,7 +51,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) With(mask ...Comp) *Filter{{ .Index }}{
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -63,7 +63,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) Without(mask ...Comp) *Filter{{ .Index 
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -76,7 +76,7 @@ func (q *Filter{{ .Index }}{{ .Types }}) WithRelation(comp Comp, target ecs.Enti
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -41,7 +41,7 @@ func (q *Filter0) With(mask ...Comp) *Filter0 {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -53,7 +53,7 @@ func (q *Filter0) Without(mask ...Comp) *Filter0 {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -66,7 +66,7 @@ func (q *Filter0) WithRelation(comp Comp, target ecs.Entity) *Filter0 {
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -179,7 +179,7 @@ func (q *Filter1[A]) Optional(mask ...Comp) *Filter1[A] {
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -191,7 +191,7 @@ func (q *Filter1[A]) With(mask ...Comp) *Filter1[A] {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -203,7 +203,7 @@ func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -216,7 +216,7 @@ func (q *Filter1[A]) WithRelation(comp Comp, target ecs.Entity) *Filter1[A] {
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -339,7 +339,7 @@ func (q *Filter2[A, B]) Optional(mask ...Comp) *Filter2[A, B] {
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -351,7 +351,7 @@ func (q *Filter2[A, B]) With(mask ...Comp) *Filter2[A, B] {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -363,7 +363,7 @@ func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -376,7 +376,7 @@ func (q *Filter2[A, B]) WithRelation(comp Comp, target ecs.Entity) *Filter2[A, B
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -503,7 +503,7 @@ func (q *Filter3[A, B, C]) Optional(mask ...Comp) *Filter3[A, B, C] {
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -515,7 +515,7 @@ func (q *Filter3[A, B, C]) With(mask ...Comp) *Filter3[A, B, C] {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -527,7 +527,7 @@ func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -540,7 +540,7 @@ func (q *Filter3[A, B, C]) WithRelation(comp Comp, target ecs.Entity) *Filter3[A
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -671,7 +671,7 @@ func (q *Filter4[A, B, C, D]) Optional(mask ...Comp) *Filter4[A, B, C, D] {
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -683,7 +683,7 @@ func (q *Filter4[A, B, C, D]) With(mask ...Comp) *Filter4[A, B, C, D] {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -695,7 +695,7 @@ func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -708,7 +708,7 @@ func (q *Filter4[A, B, C, D]) WithRelation(comp Comp, target ecs.Entity) *Filter
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -843,7 +843,7 @@ func (q *Filter5[A, B, C, D, E]) Optional(mask ...Comp) *Filter5[A, B, C, D, E] 
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -855,7 +855,7 @@ func (q *Filter5[A, B, C, D, E]) With(mask ...Comp) *Filter5[A, B, C, D, E] {
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -867,7 +867,7 @@ func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -880,7 +880,7 @@ func (q *Filter5[A, B, C, D, E]) WithRelation(comp Comp, target ecs.Entity) *Fil
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -1019,7 +1019,7 @@ func (q *Filter6[A, B, C, D, E, F]) Optional(mask ...Comp) *Filter6[A, B, C, D, 
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1031,7 +1031,7 @@ func (q *Filter6[A, B, C, D, E, F]) With(mask ...Comp) *Filter6[A, B, C, D, E, F
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1043,7 +1043,7 @@ func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1056,7 +1056,7 @@ func (q *Filter6[A, B, C, D, E, F]) WithRelation(comp Comp, target ecs.Entity) *
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -1199,7 +1199,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Optional(mask ...Comp) *Filter7[A, B, C, 
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1211,7 +1211,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) With(mask ...Comp) *Filter7[A, B, C, D, E
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1223,7 +1223,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1236,7 +1236,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) WithRelation(comp Comp, target ecs.Entity
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 
@@ -1383,7 +1383,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Optional(mask ...Comp) *Filter8[A, B, 
 		panic("can't modify a registered filter")
 	}
 	q.optional = append(q.optional, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1395,7 +1395,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) With(mask ...Comp) *Filter8[A, B, C, D
 		panic("can't modify a registered filter")
 	}
 	q.include = append(q.include, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1407,7 +1407,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C
 		panic("can't modify a registered filter")
 	}
 	q.exclude = append(q.exclude, mask...)
-	q.compiled.Reset()
+	q.compiled.Reset(false)
 	return q
 }
 
@@ -1420,7 +1420,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) WithRelation(comp Comp, target ecs.Ent
 	}
 	q.targetType = comp
 	q.target = target
-	q.compiled.Reset()
+	q.compiled.Reset(true)
 	return q
 }
 

--- a/generic/query_generated.go
+++ b/generic/query_generated.go
@@ -37,6 +37,9 @@ func NewFilter0() *Filter0 {
 //
 // Create the required mask items with [T].
 func (q *Filter0) With(mask ...Comp) *Filter0 {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -46,6 +49,9 @@ func (q *Filter0) With(mask ...Comp) *Filter0 {
 //
 // Create the required mask items with [T].
 func (q *Filter0) Without(mask ...Comp) *Filter0 {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -55,6 +61,9 @@ func (q *Filter0) Without(mask ...Comp) *Filter0 {
 //
 // Create the required component ID with [T].
 func (q *Filter0) WithRelation(comp Comp, target ecs.Entity) *Filter0 {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -86,6 +95,7 @@ func (q *Filter0) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -97,6 +107,7 @@ func (q *Filter0) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query0 is a generic query iterator for zero components.
@@ -164,6 +175,9 @@ func NewFilter1[A any]() *Filter1[A] {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter1[A]) Optional(mask ...Comp) *Filter1[A] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -173,6 +187,9 @@ func (q *Filter1[A]) Optional(mask ...Comp) *Filter1[A] {
 //
 // Create the required mask items with [T].
 func (q *Filter1[A]) With(mask ...Comp) *Filter1[A] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -182,6 +199,9 @@ func (q *Filter1[A]) With(mask ...Comp) *Filter1[A] {
 //
 // Create the required mask items with [T].
 func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -191,6 +211,9 @@ func (q *Filter1[A]) Without(mask ...Comp) *Filter1[A] {
 //
 // Create the required component ID with [T].
 func (q *Filter1[A]) WithRelation(comp Comp, target ecs.Entity) *Filter1[A] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -223,6 +246,7 @@ func (q *Filter1[A]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -234,6 +258,7 @@ func (q *Filter1[A]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query1 is a generic query iterator for one components.
@@ -310,6 +335,9 @@ func NewFilter2[A any, B any]() *Filter2[A, B] {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter2[A, B]) Optional(mask ...Comp) *Filter2[A, B] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -319,6 +347,9 @@ func (q *Filter2[A, B]) Optional(mask ...Comp) *Filter2[A, B] {
 //
 // Create the required mask items with [T].
 func (q *Filter2[A, B]) With(mask ...Comp) *Filter2[A, B] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -328,6 +359,9 @@ func (q *Filter2[A, B]) With(mask ...Comp) *Filter2[A, B] {
 //
 // Create the required mask items with [T].
 func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -337,6 +371,9 @@ func (q *Filter2[A, B]) Without(mask ...Comp) *Filter2[A, B] {
 //
 // Create the required component ID with [T].
 func (q *Filter2[A, B]) WithRelation(comp Comp, target ecs.Entity) *Filter2[A, B] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -370,6 +407,7 @@ func (q *Filter2[A, B]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -381,6 +419,7 @@ func (q *Filter2[A, B]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query2 is a generic query iterator for two components.
@@ -460,6 +499,9 @@ func NewFilter3[A any, B any, C any]() *Filter3[A, B, C] {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter3[A, B, C]) Optional(mask ...Comp) *Filter3[A, B, C] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -469,6 +511,9 @@ func (q *Filter3[A, B, C]) Optional(mask ...Comp) *Filter3[A, B, C] {
 //
 // Create the required mask items with [T].
 func (q *Filter3[A, B, C]) With(mask ...Comp) *Filter3[A, B, C] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -478,6 +523,9 @@ func (q *Filter3[A, B, C]) With(mask ...Comp) *Filter3[A, B, C] {
 //
 // Create the required mask items with [T].
 func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -487,6 +535,9 @@ func (q *Filter3[A, B, C]) Without(mask ...Comp) *Filter3[A, B, C] {
 //
 // Create the required component ID with [T].
 func (q *Filter3[A, B, C]) WithRelation(comp Comp, target ecs.Entity) *Filter3[A, B, C] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -521,6 +572,7 @@ func (q *Filter3[A, B, C]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -532,6 +584,7 @@ func (q *Filter3[A, B, C]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query3 is a generic query iterator for three components.
@@ -614,6 +667,9 @@ func NewFilter4[A any, B any, C any, D any]() *Filter4[A, B, C, D] {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter4[A, B, C, D]) Optional(mask ...Comp) *Filter4[A, B, C, D] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -623,6 +679,9 @@ func (q *Filter4[A, B, C, D]) Optional(mask ...Comp) *Filter4[A, B, C, D] {
 //
 // Create the required mask items with [T].
 func (q *Filter4[A, B, C, D]) With(mask ...Comp) *Filter4[A, B, C, D] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -632,6 +691,9 @@ func (q *Filter4[A, B, C, D]) With(mask ...Comp) *Filter4[A, B, C, D] {
 //
 // Create the required mask items with [T].
 func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -641,6 +703,9 @@ func (q *Filter4[A, B, C, D]) Without(mask ...Comp) *Filter4[A, B, C, D] {
 //
 // Create the required component ID with [T].
 func (q *Filter4[A, B, C, D]) WithRelation(comp Comp, target ecs.Entity) *Filter4[A, B, C, D] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -676,6 +741,7 @@ func (q *Filter4[A, B, C, D]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -687,6 +753,7 @@ func (q *Filter4[A, B, C, D]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query4 is a generic query iterator for four components.
@@ -772,6 +839,9 @@ func NewFilter5[A any, B any, C any, D any, E any]() *Filter5[A, B, C, D, E] {
 //
 // Only affects component types that were specified in the query.
 func (q *Filter5[A, B, C, D, E]) Optional(mask ...Comp) *Filter5[A, B, C, D, E] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -781,6 +851,9 @@ func (q *Filter5[A, B, C, D, E]) Optional(mask ...Comp) *Filter5[A, B, C, D, E] 
 //
 // Create the required mask items with [T].
 func (q *Filter5[A, B, C, D, E]) With(mask ...Comp) *Filter5[A, B, C, D, E] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -790,6 +863,9 @@ func (q *Filter5[A, B, C, D, E]) With(mask ...Comp) *Filter5[A, B, C, D, E] {
 //
 // Create the required mask items with [T].
 func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -799,6 +875,9 @@ func (q *Filter5[A, B, C, D, E]) Without(mask ...Comp) *Filter5[A, B, C, D, E] {
 //
 // Create the required component ID with [T].
 func (q *Filter5[A, B, C, D, E]) WithRelation(comp Comp, target ecs.Entity) *Filter5[A, B, C, D, E] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -835,6 +914,7 @@ func (q *Filter5[A, B, C, D, E]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -846,6 +926,7 @@ func (q *Filter5[A, B, C, D, E]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query5 is a generic query iterator for five components.
@@ -934,6 +1015,9 @@ func NewFilter6[A any, B any, C any, D any, E any, F any]() *Filter6[A, B, C, D,
 //
 // Only affects component types that were specified in the query.
 func (q *Filter6[A, B, C, D, E, F]) Optional(mask ...Comp) *Filter6[A, B, C, D, E, F] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -943,6 +1027,9 @@ func (q *Filter6[A, B, C, D, E, F]) Optional(mask ...Comp) *Filter6[A, B, C, D, 
 //
 // Create the required mask items with [T].
 func (q *Filter6[A, B, C, D, E, F]) With(mask ...Comp) *Filter6[A, B, C, D, E, F] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -952,6 +1039,9 @@ func (q *Filter6[A, B, C, D, E, F]) With(mask ...Comp) *Filter6[A, B, C, D, E, F
 //
 // Create the required mask items with [T].
 func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E, F] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -961,6 +1051,9 @@ func (q *Filter6[A, B, C, D, E, F]) Without(mask ...Comp) *Filter6[A, B, C, D, E
 //
 // Create the required component ID with [T].
 func (q *Filter6[A, B, C, D, E, F]) WithRelation(comp Comp, target ecs.Entity) *Filter6[A, B, C, D, E, F] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -998,6 +1091,7 @@ func (q *Filter6[A, B, C, D, E, F]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -1009,6 +1103,7 @@ func (q *Filter6[A, B, C, D, E, F]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query6 is a generic query iterator for six components.
@@ -1100,6 +1195,9 @@ func NewFilter7[A any, B any, C any, D any, E any, F any, G any]() *Filter7[A, B
 //
 // Only affects component types that were specified in the query.
 func (q *Filter7[A, B, C, D, E, F, G]) Optional(mask ...Comp) *Filter7[A, B, C, D, E, F, G] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -1109,6 +1207,9 @@ func (q *Filter7[A, B, C, D, E, F, G]) Optional(mask ...Comp) *Filter7[A, B, C, 
 //
 // Create the required mask items with [T].
 func (q *Filter7[A, B, C, D, E, F, G]) With(mask ...Comp) *Filter7[A, B, C, D, E, F, G] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -1118,6 +1219,9 @@ func (q *Filter7[A, B, C, D, E, F, G]) With(mask ...Comp) *Filter7[A, B, C, D, E
 //
 // Create the required mask items with [T].
 func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D, E, F, G] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -1127,6 +1231,9 @@ func (q *Filter7[A, B, C, D, E, F, G]) Without(mask ...Comp) *Filter7[A, B, C, D
 //
 // Create the required component ID with [T].
 func (q *Filter7[A, B, C, D, E, F, G]) WithRelation(comp Comp, target ecs.Entity) *Filter7[A, B, C, D, E, F, G] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -1165,6 +1272,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -1176,6 +1284,7 @@ func (q *Filter7[A, B, C, D, E, F, G]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query7 is a generic query iterator for seven components.
@@ -1270,6 +1379,9 @@ func NewFilter8[A any, B any, C any, D any, E any, F any, G any, H any]() *Filte
 //
 // Only affects component types that were specified in the query.
 func (q *Filter8[A, B, C, D, E, F, G, H]) Optional(mask ...Comp) *Filter8[A, B, C, D, E, F, G, H] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.optional = append(q.optional, mask...)
 	q.compiled.Reset()
 	return q
@@ -1279,6 +1391,9 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Optional(mask ...Comp) *Filter8[A, B, 
 //
 // Create the required mask items with [T].
 func (q *Filter8[A, B, C, D, E, F, G, H]) With(mask ...Comp) *Filter8[A, B, C, D, E, F, G, H] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.include = append(q.include, mask...)
 	q.compiled.Reset()
 	return q
@@ -1288,6 +1403,9 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) With(mask ...Comp) *Filter8[A, B, C, D
 //
 // Create the required mask items with [T].
 func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C, D, E, F, G, H] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.exclude = append(q.exclude, mask...)
 	q.compiled.Reset()
 	return q
@@ -1297,6 +1415,9 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Without(mask ...Comp) *Filter8[A, B, C
 //
 // Create the required component ID with [T].
 func (q *Filter8[A, B, C, D, E, F, G, H]) WithRelation(comp Comp, target ecs.Entity) *Filter8[A, B, C, D, E, F, G, H] {
+	if q.compiled.locked {
+		panic("can't modify a registered filter")
+	}
 	q.targetType = comp
 	q.target = target
 	q.compiled.Reset()
@@ -1336,6 +1457,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Register(w *ecs.World) {
 	q.compiled.Compile(w, q.include, q.optional, q.exclude, q.targetType, q.target)
 	q.compiled.cachedFilter = w.Cache().Register(q.compiled.filter)
 	q.compiled.filter = &q.compiled.cachedFilter
+	q.compiled.locked = true
 }
 
 // Unregister the filter from caching.
@@ -1347,6 +1469,7 @@ func (q *Filter8[A, B, C, D, E, F, G, H]) Unregister(w *ecs.World) {
 	} else {
 		panic("can't unregister a filter that is not cached")
 	}
+	q.compiled.locked = false
 }
 
 // Query8 is a generic query iterator for eight components.

--- a/generic/query_test.go
+++ b/generic/query_test.go
@@ -136,6 +136,12 @@ func TestQuery0(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery1(t *testing.T) {
@@ -198,6 +204,13 @@ func TestQuery1(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery2(t *testing.T) {
@@ -266,6 +279,13 @@ func TestQuery2(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery3(t *testing.T) {
@@ -337,6 +357,13 @@ func TestQuery3(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery4(t *testing.T) {
@@ -415,6 +442,13 @@ func TestQuery4(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery5(t *testing.T) {
@@ -499,6 +533,13 @@ func TestQuery5(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery6(t *testing.T) {
@@ -588,6 +629,13 @@ func TestQuery6(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery7(t *testing.T) {
@@ -685,6 +733,13 @@ func TestQuery7(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQuery8(t *testing.T) {
@@ -779,6 +834,13 @@ func TestQuery8(t *testing.T) {
 		trg := q.Relation()
 		assert.Equal(t, targ, trg)
 	}
+
+	filter2.Register(&w)
+	assert.Panics(t, func() { filter2.Optional(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.With(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.Without(T[testStruct0]()) })
+	assert.Panics(t, func() { filter2.WithRelation(T[testRelationA](), targ) })
+	filter2.Unregister(&w)
 }
 
 func TestQueryGeneric(t *testing.T) {


### PR DESCRIPTION
* Prevent modifying registered generic filters
* Don't fully recompile after changing relation target