### PR TITLE
Optimize archetype iteration

### DIFF
--- a/benchmark/arche/common/components.go
+++ b/benchmark/arche/common/components.go
@@ -11,6 +11,10 @@ type Rotation struct {
 	Angle int
 }
 
+type ChildOf struct {
+	ecs.Relation
+}
+
 type TestStruct0 struct{ Val int32 }
 type TestStruct1 struct{ Val int32 }
 type TestStruct2 struct{ Val int32 }

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -7,16 +7,27 @@ import (
 )
 
 func TestFilterCache(t *testing.T) {
-	cache := newCache()
-	cache.getArchetypes = getArchetypes
+	world := NewWorld()
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+	rotID := ComponentID[rotation](&world)
 
-	all1 := All(0, 1)
-	all2 := All(0, 1, 2)
+	cache := world.Cache()
+
+	world.NewEntity()
+	world.NewEntity(posID, velID)
+	world.NewEntity(posID, velID, rotID)
+
+	all1 := All(posID, velID)
+	all2 := All(posID, velID, rotID)
 
 	f1 := cache.Register(all1)
 	f2 := cache.Register(all2)
 	assert.Equal(t, 0, int(f1.id))
 	assert.Equal(t, 1, int(f2.id))
+
+	assert.Equal(t, 2, len(world.getArchetypes(&f1).pointers))
+	assert.Equal(t, 1, len(world.getArchetypes(&f2).pointers))
 
 	assert.Panics(t, func() { cache.Register(&f2) })
 
@@ -34,10 +45,6 @@ func TestFilterCache(t *testing.T) {
 
 	assert.Panics(t, func() { cache.Unregister(&f1) })
 	assert.Panics(t, func() { cache.get(&f1) })
-}
-
-func getArchetypes(f Filter) archetypePointers {
-	return archetypePointers{}
 }
 
 func ExampleCache() {

--- a/ecs/filter.go
+++ b/ecs/filter.go
@@ -32,6 +32,8 @@ type relationFilter struct {
 // RelationFilter creates a new [Relation] filter.
 // It is a [Filter] for a [Relation] target, in addition to components.
 //
+// Logic filters ignore relation targets. Thus, a relation filter should be the outermost filter.
+//
 // See [Relation] for details and examples.
 func RelationFilter(filter Filter, target Entity) Filter {
 	return &relationFilter{

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -217,7 +217,7 @@ func (q *Query) nextArchetypeSimple() bool {
 		q.archIndex++
 		a := q.archetypes.Get(q.archIndex)
 		aLen := a.Len()
-		if a.Matches(q.filter) && aLen > 0 {
+		if aLen > 0 {
 			q.access = &a.archetypeAccess
 			q.entityIndex = 0
 			q.entityIndexMax = uintptr(aLen) - 1

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -184,14 +184,14 @@ func (q *Query) nextArchetype() bool {
 	if !q.isFiltered {
 		return q.nextNode()
 	}
-	if q.nextArchetypeFiltered() {
+	if q.nextArchetypeBatch() {
 		return true
 	}
 	q.world.closeQuery(q)
 	return false
 }
 
-func (q *Query) nextArchetypeFiltered() bool {
+func (q *Query) nextArchetypeBatch() bool {
 	len := int32(q.archetypes.Len()) - 1
 	for q.archIndex < len {
 		q.archIndex++

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1332,6 +1332,10 @@ func (w *World) createArchetype(node *archNode, target Entity, forStorage bool) 
 
 // Returns all archetypes that match the given filter. Used by [Cache].
 func (w *World) getArchetypes(filter Filter) archetypePointers {
+	if cached, ok := filter.(*CachedFilter); ok {
+		return w.filterCache.get(cached).Archetypes
+	}
+
 	arches := []*archetype{}
 	ln := w.nodes.Len()
 	var i int32

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1358,7 +1358,7 @@ func (w *World) getArchetypes(filter Filter) archetypePointers {
 		var j int32
 		for j = 0; j < ln2; j++ {
 			a := nodeArches.Get(j)
-			if a.IsActive() && a.Matches(filter) {
+			if a.IsActive() {
 				arches = append(arches, a)
 			}
 		}

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -375,10 +375,6 @@ func (w *World) removeEntities(filter Filter) int {
 	for i = 0; i < numArches; i++ {
 		arch := arches.Get(i)
 
-		if !arch.IsActive() {
-			continue
-		}
-
 		len := uintptr(arch.Len())
 		count += len
 

--- a/filter/doc.go
+++ b/filter/doc.go
@@ -1,4 +1,6 @@
 // Package filter contains Arche's advanced logic filtering API.
 //
+// Logic filters ignore relation targets. Thus, a relation filter should be the outermost filter.
+//
 // See the top level module [github.com/mlange-42/arche] for an overview.
 package filter

--- a/filter/filter.go
+++ b/filter/filter.go
@@ -20,7 +20,7 @@ func Any(comps ...ecs.ID) ANY {
 }
 
 // Matches matches a filter against a bitmask
-func (f ANY) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
+func (f ANY) Matches(bits ecs.Mask, target *ecs.Entity) bool {
 	return bits.ContainsAny(ecs.Mask(f))
 }
 
@@ -33,7 +33,7 @@ func NoneOf(comps ...ecs.ID) NoneOF {
 }
 
 // Matches matches a filter against a bitmask
-func (f NoneOF) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
+func (f NoneOF) Matches(bits ecs.Mask, target *ecs.Entity) bool {
 	return !bits.ContainsAny(ecs.Mask(f))
 }
 
@@ -46,59 +46,73 @@ func AnyNot(comps ...ecs.ID) AnyNOT {
 }
 
 // Matches matches a filter against a bitmask
-func (f AnyNOT) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
+func (f AnyNOT) Matches(bits ecs.Mask, target *ecs.Entity) bool {
 	return !bits.Contains(ecs.Mask(f))
 }
 
 // AND combines two filters using AND.
+//
+// Ignores potential relation targets.
 type AND struct {
 	L ecs.Filter
 	R ecs.Filter
 }
 
 // And combines two filters using AND.
+//
+// Ignores potential relation targets.
 func And(l, r ecs.Filter) *AND {
 	return &AND{L: l, R: r}
 }
 
-// Matches matches a filter against a bitmask
-func (f *AND) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
-	return f.L.Matches(bits, relation) && f.R.Matches(bits, relation)
+// Matches matches a filter against a bitmask.
+func (f *AND) Matches(bits ecs.Mask, target *ecs.Entity) bool {
+	return f.L.Matches(bits, nil) && f.R.Matches(bits, nil)
 }
 
 // OR combines two filters using OR.
+//
+// Ignores potential relation targets.
 type OR struct {
 	L ecs.Filter
 	R ecs.Filter
 }
 
 // Or combines two filters using OR.
+//
+// Ignores potential relation targets.
 func Or(l, r ecs.Filter) *OR {
 	return &OR{L: l, R: r}
 }
 
-// Matches matches a filter against a bitmask
-func (f *OR) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
-	return f.L.Matches(bits, relation) || f.R.Matches(bits, relation)
+// Matches matches a filter against a bitmask.
+func (f *OR) Matches(bits ecs.Mask, target *ecs.Entity) bool {
+	return f.L.Matches(bits, nil) || f.R.Matches(bits, nil)
 }
 
 // XOR combines two filters using XOR.
+//
+// Ignores potential relation targets.
 type XOR struct {
 	L ecs.Filter
 	R ecs.Filter
 }
 
 // XOr combines two filters using XOR.
+//
+// Ignores potential relation targets.
 func XOr(l, r ecs.Filter) *XOR {
 	return &XOR{L: l, R: r}
 }
 
-// Matches matches a filter against a bitmask
-func (f *XOR) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
-	return f.L.Matches(bits, relation) != f.R.Matches(bits, relation)
+// Matches matches a filter against a bitmask.
+func (f *XOR) Matches(bits ecs.Mask, target *ecs.Entity) bool {
+	return f.L.Matches(bits, nil) != f.R.Matches(bits, nil)
 }
 
 // NOT inverts a filter. It matches if the inner filter does not.
+//
+// Does NOT ignore a potential relation target.
 type NOT struct {
 	F ecs.Filter
 }
@@ -108,7 +122,7 @@ func Not(f ecs.Filter) *NOT {
 	return &NOT{F: f}
 }
 
-// Matches matches a filter against a bitmask
-func (f *NOT) Matches(bits ecs.Mask, relation *ecs.Entity) bool {
-	return !f.F.Matches(bits, relation)
+// Matches matches a filter against a bitmask.
+func (f *NOT) Matches(bits ecs.Mask, target *ecs.Entity) bool {
+	return !f.F.Matches(bits, target)
 }


### PR DESCRIPTION
* Don't check relation archetype match if not a relation filter
* Relation filters can only be outermost filter (except for `CachedFilter`)
* Add benchmarks for iteration over many targets, fix 1k arches benchmarks

TODO

* [x] ~~Cache stores nodes instead of archetypes?~~ Tracked in #274
   * Could be more efficient, as iterating archetypes in a node seems faster than iterating the prepared list of archetypes now