### PR TITLE
Batch-exchange and add with target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * Archetypes with entity relations are removed on `World.Reset` (#247)
 * Capacity increment can be configured separately for relation archetypes (#257)
 * Adds methods for faster, unchecked entity relation access (#259)
+* Re-introduce `World.Batch` for batch-processing of entities (add/remove/exchange) (#264)
+* New method `Builder.Add` for adding components with a target to entities (#264)
 
 ### Performance
 

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -59,7 +59,7 @@ func (a *archetypeNode) Archetypes() archetypes {
 	if a.archetype == nil {
 		return nil
 	}
-	return batchArchetype{Archetype: a.archetype, StartIndex: 0}
+	return singleArchetype{Archetype: a.archetype}
 }
 
 // GetArchetype returns the archetype for the given relation target.

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -357,13 +357,13 @@ func (a *archetype) Alloc(entity Entity) uintptr {
 	return idx
 }
 
-// Add adds storage to the archetype
+// AllocN allocates storage for the given number of entities.
 func (a *archetype) AllocN(count uint32) {
 	a.extend(count)
 	a.len += count
 }
 
-// Add adds an entity with components to the archetype
+// Add adds an entity with components to the archetype.
 func (a *archetype) Add(entity Entity, components ...Component) uintptr {
 	if len(components) != len(a.graphNode.Ids) {
 		panic("Invalid number of components")

--- a/ecs/archetypes.go
+++ b/ecs/archetypes.go
@@ -17,8 +17,11 @@ type archetypes interface {
 //
 // Used for the [Query] returned by entity batch creation methods.
 type batchArchetype struct {
-	Archetype  *archetype
-	StartIndex uint32
+	Archetype    *archetype
+	StartIndex   uint32
+	OldArchetype *archetype
+	Added        []ID
+	Removed      []ID
 }
 
 // Get returns the value at the given index.

--- a/ecs/archetypes.go
+++ b/ecs/archetypes.go
@@ -14,11 +14,28 @@ type archetypes interface {
 
 // Implementation of an archetype iterator for a single archetype.
 // Implements [archetypes].
+type singleArchetype struct {
+	Archetype *archetype
+}
+
+// Get returns the value at the given index.
+func (s singleArchetype) Get(index int32) *archetype {
+	return s.Archetype
+}
+
+// Len returns the current number of items in the paged array.
+func (s singleArchetype) Len() int32 {
+	return 1
+}
+
+// Implementation of an archetype iterator for a single archetype and partial iteration.
+// Implements [archetypes].
 //
 // Used for the [Query] returned by entity batch creation methods.
 type batchArchetype struct {
 	Archetype    *archetype
 	StartIndex   uint32
+	EndIndex     uint32
 	OldArchetype *archetype
 	Added        []ID
 	Removed      []ID

--- a/ecs/archetypes.go
+++ b/ecs/archetypes.go
@@ -35,7 +35,6 @@ func (s singleArchetype) Len() int32 {
 type batchArchetype struct {
 	Archetype    *archetype
 	StartIndex   uint32
-	EndIndex     uint32
 	OldArchetype *archetype
 	Added        []ID
 	Removed      []ID

--- a/ecs/batch.go
+++ b/ecs/batch.go
@@ -1,0 +1,60 @@
+package ecs
+
+// Batch is a helper to perform batched operations on the world.
+//
+// Create using [World.Batch].
+type Batch struct {
+	world *World
+}
+
+// Add adds components to many entities, matching a filter.
+//
+// If the callback argument is given, it is called with a [Query] over the affected entities,
+// one Query for each affected archetype.
+//
+// Panics:
+//   - when called with components that can't be added because they are already present.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [World.Exchange].
+func (b *Batch) Add(filter Filter, callback func(Query), comps ...ID) {
+	b.world.exchangeBatch(filter, comps, nil, callback)
+}
+
+// Remove removes components from many entities, matching a filter.
+//
+// If the callback argument is given, it is called with a [Query] over the affected entities,
+// one Query for each affected archetype.
+//
+// Panics:
+//   - when called with components that can't be removed because they are not present.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [World.Exchange].
+func (b *Batch) Remove(filter Filter, callback func(Query), comps ...ID) {
+	b.world.exchangeBatch(filter, nil, comps, callback)
+}
+
+// Exchange exchanges components for many entities, matching a filter.
+//
+// If the callback argument is given, it is called with a [Query] over the affected entities,
+// one Query for each affected archetype.
+//
+// Panics:
+//   - when called with components that can't be added or removed because they are already present/not present, respectively.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [World.Exchange].
+func (b *Batch) Exchange(filter Filter, add []ID, rem []ID, callback func(Query)) {
+	b.world.exchangeBatch(filter, add, rem, callback)
+}
+
+// RemoveEntities removes and recycles all entities matching a filter.
+//
+// Returns the number of removed entities.
+//
+// Panics when called on a locked world.
+// Do not use during [Query] iteration!
+func (b *Batch) RemoveEntities(filter Filter) int {
+	return b.world.removeEntities(filter)
+}

--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -45,7 +45,7 @@ func (b *Builder) WithRelation(comp ID) *Builder {
 func (b *Builder) New(target ...Entity) Entity {
 	if len(target) > 0 {
 		if !b.hasTarget {
-			panic("entity builder has no target")
+			panic("can't set target entity: builder has no relation")
 		}
 		if b.comps == nil {
 			return b.world.newEntityTarget(b.targetID, target[0], b.ids...)
@@ -65,7 +65,7 @@ func (b *Builder) New(target ...Entity) Entity {
 func (b *Builder) NewBatch(count int, target ...Entity) {
 	if len(target) > 0 {
 		if !b.hasTarget {
-			panic("entity builder has no target")
+			panic("can't set target entity: builder has no relation")
 		}
 		if b.comps == nil {
 			b.world.newEntities(count, int8(b.targetID), target[0], b.ids...)
@@ -88,7 +88,7 @@ func (b *Builder) NewBatch(count int, target ...Entity) {
 func (b *Builder) NewQuery(count int, target ...Entity) Query {
 	if len(target) > 0 {
 		if !b.hasTarget {
-			panic("entity builder has no target")
+			panic("can't set target entity: builder has no relation")
 		}
 		if b.comps == nil {
 			return b.world.newEntitiesQuery(count, int8(b.targetID), target[0], b.ids...)
@@ -99,4 +99,27 @@ func (b *Builder) NewQuery(count int, target ...Entity) Query {
 		return b.world.newEntitiesQuery(count, -1, Entity{}, b.ids...)
 	}
 	return b.world.newEntitiesWithQuery(count, -1, Entity{}, b.comps...)
+}
+
+// Add the builder's components to an entity.
+//
+// The optional argument can be used to set the target [Entity] for the Builder's [Relation].
+// See [Builder.WithRelation].
+func (b *Builder) Add(entity Entity, target ...Entity) {
+	if len(target) > 0 {
+		if !b.hasTarget {
+			panic("can't set target entity: builder has no relation")
+		}
+		if b.comps == nil {
+			b.world.exchange(entity, b.ids, nil, int8(b.targetID), target[0])
+			return
+		}
+		b.world.assign(entity, int8(b.targetID), target[0], b.comps...)
+		return
+	}
+	if b.comps == nil {
+		b.world.Exchange(entity, b.ids, nil)
+		return
+	}
+	b.world.Assign(entity, b.comps...)
 }

--- a/ecs/builder_test.go
+++ b/ecs/builder_test.go
@@ -21,9 +21,13 @@ func TestBuilder(t *testing.T) {
 	assert.True(t, w.Has(e1, posID))
 	assert.True(t, w.Has(e1, velID))
 
+	e2 := w.NewEntity()
+	b1.Add(e2)
+
 	assert.Panics(t, func() { b1.New(target) })
 	assert.Panics(t, func() { b1.NewBatch(10, target) })
 	assert.Panics(t, func() { b1.NewQuery(10, target) })
+	assert.Panics(t, func() { b1.Add(e1, target) })
 
 	b1.NewBatch(10)
 	q := b1.NewQuery(10)
@@ -35,9 +39,14 @@ func TestBuilder(t *testing.T) {
 	e1 = b1.New()
 	assert.True(t, w.Has(e1, posID))
 
+	e2 = w.NewEntity()
+	b1.Add(e2)
+	e2 = w.NewEntity()
+
 	assert.Panics(t, func() { b1.New(target) })
 	assert.Panics(t, func() { b1.NewBatch(10, target) })
 	assert.Panics(t, func() { b1.NewQuery(10, target) })
+	assert.Panics(t, func() { b1.Add(e2, target) })
 
 	b1.NewBatch(10)
 	q = b1.NewQuery(10)
@@ -47,7 +56,11 @@ func TestBuilder(t *testing.T) {
 	b1 = NewBuilder(&w, posID, velID, relID).WithRelation(relID)
 
 	b1.New()
-	e2 := b1.New(target)
+	e2 = b1.New(target)
+	assert.Equal(t, target, w.Relations().Get(e2, relID))
+
+	e2 = w.NewEntity()
+	b1.Add(e2, target)
 	assert.Equal(t, target, w.Relations().Get(e2, relID))
 
 	b1.NewBatch(10, target)
@@ -64,6 +77,10 @@ func TestBuilder(t *testing.T) {
 
 	b1.New()
 	e2 = b1.New(target)
+	assert.Equal(t, target, w.Relations().Get(e2, relID))
+
+	e2 = w.NewEntity()
+	b1.Add(e2, target)
 	assert.Equal(t, target, w.Relations().Get(e2, relID))
 
 	b1.NewBatch(10, target)

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -66,9 +66,9 @@ func newArchQuery(world *World, lockBit uint8, archetype batchArchetype) Query {
 			access:         &arch.archetypeAccess,
 			archIndex:      0,
 			lockBit:        lockBit,
-			count:          int32(archetype.EndIndex - archetype.StartIndex),
+			count:          int32(arch.Len() - archetype.StartIndex),
 			entityIndex:    uintptr(archetype.StartIndex - 1),
-			entityIndexMax: uintptr(archetype.EndIndex - 1),
+			entityIndexMax: uintptr(arch.Len() - 1),
 		}
 	}
 	return Query{
@@ -78,7 +78,7 @@ func newArchQuery(world *World, lockBit uint8, archetype batchArchetype) Query {
 		archetypes: archetype,
 		archIndex:  -1,
 		lockBit:    lockBit,
-		count:      int32(archetype.EndIndex),
+		count:      int32(arch.Len()),
 	}
 }
 
@@ -200,10 +200,6 @@ func (q *Query) nextArchetypeSimple() bool {
 		if a.IsActive() && (q.isFiltered || a.Matches(q.filter)) && aLen > 0 {
 			q.access = &a.archetypeAccess
 			q.entityIndex = 0
-			if batch, ok := q.archetypes.(batchArchetype); ok {
-				q.entityIndexMax = uintptr(batch.EndIndex) - 1
-				return true
-			}
 			q.entityIndexMax = uintptr(aLen) - 1
 			return true
 		}

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -66,9 +66,9 @@ func newArchQuery(world *World, lockBit uint8, archetype batchArchetype) Query {
 			access:         &arch.archetypeAccess,
 			archIndex:      0,
 			lockBit:        lockBit,
-			count:          int32(arch.Len() - archetype.StartIndex),
+			count:          int32(archetype.EndIndex - archetype.StartIndex),
 			entityIndex:    uintptr(archetype.StartIndex - 1),
-			entityIndexMax: uintptr(arch.Len()) - 1,
+			entityIndexMax: uintptr(archetype.EndIndex - 1),
 		}
 	}
 	return Query{
@@ -78,7 +78,7 @@ func newArchQuery(world *World, lockBit uint8, archetype batchArchetype) Query {
 		archetypes: archetype,
 		archIndex:  -1,
 		lockBit:    lockBit,
-		count:      int32(arch.Len()),
+		count:      int32(archetype.EndIndex),
 	}
 }
 
@@ -200,6 +200,10 @@ func (q *Query) nextArchetypeSimple() bool {
 		if a.IsActive() && (q.isFiltered || a.Matches(q.filter)) && aLen > 0 {
 			q.access = &a.archetypeAccess
 			q.entityIndex = 0
+			if batch, ok := q.archetypes.(batchArchetype); ok {
+				q.entityIndexMax = uintptr(batch.EndIndex) - 1
+				return true
+			}
 			q.entityIndexMax = uintptr(aLen) - 1
 			return true
 		}

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -55,29 +55,30 @@ func newArchesQuery(world *World, filter Filter, lockBit uint8, archetypes arche
 }
 
 // newQuery creates a query on a single archetype
-func newArchQuery(world *World, lockBit uint8, archetype *archetype, start uint32) Query {
-	if start > 0 {
+func newArchQuery(world *World, lockBit uint8, archetype batchArchetype) Query {
+	arch := archetype.Archetype
+	if archetype.StartIndex > 0 {
 		return Query{
 			filter:         nil,
 			isFiltered:     true,
 			world:          world,
-			archetypes:     batchArchetype{archetype, start},
-			access:         &archetype.archetypeAccess,
+			archetypes:     archetype,
+			access:         &arch.archetypeAccess,
 			archIndex:      0,
 			lockBit:        lockBit,
-			count:          int32(archetype.Len() - start),
-			entityIndex:    uintptr(start - 1),
-			entityIndexMax: uintptr(archetype.Len()) - 1,
+			count:          int32(arch.Len() - archetype.StartIndex),
+			entityIndex:    uintptr(archetype.StartIndex - 1),
+			entityIndexMax: uintptr(arch.Len()) - 1,
 		}
 	}
 	return Query{
 		filter:     nil,
 		isFiltered: true,
 		world:      world,
-		archetypes: batchArchetype{archetype, start},
+		archetypes: archetype,
 		archIndex:  -1,
 		lockBit:    lockBit,
-		count:      int32(archetype.Len()),
+		count:      int32(arch.Len()),
 	}
 }
 

--- a/ecs/relation_stress_test.go
+++ b/ecs/relation_stress_test.go
@@ -44,7 +44,7 @@ func TestRelationStress(t *testing.T) {
 				Filter: ecs.All(relID),
 				Target: parent,
 			}
-			removed := world.RemoveEntities(&childFilter)
+			removed := world.Batch().RemoveEntities(&childFilter)
 			world.RemoveEntity(parent)
 			assert.Equal(t, numChildren, removed)
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -271,7 +271,7 @@ func (w *World) newEntities(count int, targetID int8, target Entity, comps ...ID
 func (w *World) newEntitiesQuery(count int, targetID int8, target Entity, comps ...ID) Query {
 	arch, startIdx := w.newEntitiesNoNotify(count, targetID, target, comps...)
 	lock := w.lock()
-	return newArchQuery(w, lock, batchArchetype{arch, startIdx, arch.Len(), nil, arch.Components(), nil})
+	return newArchQuery(w, lock, batchArchetype{arch, startIdx, nil, arch.Components(), nil})
 }
 
 // Creates new entities with component values without returning a query over them.
@@ -307,7 +307,7 @@ func (w *World) newEntitiesWithQuery(count int, targetID int8, target Entity, co
 
 	arch, startIdx := w.newEntitiesWithNoNotify(count, targetID, target, ids, comps...)
 	lock := w.lock()
-	return newArchQuery(w, lock, batchArchetype{arch, startIdx, arch.Len(), nil, arch.Components(), nil})
+	return newArchQuery(w, lock, batchArchetype{arch, startIdx, nil, arch.Components(), nil})
 }
 
 // RemoveEntity removes and recycles an [Entity].
@@ -657,11 +657,11 @@ func (w *World) exchangeBatch(filter Filter, add []ID, rem []ID, callback func(Q
 		newArch, start := w.exchangeArch(arch, archLen, add, rem)
 		if callback == nil {
 			if w.listener != nil {
-				w.notifyQuery(&batchArchetype{newArch, start, start + archLen, arch, add, rem})
+				w.notifyQuery(&batchArchetype{newArch, start, arch, add, rem})
 			}
 		} else {
 			lock := w.lock()
-			query := newArchQuery(w, lock, batchArchetype{newArch, start, start + archLen, arch, add, rem})
+			query := newArchQuery(w, lock, batchArchetype{newArch, start, arch, add, rem})
 			callback(query)
 		}
 	}
@@ -1327,7 +1327,7 @@ func (w *World) notifyQuery(batchArch *batchArchetype) {
 		event.AddedRemoved = 0
 	}
 
-	start, end := uintptr(batchArch.StartIndex), uintptr(batchArch.EndIndex)
+	start, end := uintptr(batchArch.StartIndex), uintptr(arch.Len())
 	for i = start; i < end; i++ {
 		entity := arch.GetEntity(i)
 		event.Entity = entity

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -161,7 +161,7 @@ func BenchmarkRemoveEntitiesBatch_10_000(b *testing.B) {
 		q := world.newEntitiesQuery(10000, -1, Entity{}, posID, velID)
 		q.Close()
 		b.StartTimer()
-		world.RemoveEntities(All(posID, velID))
+		world.Batch().RemoveEntities(All(posID, velID))
 	}
 }
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -215,6 +215,8 @@ func TestWorldExchange(t *testing.T) {
 	posID := ComponentID[Position](&w)
 	velID := ComponentID[Velocity](&w)
 	rotID := ComponentID[rotation](&w)
+	rel1ID := ComponentID[testRelationA](&w)
+	rel2ID := ComponentID[testRelationB](&w)
 
 	e0 := w.NewEntity()
 	e1 := w.NewEntity()
@@ -252,6 +254,15 @@ func TestWorldExchange(t *testing.T) {
 	w.RemoveEntity(e0)
 	_ = w.NewEntity()
 	assert.Panics(t, func() { w.Exchange(e0, []ID{posID}, []ID{}) })
+
+	target := w.NewEntity()
+	e0 = w.NewEntity(rel1ID)
+
+	assert.Panics(t, func() { w.exchange(e0, []ID{rel2ID}, nil, int8(rel2ID), target) })
+	assert.Panics(t, func() { w.exchange(e0, []ID{posID}, nil, int8(posID), target) })
+
+	w.Remove(e0, rel1ID)
+	assert.Panics(t, func() { w.exchange(e0, []ID{posID}, nil, int8(rel1ID), target) })
 }
 
 func TestWorldExchangeBatch(t *testing.T) {

--- a/examples/batch_ops/main.go
+++ b/examples/batch_ops/main.go
@@ -52,11 +52,11 @@ func run() {
 
 	// Batch-remove all entities with exactly the given components.
 	filterExcl := ecs.All(posID, velID).Exclusive()
-	world.RemoveEntities(&filterExcl)
+	world.Batch().RemoveEntities(&filterExcl)
 
 	// Batch-remove all entities with the given components (and potentially further components).
 	filter := ecs.All(posID, velID)
-	world.RemoveEntities(&filter)
+	world.Batch().RemoveEntities(&filter)
 }
 
 // Uses the type-safe generic API.

--- a/examples/batch_ops/main.go
+++ b/examples/batch_ops/main.go
@@ -1,4 +1,4 @@
-// Demonstrates batch-creation and batch-removal of entities.
+// Demonstrates batch-creation, manipulation and removal of entities.
 //
 // Batch operations are an optimization for creating and removing many entities in one go.
 package main
@@ -49,6 +49,11 @@ func run() {
 		pos.X = 1.0
 		pos.Y = 1.0
 	}
+
+	// Batch-remove components.
+	world.Batch().Remove(ecs.All(posID, velID), nil, velID)
+	// Batch-add components.
+	world.Batch().Add(ecs.All(posID), nil, velID)
 
 	// Batch-remove all entities with exactly the given components.
 	filterExcl := ecs.All(posID, velID).Exclusive()

--- a/generic/generate/map.go.txt
+++ b/generic/generate/map.go.txt
@@ -163,7 +163,7 @@ func (m *Map{{ .Index }}{{ .Types }}) Remove(entity ecs.Entity) {
 func (m *Map{{ .Index }}{{ .Types }}) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -167,9 +167,9 @@ func (m *Map1[A]) Remove(entity ecs.Entity) {
 func (m *Map1[A]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -343,9 +343,9 @@ func (m *Map2[A, B]) Remove(entity ecs.Entity) {
 func (m *Map2[A, B]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -527,9 +527,9 @@ func (m *Map3[A, B, C]) Remove(entity ecs.Entity) {
 func (m *Map3[A, B, C]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -719,9 +719,9 @@ func (m *Map4[A, B, C, D]) Remove(entity ecs.Entity) {
 func (m *Map4[A, B, C, D]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -919,9 +919,9 @@ func (m *Map5[A, B, C, D, E]) Remove(entity ecs.Entity) {
 func (m *Map5[A, B, C, D, E]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1127,9 +1127,9 @@ func (m *Map6[A, B, C, D, E, F]) Remove(entity ecs.Entity) {
 func (m *Map6[A, B, C, D, E, F]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1343,9 +1343,9 @@ func (m *Map7[A, B, C, D, E, F, G]) Remove(entity ecs.Entity) {
 func (m *Map7[A, B, C, D, E, F, G]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1567,7 +1567,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) Remove(entity ecs.Entity) {
 func (m *Map8[A, B, C, D, E, F, G, H]) RemoveEntities(exclusive bool) int {
 	if exclusive {
 		filter := m.mask.Exclusive()
-		return m.world.RemoveEntities(&filter)
+		return m.world.Batch().RemoveEntities(&filter)
 	}
-	return m.world.RemoveEntities(m.mask)
+	return m.world.Batch().RemoveEntities(m.mask)
 }


### PR DESCRIPTION
* Re-introduce `World.Batch` for batch-processing of entities (add/remove/exchange)
* New method `Builder.Add` for adding components with a target to entities

Fixes #263