### PR TITLE
Use for loop with counter in AoS competition benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * Generic filters are locked when registered for caching (#241)
 * Adds benchmarks for getting and setting entity relations (#259)
 * Arche now has an official logo (#273)
+* Use for loop with counter in AoS competition benchmarks, to allow for pointers (284)
 
 ## [[v0.7.1]](https://github.com/mlange-42/arche/compare/v0.7.0...v0.7.1)
 

--- a/benchmark/arche/relations/child_test.go
+++ b/benchmark/arche/relations/child_test.go
@@ -75,6 +75,10 @@ func BenchmarkRelationChild_1k_100_x_10(b *testing.B) {
 	benchmarkChild(b, 100, 10)
 }
 
+func BenchmarkRelationChild_1k_1000_x_1(b *testing.B) {
+	benchmarkChild(b, 1000, 1)
+}
+
 func BenchmarkRelationChild_10k_10_x_1000(b *testing.B) {
 	benchmarkChild(b, 10, 1000)
 }
@@ -101,6 +105,10 @@ func BenchmarkRelationChild_100k_1000_x_100(b *testing.B) {
 
 func BenchmarkRelationChild_100k_10000_x_10(b *testing.B) {
 	benchmarkChild(b, 10000, 10)
+}
+
+func BenchmarkRelationChild_1M_10_x_100000(b *testing.B) {
+	benchmarkChild(b, 10, 100000)
 }
 
 func BenchmarkRelationChild_1M_100_x_10000(b *testing.B) {

--- a/benchmark/arche/relations/parent_list_test.go
+++ b/benchmark/arche/relations/parent_list_test.go
@@ -80,6 +80,10 @@ func BenchmarkRelationParentList_1k_100_x_10(b *testing.B) {
 	benchmarkParentList(b, 100, 10)
 }
 
+func BenchmarkRelationParentList_1k_1000_x_1(b *testing.B) {
+	benchmarkParentList(b, 1000, 1)
+}
+
 func BenchmarkRelationParentList_10k_10_x_1000(b *testing.B) {
 	benchmarkParentList(b, 10, 1000)
 }
@@ -102,6 +106,10 @@ func BenchmarkRelationParentList_100k_100_x_1000(b *testing.B) {
 
 func BenchmarkRelationParentList_100k_1000_x_100(b *testing.B) {
 	benchmarkParentList(b, 1000, 100)
+}
+
+func BenchmarkRelationParentList_1M_10_x_100000(b *testing.B) {
+	benchmarkParentList(b, 10, 100000)
 }
 
 func BenchmarkRelationParentList_1M_100_x_10000(b *testing.B) {

--- a/benchmark/arche/relations/parent_slice_test.go
+++ b/benchmark/arche/relations/parent_slice_test.go
@@ -74,6 +74,10 @@ func BenchmarkRelationParentSlice_1k_100_x_10(b *testing.B) {
 	benchmarkParentSlice(b, 100, 10)
 }
 
+func BenchmarkRelationParentSlice_1k_1000_x_1(b *testing.B) {
+	benchmarkParentSlice(b, 1000, 1)
+}
+
 func BenchmarkRelationParentSlice_10k_10_x_1000(b *testing.B) {
 	benchmarkParentSlice(b, 10, 1000)
 }
@@ -100,6 +104,10 @@ func BenchmarkRelationParentSlice_100k_1000_x_100(b *testing.B) {
 
 func BenchmarkRelationParentSlice_100k_10000_x_10(b *testing.B) {
 	benchmarkParentSlice(b, 1000, 100)
+}
+
+func BenchmarkRelationParentSlice_1M_10_x_100000(b *testing.B) {
+	benchmarkParentSlice(b, 10, 100000)
 }
 
 func BenchmarkRelationParentSlice_1M_100_x_10000(b *testing.B) {

--- a/benchmark/arche/relations/relation_cached_test.go
+++ b/benchmark/arche/relations/relation_cached_test.go
@@ -88,6 +88,10 @@ func BenchmarkRelationCached_1k_100_x_10(b *testing.B) {
 	benchmarkRelationCached(b, 100, 10)
 }
 
+func BenchmarkRelationCached_1k_1000_x_1(b *testing.B) {
+	benchmarkRelationCached(b, 1000, 1)
+}
+
 func BenchmarkRelationCached_10k_10_x_1000(b *testing.B) {
 	benchmarkRelationCached(b, 10, 1000)
 }
@@ -114,6 +118,10 @@ func BenchmarkRelationCached_100k_1000_x_100(b *testing.B) {
 
 func BenchmarkRelationCached_100k_10000_x_10(b *testing.B) {
 	benchmarkRelationCached(b, 1000, 100)
+}
+
+func BenchmarkRelationCached_1M_10_x_100000(b *testing.B) {
+	benchmarkRelationCached(b, 10, 100000)
 }
 
 func BenchmarkRelationCached_1M_100_x_10000(b *testing.B) {

--- a/benchmark/arche/relations/relation_test.go
+++ b/benchmark/arche/relations/relation_test.go
@@ -83,6 +83,10 @@ func BenchmarkRelation_1k_100_x_10(b *testing.B) {
 	benchmarkRelation(b, 100, 10)
 }
 
+func BenchmarkRelation_1k_1000_x_1(b *testing.B) {
+	benchmarkRelation(b, 1000, 1)
+}
+
 func BenchmarkRelation_10k_10_x_1000(b *testing.B) {
 	benchmarkRelation(b, 10, 1000)
 }
@@ -109,6 +113,10 @@ func BenchmarkRelation_100k_1000_x_100(b *testing.B) {
 
 func BenchmarkRelation_100k_10000_x_10(b *testing.B) {
 	benchmarkRelation(b, 1000, 100)
+}
+
+func BenchmarkRelation_1M_10_x_100000(b *testing.B) {
+	benchmarkRelation(b, 10, 100000)
 }
 
 func BenchmarkRelation_1M_100_x_10000(b *testing.B) {

--- a/benchmark/competition/array_of_structs/arche_test.go
+++ b/benchmark/competition/array_of_structs/arche_test.go
@@ -169,10 +169,6 @@ func BenchmarkArche_16B_100_000(b *testing.B) {
 	runArche16B(b, 100000)
 }
 
-func BenchmarkArche_16B_250_000(b *testing.B) {
-	runArche16B(b, 250000)
-}
-
 func BenchmarkArche_32B_1_000(b *testing.B) {
 	runArche32B(b, 1000)
 }
@@ -183,10 +179,6 @@ func BenchmarkArche_32B_10_000(b *testing.B) {
 
 func BenchmarkArche_32B_100_000(b *testing.B) {
 	runArche32B(b, 100000)
-}
-
-func BenchmarkArche_32B_250_000(b *testing.B) {
-	runArche32B(b, 250000)
 }
 
 func BenchmarkArche_64B_1_000(b *testing.B) {
@@ -201,10 +193,6 @@ func BenchmarkArche_64B_100_000(b *testing.B) {
 	runArche64B(b, 100000)
 }
 
-func BenchmarkArche_64B_250_000(b *testing.B) {
-	runArche64B(b, 250000)
-}
-
 func BenchmarkArche_128B_1_000(b *testing.B) {
 	runArche128B(b, 1000)
 }
@@ -217,10 +205,6 @@ func BenchmarkArche_128B_100_000(b *testing.B) {
 	runArche128B(b, 100000)
 }
 
-func BenchmarkArche_128B_250_000(b *testing.B) {
-	runArche128B(b, 250000)
-}
-
 func BenchmarkArche_256B_1_000(b *testing.B) {
 	runArche256B(b, 1000)
 }
@@ -231,8 +215,4 @@ func BenchmarkArche_256B_10_000(b *testing.B) {
 
 func BenchmarkArche_256B_100_000(b *testing.B) {
 	runArche256B(b, 100000)
-}
-
-func BenchmarkArche_256B_250_000(b *testing.B) {
-	runArche256B(b, 250000)
 }

--- a/benchmark/competition/array_of_structs/array_of_pointers_test.go
+++ b/benchmark/competition/array_of_structs/array_of_pointers_test.go
@@ -14,7 +14,9 @@ func runAoP16B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -31,7 +33,9 @@ func runAoP32B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -48,7 +52,9 @@ func runAoP64B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -65,7 +71,9 @@ func runAoP128B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -82,7 +90,9 @@ func runAoP256B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -101,10 +111,6 @@ func BenchmarkArrOfPointers_16B_100_000(b *testing.B) {
 	runAoP16B(b, 100000)
 }
 
-func BenchmarkArrOfPointers_16B_250_000(b *testing.B) {
-	runAoP16B(b, 250000)
-}
-
 func BenchmarkArrOfPointers_32B_1_000(b *testing.B) {
 	runAoP32B(b, 1000)
 }
@@ -115,10 +121,6 @@ func BenchmarkArrOfPointers_32B_10_000(b *testing.B) {
 
 func BenchmarkArrOfPointers_32B_100_000(b *testing.B) {
 	runAoP32B(b, 100000)
-}
-
-func BenchmarkArrOfPointers_32B_250_000(b *testing.B) {
-	runAoP32B(b, 250000)
 }
 
 func BenchmarkArrOfPointers_64B_1_000(b *testing.B) {
@@ -133,10 +135,6 @@ func BenchmarkArrOfPointers_64B_100_000(b *testing.B) {
 	runAoP64B(b, 100000)
 }
 
-func BenchmarkArrOfPointers_64B_250_000(b *testing.B) {
-	runAoP64B(b, 250000)
-}
-
 func BenchmarkArrOfPointers_128B_1_000(b *testing.B) {
 	runAoP128B(b, 1000)
 }
@@ -149,10 +147,6 @@ func BenchmarkArrOfPointers_128B_100_000(b *testing.B) {
 	runAoP128B(b, 100000)
 }
 
-func BenchmarkArrOfPointers_128B_250_000(b *testing.B) {
-	runAoP128B(b, 250000)
-}
-
 func BenchmarkArrOfPointers_256B_1_000(b *testing.B) {
 	runAoP256B(b, 1000)
 }
@@ -163,8 +157,4 @@ func BenchmarkArrOfPointers_256B_10_000(b *testing.B) {
 
 func BenchmarkArrOfPointers_256B_100_000(b *testing.B) {
 	runAoP256B(b, 100000)
-}
-
-func BenchmarkArrOfPointers_256B_250_000(b *testing.B) {
-	runAoP256B(b, 250000)
 }

--- a/benchmark/competition/array_of_structs/array_of_structs_test.go
+++ b/benchmark/competition/array_of_structs/array_of_structs_test.go
@@ -60,7 +60,9 @@ func runAoS16B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := &entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -77,7 +79,9 @@ func runAoS32B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := &entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -94,7 +98,9 @@ func runAoS64B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := &entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -111,7 +117,9 @@ func runAoS128B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := &entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -128,7 +136,9 @@ func runAoS256B(b *testing.B, count int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		for _, e := range entities {
+		count := len(entities)
+		for i := 0; i < count; i++ {
+			e := &entities[i]
 			e.S0.Hi++
 			e.S0.Lo++
 		}
@@ -147,10 +157,6 @@ func BenchmarkArrOfStructs_16B_100_000(b *testing.B) {
 	runAoS16B(b, 100000)
 }
 
-func BenchmarkArrOfStructs_16B_250_000(b *testing.B) {
-	runAoS16B(b, 250000)
-}
-
 func BenchmarkArrOfStructs_32B_1_000(b *testing.B) {
 	runAoS32B(b, 1000)
 }
@@ -161,10 +167,6 @@ func BenchmarkArrOfStructs_32B_10_000(b *testing.B) {
 
 func BenchmarkArrOfStructs_32B_100_000(b *testing.B) {
 	runAoS32B(b, 100000)
-}
-
-func BenchmarkArrOfStructs_32B_250_000(b *testing.B) {
-	runAoS32B(b, 250000)
 }
 
 func BenchmarkArrOfStructs_64B_1_000(b *testing.B) {
@@ -179,10 +181,6 @@ func BenchmarkArrOfStructs_64B_100_000(b *testing.B) {
 	runAoS64B(b, 100000)
 }
 
-func BenchmarkArrOfStructs_64B_250_000(b *testing.B) {
-	runAoS64B(b, 250000)
-}
-
 func BenchmarkArrOfStructs_128B_1_000(b *testing.B) {
 	runAoS128B(b, 1000)
 }
@@ -195,10 +193,6 @@ func BenchmarkArrOfStructs_128B_100_000(b *testing.B) {
 	runAoS128B(b, 100000)
 }
 
-func BenchmarkArrOfStructs_128B_250_000(b *testing.B) {
-	runAoS128B(b, 250000)
-}
-
 func BenchmarkArrOfStructs_256B_1_000(b *testing.B) {
 	runAoS256B(b, 1000)
 }
@@ -209,8 +203,4 @@ func BenchmarkArrOfStructs_256B_10_000(b *testing.B) {
 
 func BenchmarkArrOfStructs_256B_100_000(b *testing.B) {
 	runAoS256B(b, 100000)
-}
-
-func BenchmarkArrOfStructs_256B_250_000(b *testing.B) {
-	runAoS256B(b, 250000)
 }

--- a/benchmark/competition/array_of_structs/linked_list_test.go
+++ b/benchmark/competition/array_of_structs/linked_list_test.go
@@ -172,10 +172,6 @@ func BenchmarkLinkedList_16B_100_000(b *testing.B) {
 	runLL16B(b, 100000)
 }
 
-func BenchmarkLinkedList_16B_250_000(b *testing.B) {
-	runLL16B(b, 250000)
-}
-
 func BenchmarkLinkedList_32B_1_000(b *testing.B) {
 	runLL32B(b, 1000)
 }
@@ -186,10 +182,6 @@ func BenchmarkLinkedList_32B_10_000(b *testing.B) {
 
 func BenchmarkLinkedList_32B_100_000(b *testing.B) {
 	runLL32B(b, 100000)
-}
-
-func BenchmarkLinkedList_32B_250_000(b *testing.B) {
-	runLL32B(b, 250000)
 }
 
 func BenchmarkLinkedList_64B_1_000(b *testing.B) {
@@ -204,10 +196,6 @@ func BenchmarkLinkedList_64B_100_000(b *testing.B) {
 	runLL64B(b, 100000)
 }
 
-func BenchmarkLinkedList_64B_250_000(b *testing.B) {
-	runLL64B(b, 250000)
-}
-
 func BenchmarkLinkedList_128B_1_000(b *testing.B) {
 	runLL128B(b, 1000)
 }
@@ -220,10 +208,6 @@ func BenchmarkLinkedList_128B_100_000(b *testing.B) {
 	runLL128B(b, 100000)
 }
 
-func BenchmarkLinkedList_128B_250_000(b *testing.B) {
-	runLL128B(b, 250000)
-}
-
 func BenchmarkLinkedList_256B_1_000(b *testing.B) {
 	runLL256B(b, 1000)
 }
@@ -234,8 +218,4 @@ func BenchmarkLinkedList_256B_10_000(b *testing.B) {
 
 func BenchmarkLinkedList_256B_100_000(b *testing.B) {
 	runLL256B(b, 100000)
-}
-
-func BenchmarkLinkedList_256B_250_000(b *testing.B) {
-	runLL256B(b, 250000)
 }


### PR DESCRIPTION
* Use for loop with counter in AoS competition benchmarks, to allow for pointers
* Remove benchmarks with 250k entities