### PR TITLE
Bugfix: Move relation target when exchanging components

### DIFF
--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -93,7 +93,7 @@ func (a *archetypeNode) CreateArchetype(target Entity, components ...componentTy
 		a.archetypes.Add(archetype{})
 		archIndex := a.archetypes.Len() - 1
 		arch = a.archetypes.Get(archIndex)
-		arch.Init(a, archIndex, true, target, a.relation, components...)
+		arch.Init(a, archIndex, true, target, components...)
 	}
 	a.archetypeMap[target] = arch
 	return arch
@@ -281,7 +281,7 @@ type archetype struct {
 }
 
 // Init initializes an archetype
-func (a *archetype) Init(node *archetypeNode, index int32, forStorage bool, relation Entity, relationComp int8, components ...componentType) {
+func (a *archetype) Init(node *archetypeNode, index int32, forStorage bool, relation Entity, components ...componentType) {
 	var mask Mask
 	if !node.IsActive() {
 		node.Ids = make([]ID, len(components))
@@ -337,7 +337,7 @@ func (a *archetype) Init(node *archetypeNode, index int32, forStorage bool, rela
 		entityPointer:     a.entityBuffer.Addr().UnsafePointer(),
 		Mask:              mask,
 		Relation:          relation,
-		RelationComponent: relationComp,
+		RelationComponent: node.relation,
 	}
 
 	a.graphNode = node

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -204,6 +204,8 @@ func (a *archetypeNode) UpdateStats(stats *stats.NodeStats, reg *componentRegist
 	}
 
 	stats.IsActive = true
+	stats.ArchetypeCount = int(cntNew)
+	stats.ActiveArchetypeCount = int(cntNew) - len(a.freeIndices)
 	stats.Capacity = cap
 	stats.Size = count
 	stats.Memory = memory

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -15,7 +15,7 @@ func TestArchetype(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 0, false, Entity{}, -1, comps...)
+	arch.Init(&node, 0, false, Entity{}, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -73,11 +73,11 @@ func TestNewArchetype(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 0, true, Entity{}, -1, comps...)
+	arch.Init(&node, 0, true, Entity{}, comps...)
 	assert.Equal(t, 32, int(arch.Cap()))
 
 	arch = archetype{}
-	arch.Init(&node, 0, false, Entity{}, -1, comps...)
+	arch.Init(&node, 0, false, Entity{}, comps...)
 	assert.Equal(t, 1, int(arch.Cap()))
 
 	comps = []componentType{
@@ -87,7 +87,7 @@ func TestNewArchetype(t *testing.T) {
 	assert.Panics(t, func() {
 		node := newArchetypeNode(All(0, 1), -1, 32)
 		arch := archetype{}
-		arch.Init(&node, 0, true, Entity{}, -1, comps...)
+		arch.Init(&node, 0, true, Entity{}, comps...)
 	})
 }
 
@@ -99,7 +99,7 @@ func TestArchetypeExtend(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 8)
 	arch := archetype{}
-	arch.Init(&node, 0, true, Entity{}, -1, comps...)
+	arch.Init(&node, 0, true, Entity{}, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -121,7 +121,7 @@ func TestArchetypeAlloc(t *testing.T) {
 	}
 	node := newArchetypeNode(All(0, 1), -1, 8)
 	arch := archetype{}
-	arch.Init(&node, 0, true, Entity{}, -1, comps...)
+	arch.Init(&node, 0, true, Entity{}, comps...)
 
 	assert.Equal(t, 8, int(arch.Cap()))
 	assert.Equal(t, 0, int(arch.Len()))
@@ -146,7 +146,7 @@ func TestArchetypeAddGetSet(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 1)
 	a := archetype{}
-	a.Init(&node, 0, true, Entity{}, -1, comps...)
+	a.Init(&node, 0, true, Entity{}, comps...)
 
 	assert.Equal(t, 1, int(a.Cap()))
 	assert.Equal(t, 0, int(a.Len()))
@@ -181,7 +181,7 @@ func TestArchetypeReset(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 0, false, Entity{}, -1, comps...)
+	arch.Init(&node, 0, false, Entity{}, comps...)
 
 	arch.Add(
 		newEntity(0),
@@ -227,7 +227,7 @@ func TestArchetypeZero(t *testing.T) {
 
 	node := newArchetypeNode(All(0, 1), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 0, false, Entity{}, -1, comps...)
+	arch.Init(&node, 0, false, Entity{}, comps...)
 
 	arch.Alloc(newEntity(0))
 	arch.Alloc(newEntity(1))
@@ -259,7 +259,7 @@ func BenchmarkIterArchetype_1000(b *testing.B) {
 
 	node := newArchetypeNode(All(0), -1, 32)
 	arch := archetype{}
-	arch.Init(&node, 0, true, Entity{}, -1, comps...)
+	arch.Init(&node, 0, true, Entity{}, comps...)
 
 	for i := 0; i < 1000; i++ {
 		arch.Alloc(newEntity(eid(i)))

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -902,6 +902,43 @@ func TestWorldRelationCreate(t *testing.T) {
 	})
 }
 
+func TestWorldRelationMove(t *testing.T) {
+	world := NewWorld()
+	world.SetListener(func(e *EntityEvent) {})
+
+	relID := ComponentID[testRelationA](&world)
+	posID := ComponentID[Position](&world)
+
+	target1 := world.NewEntity()
+	target2 := world.NewEntity()
+
+	entities := []Entity{}
+	for _, trg := range [...]Entity{target1, target2} {
+		query := NewBuilder(&world, relID).WithRelation(relID).NewQuery(100, trg)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+	}
+
+	for _, e := range entities {
+		world.Add(e, posID)
+	}
+
+	for i, e := range entities {
+		trg := world.Relations().Get(e, relID)
+
+		if i < 100 {
+			assert.Equal(t, target1, trg)
+		} else {
+			assert.Equal(t, target2, trg)
+		}
+	}
+
+	for _, e := range entities {
+		world.Remove(e, relID)
+	}
+}
+
 func TestWorldLock(t *testing.T) {
 	world := NewWorld()
 
@@ -1148,23 +1185,23 @@ func TestArchetypeGraph(t *testing.T) {
 	rotID := ComponentID[rotation](&world)
 
 	archEmpty := world.archetypes.Get(0)
-	arch0 := world.findOrCreateArchetype(archEmpty, []ID{posID, velID}, []ID{}, Entity{}, -1)
-	archEmpty2 := world.findOrCreateArchetype(arch0, []ID{}, []ID{velID, posID}, Entity{}, -1)
+	arch0 := world.findOrCreateArchetype(archEmpty, []ID{posID, velID}, []ID{}, Entity{})
+	archEmpty2 := world.findOrCreateArchetype(arch0, []ID{}, []ID{velID, posID}, Entity{})
 	assert.Equal(t, archEmpty, archEmpty2)
 	assert.Equal(t, int32(2), world.archetypes.Len())
 	assert.Equal(t, int32(3), world.graph.Len())
 
-	archEmpty3 := world.findOrCreateArchetype(arch0, []ID{}, []ID{posID, velID}, Entity{}, -1)
+	archEmpty3 := world.findOrCreateArchetype(arch0, []ID{}, []ID{posID, velID}, Entity{})
 	assert.Equal(t, archEmpty, archEmpty3)
 	assert.Equal(t, int32(2), world.archetypes.Len())
 	assert.Equal(t, int32(4), world.graph.Len())
 
-	arch01 := world.findOrCreateArchetype(arch0, []ID{velID}, []ID{}, Entity{}, -1)
-	arch012 := world.findOrCreateArchetype(arch01, []ID{rotID}, []ID{}, Entity{}, -1)
+	arch01 := world.findOrCreateArchetype(arch0, []ID{velID}, []ID{}, Entity{})
+	arch012 := world.findOrCreateArchetype(arch01, []ID{rotID}, []ID{}, Entity{})
 
 	assert.Equal(t, []ID{0, 1, 2}, arch012.graphNode.Ids)
 
-	archEmpty4 := world.findOrCreateArchetype(arch012, []ID{}, []ID{posID, rotID, velID}, Entity{}, -1)
+	archEmpty4 := world.findOrCreateArchetype(arch012, []ID{}, []ID{posID, rotID, velID}, Entity{})
 	assert.Equal(t, archEmpty, archEmpty4)
 }
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -906,8 +906,8 @@ func TestWorldRelationMove(t *testing.T) {
 	world := NewWorld()
 	world.SetListener(func(e *EntityEvent) {})
 
-	relID := ComponentID[testRelationA](&world)
 	posID := ComponentID[Position](&world)
+	relID := ComponentID[testRelationA](&world)
 
 	target1 := world.NewEntity()
 	target2 := world.NewEntity()
@@ -922,6 +922,20 @@ func TestWorldRelationMove(t *testing.T) {
 
 	for _, e := range entities {
 		world.Add(e, posID)
+	}
+
+	for i, e := range entities {
+		trg := world.Relations().Get(e, relID)
+
+		if i < 100 {
+			assert.Equal(t, target1, trg)
+		} else {
+			assert.Equal(t, target2, trg)
+		}
+	}
+
+	for _, e := range entities {
+		world.Remove(e, posID)
 	}
 
 	for i, e := range entities {

--- a/examples/relations/main.go
+++ b/examples/relations/main.go
@@ -34,7 +34,12 @@ func run() {
 	parent2 := world.NewEntity()
 
 	// Create an entity with a ChildOf relation to a parent entity.
-	childBuilder.New(parent1)
+	child := childBuilder.New(parent1)
+	// Change the child's relation target.
+	world.Relations().Set(child, childID, parent2)
+	// Get the child's relation target.
+	fmt.Println(world.Relations().Get(child, childID))
+
 	// Create entities with a relation in batches.
 	childBuilder.NewBatch(10, parent1)
 	childBuilder.NewBatch(10, parent2)
@@ -70,7 +75,14 @@ func runGeneric() {
 	parent2 := world.NewEntity()
 
 	// Create an entity with a ChildOf relation to a parent entity.
-	childBuilder.New(parent1)
+	child := childBuilder.New(parent1)
+	// To set or get the relation target via the world, a Map is required.
+	relationMap := generic.NewMap[ChildOf](&world)
+	// Change the child's relation target.
+	relationMap.SetRelation(child, parent2)
+	// Get the child's relation target.
+	fmt.Println(relationMap.GetRelation(child))
+
 	// Create entities with a relation in batches.
 	childBuilder.NewBatch(10, parent1)
 	childBuilder.NewBatch(10, parent2)


### PR DESCRIPTION
* Relation target got lost when moving between nodes/archetypes.
* Update archetype count in node stats update