### PR TITLE
Replace Aos benchmarks plot for pointer iteration fix #284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 * Adds an example for creating and querying entity relations (#256)
 * Adds a section on entity relations to the `ARCHITECTURE.md` document (#256)
+* Replace Aos benchmarks plot in README for pointer iteration fix #284 (#285)
 
 ### Other
 
@@ -51,7 +52,7 @@
 * Generic filters are locked when registered for caching (#241)
 * Adds benchmarks for getting and setting entity relations (#259)
 * Arche now has an official logo (#273)
-* Use for loop with counter in AoS competition benchmarks, to allow for pointers (284)
+* Use for loop with counter in AoS competition benchmarks, to allow for pointers (#284)
 
 ## [[v0.7.1]](https://github.com/mlange-42/arche/compare/v0.7.0...v0.7.1)
 

--- a/README.md
+++ b/README.md
@@ -214,10 +214,11 @@ For AoS and AoP, time per access increases with memory per entity as well as num
 
 In the given example with components of 16 bytes each, from 64 bytes per entity onwards (i.e. 4 components or 8 `float64` values),
 Arche outperforms AoS and AoP, particularly with a large number of entities.
+Note that the maximum shown here corresponds to only 25 MB of entity data!
 
 <div align="center" width="100%">
 
-![Benchmark vs. AoS and AoP](https://user-images.githubusercontent.com/44003176/227033985-587b5d02-c159-4e00-b2a5-dc8b2f65b124.svg)  
+![Benchmark vs. AoS and AoP](https://user-images.githubusercontent.com/44003176/237245154-0070bba0-c8fe-447e-a710-e370af1dcdab.svg)  
 *CPU benchmarks of Arche (black) vs. Array of Structs (AoS, red) and Array of Pointers (AoP, blue).*
 </div>
 

--- a/benchmark/competition/array_of_structs/plot.py
+++ b/benchmark/competition/array_of_structs/plot.py
@@ -61,9 +61,11 @@ if __name__ == "__main__":
     for model in reversed(models):
         for ent in entities:
             extr = data[(data["Model"] == model) & (data["Entities"] == ent)]
+            extr = extr.groupby("Bytes"). mean()
+            
             line = linesEntities[ent]
             ax.plot(
-                extr["Bytes"],
+                extr.index,
                 extr["Time"],
                 linestyle=line[0],
                 linewidth=line[1],

--- a/benchmark/competition/array_of_structs/plot.py
+++ b/benchmark/competition/array_of_structs/plot.py
@@ -5,8 +5,28 @@ from matplotlib import pyplot as plt
 
 if __name__ == "__main__":
     data = pd.read_csv("results.csv", sep=";")
+    
+    model_names = {
+        "Arche": "Arche",
+        "ArrOfPointers": "AoP",
+        "ArrOfStructs": "AoS",
+        "LinkedList": "LL",
+    }
+    
+    data["Model"] = ""
+    data["Entities"] = 0
+    data["Bytes"] = 0
+    
+    data["Benchmark"] = data["Benchmark"].str.replace("Benchmark","")
+    for index, row in data.iterrows():
+        parts = row["Benchmark"].split("_")
+        data.loc[index, "Model"] = model_names[parts[0]]
+        data.loc[index, "Entities"] = int(parts[2]) * 1000
+        data.loc[index, "Bytes"] = int(parts[1].replace("B", ""))
+    
+    data["Time"] = data["TotalTime"] / data["Entities"]
+    
     data = data[data["Model"] != "LL"]
-    data = data[data["Entities"] <= 100000]
 
     models = np.unique(data["Model"])
     entities = np.unique(data["Entities"])


### PR DESCRIPTION
Using pointer iteration in AoS benchmarks improves the runtime of AoS by avoiding copy. Also, it is necessary to change the underlying entites, not only there copies.

This PR replaces the respective plot in the README, as the old information was wrong/biased.