### PR TITLE
Return a single query from batch operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Re-introduce `World.Batch` for batch-processing of entities (add/remove/exchange) (#264)
 * New method `Builder.Add` for adding components with a target to entities (#264)
 * New method `Batch.SetRelation` for batch-setting entity relations (#265)
+* New methods `Builder.AddQuery`, `Builder.RemoveQuery` etc. to get a query over batch-processed entities (#297)
 * Sends an `EntityEvent` to the world listener on relation target changes (#265)
 
 ### Performance

--- a/ecs/archetype_node.go
+++ b/ecs/archetype_node.go
@@ -142,6 +142,8 @@ func (a *archNode) RemoveArchetype(arch *archetype) {
 	a.archetypes.Get(idx).Deactivate()
 }
 
+// Reset resets the archetypes in this node.
+// Relation archetypes with non-zero target are de-activated for re-use.
 func (a *archNode) Reset(cache *Cache) {
 	if !a.IsActive {
 		return

--- a/ecs/archetypes.go
+++ b/ecs/archetypes.go
@@ -26,23 +26,30 @@ func (s singleArchetype) Len() int32 {
 // Implements [archetypes].
 //
 // Used for the [Query] returned by entity batch creation methods.
-type batchArchetype struct {
-	Archetype    *archetype
-	StartIndex   uint32
-	EndIndex     uint32
-	OldArchetype *archetype
+type batchArchetypes struct {
+	Archetype    []*archetype
+	StartIndex   []uint32
+	EndIndex     []uint32
+	OldArchetype []*archetype
 	Added        []ID
 	Removed      []ID
 }
 
 // Get returns the value at the given index.
-func (s *batchArchetype) Get(index int32) *archetype {
-	return s.Archetype
+func (s *batchArchetypes) Get(index int32) *archetype {
+	return s.Archetype[index]
 }
 
 // Len returns the current number of items in the paged array.
-func (s *batchArchetype) Len() int32 {
-	return 1
+func (s *batchArchetypes) Len() int32 {
+	return int32(len(s.Archetype))
+}
+
+func (s *batchArchetypes) Add(arch, oldArch *archetype, start, end uint32) {
+	s.Archetype = append(s.Archetype, arch)
+	s.OldArchetype = append(s.OldArchetype, oldArch)
+	s.StartIndex = append(s.StartIndex, start)
+	s.EndIndex = append(s.EndIndex, end)
 }
 
 // Implementation of an archetype iterator for pointers.

--- a/ecs/archetypes_test.go
+++ b/ecs/archetypes_test.go
@@ -40,7 +40,8 @@ func TestArchetypePointers(t *testing.T) {
 
 func TestBatchArchetype(t *testing.T) {
 	arch := archetype{}
-	batch := batchArchetype{Archetype: &arch}
+	batch := batchArchetypes{}
+	batch.Add(&arch, nil, 0, 1)
 
 	assert.Equal(t, &arch, batch.Get(0))
 	assert.Equal(t, int32(1), batch.Len())

--- a/ecs/batch.go
+++ b/ecs/batch.go
@@ -19,7 +19,7 @@ func (b *Batch) Add(filter Filter, comps ...ID) {
 }
 
 // AddQuery adds components to many entities, matching a filter.
-// It returns a query over the altered entities.
+// It returns a query over the affected entities.
 //
 // Panics:
 //   - when called with components that can't be added because they are already present.
@@ -42,7 +42,7 @@ func (b *Batch) Remove(filter Filter, comps ...ID) {
 }
 
 // RemoveQuery removes components from many entities, matching a filter.
-// It returns a query over the altered entities.
+// It returns a query over the affected entities.
 //
 // Panics:
 //   - when called with components that can't be removed because they are not present.
@@ -55,8 +55,18 @@ func (b *Batch) RemoveQuery(filter Filter, comps ...ID) Query {
 
 // SetRelation sets the [Relation] target for many entities, matching a filter.
 //
-// If the callback argument is given, it is called with a [Query] over the affected entities,
-// one Query for each affected archetype.
+// Panics:
+//   - when called for a missing component.
+//   - when called for a component that is not a relation.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [Relations.Set] and [Relations.SetBatch].
+func (b *Batch) SetRelation(filter Filter, comp ID, target Entity) {
+	b.world.setRelationBatch(filter, comp, target)
+}
+
+// SetRelationQuery sets the [Relation] target for many entities, matching a filter.
+// It returns a query over the affected entities.
 //
 // Panics:
 //   - when called for a missing component.
@@ -64,8 +74,8 @@ func (b *Batch) RemoveQuery(filter Filter, comps ...ID) Query {
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
 // See also [Relations.Set] and [Relations.SetBatch].
-func (b *Batch) SetRelation(filter Filter, comp ID, target Entity, callback func(Query)) {
-	b.world.setRelationBatch(filter, comp, target, callback)
+func (b *Batch) SetRelationQuery(filter Filter, comp ID, target Entity) Query {
+	return b.world.setRelationBatchQuery(filter, comp, target)
 }
 
 // Exchange exchanges components for many entities, matching a filter.
@@ -80,7 +90,7 @@ func (b *Batch) Exchange(filter Filter, add []ID, rem []ID) {
 }
 
 // ExchangeQuery exchanges components for many entities, matching a filter.
-// It returns a query over the altered entities.
+// It returns a query over the affected entities.
 //
 // Panics:
 //   - when called with components that can't be added or removed because they are already present/not present, respectively.

--- a/ecs/batch.go
+++ b/ecs/batch.go
@@ -9,30 +9,48 @@ type Batch struct {
 
 // Add adds components to many entities, matching a filter.
 //
-// If the callback argument is given, it is called with a [Query] over the affected entities,
-// one Query for each affected archetype.
+// Panics:
+//   - when called with components that can't be added because they are already present.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [Batch.AddQuery] and [World.Add].
+func (b *Batch) Add(filter Filter, comps ...ID) {
+	b.world.exchangeBatch(filter, comps, nil)
+}
+
+// AddQuery adds components to many entities, matching a filter.
+// It returns a query over the altered entities.
 //
 // Panics:
 //   - when called with components that can't be added because they are already present.
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
-// See also [World.Add].
-func (b *Batch) Add(filter Filter, callback func(Query), comps ...ID) {
-	b.world.exchangeBatch(filter, comps, nil, callback)
+// See also [Batch.Add] and [World.Add].
+func (b *Batch) AddQuery(filter Filter, comps ...ID) Query {
+	return b.world.exchangeBatchQuery(filter, comps, nil)
 }
 
 // Remove removes components from many entities, matching a filter.
-//
-// If the callback argument is given, it is called with a [Query] over the affected entities,
-// one Query for each affected archetype.
 //
 // Panics:
 //   - when called with components that can't be removed because they are not present.
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
-// See also [World.Remove].
-func (b *Batch) Remove(filter Filter, callback func(Query), comps ...ID) {
-	b.world.exchangeBatch(filter, nil, comps, callback)
+// See also [Batch.RemoveQuery] and [World.Remove].
+func (b *Batch) Remove(filter Filter, comps ...ID) {
+	b.world.exchangeBatch(filter, nil, comps)
+}
+
+// RemoveQuery removes components from many entities, matching a filter.
+// It returns a query over the altered entities.
+//
+// Panics:
+//   - when called with components that can't be removed because they are not present.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [Batch.Remove] and [World.Remove].
+func (b *Batch) RemoveQuery(filter Filter, comps ...ID) Query {
+	return b.world.exchangeBatchQuery(filter, nil, comps)
 }
 
 // SetRelation sets the [Relation] target for many entities, matching a filter.
@@ -52,16 +70,25 @@ func (b *Batch) SetRelation(filter Filter, comp ID, target Entity, callback func
 
 // Exchange exchanges components for many entities, matching a filter.
 //
-// If the callback argument is given, it is called with a [Query] over the affected entities,
-// one Query for each affected archetype.
+// Panics:
+//   - when called with components that can't be added or removed because they are already present/not present, respectively.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [Batch.ExchangeQuery] and [World.Exchange].
+func (b *Batch) Exchange(filter Filter, add []ID, rem []ID) {
+	b.world.exchangeBatch(filter, add, rem)
+}
+
+// ExchangeQuery exchanges components for many entities, matching a filter.
+// It returns a query over the altered entities.
 //
 // Panics:
 //   - when called with components that can't be added or removed because they are already present/not present, respectively.
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
-// See also [World.Exchange].
-func (b *Batch) Exchange(filter Filter, add []ID, rem []ID, callback func(Query)) {
-	b.world.exchangeBatch(filter, add, rem, callback)
+// See also [Batch.Exchange] and [World.Exchange].
+func (b *Batch) ExchangeQuery(filter Filter, add []ID, rem []ID) Query {
+	return b.world.exchangeBatchQuery(filter, add, rem)
 }
 
 // RemoveEntities removes and recycles all entities matching a filter.

--- a/ecs/batch_test.go
+++ b/ecs/batch_test.go
@@ -82,5 +82,5 @@ func ExampleBatch_SetRelation() {
 	builder.NewBatch(100)
 
 	filter := ecs.All(childID)
-	world.Batch().SetRelation(filter, childID, target, nil)
+	world.Batch().SetRelation(filter, childID, target)
 }

--- a/ecs/batch_test.go
+++ b/ecs/batch_test.go
@@ -11,7 +11,7 @@ func ExampleBatch() {
 	builder := ecs.NewBuilder(&world, posID, velID)
 	builder.NewBatch(100)
 
-	world.Batch().Remove(ecs.All(posID, velID), nil, velID)
+	world.Batch().Remove(ecs.All(posID, velID), velID)
 	world.Batch().RemoveEntities(ecs.All(posID))
 }
 
@@ -25,7 +25,7 @@ func ExampleBatch_Add() {
 	builder.NewBatch(100)
 
 	filter := ecs.All(posID)
-	world.Batch().Add(filter, nil, velID)
+	world.Batch().Add(filter, velID)
 }
 
 func ExampleBatch_Remove() {
@@ -38,7 +38,7 @@ func ExampleBatch_Remove() {
 	builder.NewBatch(100)
 
 	filter := ecs.All(posID, velID)
-	world.Batch().Remove(filter, nil, velID)
+	world.Batch().Remove(filter, velID)
 }
 
 func ExampleBatch_Exchange() {
@@ -55,7 +55,6 @@ func ExampleBatch_Exchange() {
 		filter,          // Filter
 		[]ecs.ID{velID}, // Add components
 		[]ecs.ID{posID}, // Remove components
-		nil,             // Optional callback
 	)
 }
 

--- a/ecs/relations.go
+++ b/ecs/relations.go
@@ -43,15 +43,25 @@ func (r *Relations) Set(entity Entity, comp ID, target Entity) {
 
 // SetBatch sets the [Relation] target for many entities, matching a filter.
 //
-// If the callback argument is given, it is called with a [Query] over the affected entities,
-// one Query for each affected archetype.
+// Panics:
+//   - when called for a missing component.
+//   - when called for a component that is not a relation.
+//   - when called on a locked world. Do not use during [Query] iteration!
+//
+// See also [Relations.Set], [Relations.SetBatchQuery] and [Batch.SetRelation].
+func (r *Relations) SetBatch(filter Filter, comp ID, target Entity) {
+	r.world.setRelationBatch(filter, comp, target)
+}
+
+// SetBatchQuery sets the [Relation] target for many entities, matching a filter.
+// Returns a query over all affected entities.
 //
 // Panics:
 //   - when called for a missing component.
 //   - when called for a component that is not a relation.
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
-// See also [Relations.Set] and [Batch.SetRelation].
-func (r *Relations) SetBatch(filter Filter, comp ID, target Entity, callback func(Query)) {
-	r.world.setRelationBatch(filter, comp, target, callback)
+// See also [Relations.Set], [Relations.SetBatch] and [Batch.SetRelation].
+func (r *Relations) SetBatchQuery(filter Filter, comp ID, target Entity) Query {
+	return r.world.setRelationBatchQuery(filter, comp, target)
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -278,7 +278,13 @@ func (w *World) newEntities(count int, targetID int8, target Entity, comps ...ID
 func (w *World) newEntitiesQuery(count int, targetID int8, target Entity, comps ...ID) Query {
 	arch, startIdx := w.newEntitiesNoNotify(count, targetID, target, comps...)
 	lock := w.lock()
-	return newBatchQuery(w, lock, &batchArchetype{arch, startIdx, arch.Len(), nil, arch.Components(), nil})
+
+	batches := batchArchetypes{
+		Added:   arch.Components(),
+		Removed: nil,
+	}
+	batches.Add(arch, nil, startIdx, arch.Len())
+	return newBatchQuery(w, lock, &batches)
 }
 
 // Creates new entities with component values without returning a query over them.
@@ -314,7 +320,12 @@ func (w *World) newEntitiesWithQuery(count int, targetID int8, target Entity, co
 
 	arch, startIdx := w.newEntitiesWithNoNotify(count, targetID, target, ids, comps...)
 	lock := w.lock()
-	return newBatchQuery(w, lock, &batchArchetype{arch, startIdx, arch.Len(), nil, arch.Components(), nil})
+	batches := batchArchetypes{
+		Added:   arch.Components(),
+		Removed: nil,
+	}
+	batches.Add(arch, nil, startIdx, arch.Len())
+	return newBatchQuery(w, lock, &batches)
 }
 
 // RemoveEntity removes and recycles an [Entity].
@@ -658,6 +669,11 @@ func (w *World) exchangeBatch(filter Filter, add []ID, rem []ID, callback func(Q
 		lengths[i] = arch.Len()
 	}
 
+	batches := batchArchetypes{
+		Added:   add,
+		Removed: rem,
+	}
+
 	for i, arch := range arches {
 		archLen := lengths[i]
 
@@ -666,16 +682,17 @@ func (w *World) exchangeBatch(filter Filter, add []ID, rem []ID, callback func(Q
 		}
 
 		newArch, start := w.exchangeArch(arch, archLen, add, rem)
-		if callback == nil {
-			if w.listener != nil {
-				w.notifyQuery(&batchArchetype{newArch, start, newArch.Len(), arch, add, rem})
-			}
-		} else {
-			lock := w.lock()
-			query := newBatchQuery(w, lock, &batchArchetype{newArch, start, newArch.Len(), arch, add, rem})
-			callback(query)
-			w.checkLocked()
+		batches.Add(newArch, arch, start, newArch.Len())
+	}
+	if callback == nil {
+		if w.listener != nil {
+			w.notifyQuery(&batches)
 		}
+	} else {
+		lock := w.lock()
+		query := newBatchQuery(w, lock, &batches)
+		callback(query)
+		w.checkLocked()
 	}
 }
 
@@ -813,6 +830,8 @@ func (w *World) setRelationBatch(filter Filter, comp ID, target Entity, callback
 		lengths[i] = arch.Len()
 	}
 
+	batches := batchArchetypes{}
+
 	for i, arch := range arches {
 		archLen := lengths[i]
 
@@ -821,16 +840,17 @@ func (w *World) setRelationBatch(filter Filter, comp ID, target Entity, callback
 		}
 
 		newArch, start, end := w.setRelationArch(arch, archLen, comp, target)
-		if callback == nil {
-			if w.listener != nil {
-				w.notifyQuery(&batchArchetype{newArch, start, end, arch, nil, nil})
-			}
-		} else {
-			lock := w.lock()
-			query := newBatchQuery(w, lock, &batchArchetype{newArch, start, end, arch, nil, nil})
-			callback(query)
-			w.checkLocked()
+		batches.Add(newArch, arch, start, end)
+	}
+	if callback == nil {
+		if w.listener != nil {
+			w.notifyQuery(&batches)
 		}
+	} else {
+		lock := w.lock()
+		query := newBatchQuery(w, lock, &batches)
+		callback(query)
+		w.checkLocked()
 	}
 }
 
@@ -1372,34 +1392,37 @@ func (w *World) closeQuery(query *Query) {
 	w.unlock(query.lockBit)
 
 	if w.listener != nil {
-		if arch, ok := query.nodeArchetypes.(*batchArchetype); ok {
+		if arch, ok := query.nodeArchetypes.(*batchArchetypes); ok {
 			w.notifyQuery(arch)
 		}
 	}
 }
 
 // notifies the listener for all entities on a batch query.
-func (w *World) notifyQuery(batchArch *batchArchetype) {
-	arch := batchArch.Archetype
-	var i uint32
+func (w *World) notifyQuery(batchArch *batchArchetypes) {
+	count := batchArch.Len()
+	var i int32
+	for i = 0; i < count; i++ {
+		arch := batchArch.Get(i)
+		event := EntityEvent{
+			Entity{}, Mask{}, arch.Mask, batchArch.Added, batchArch.Removed, arch.node.Ids, 1,
+			Entity{}, arch.RelationTarget, false,
+		}
 
-	event := EntityEvent{
-		Entity{}, Mask{}, arch.Mask, batchArch.Added, batchArch.Removed, arch.node.Ids, 1,
-		Entity{}, arch.RelationTarget, false,
-	}
+		oldArch := batchArch.OldArchetype[i]
+		if oldArch != nil {
+			event.OldMask = oldArch.node.Mask
+			event.AddedRemoved = 0
+			event.OldTarget = oldArch.RelationTarget
+			event.TargetChanged = event.OldMask == event.NewMask
+		}
 
-	oldArch := batchArch.OldArchetype
-	if oldArch != nil {
-		event.OldMask = oldArch.node.Mask
-		event.AddedRemoved = 0
-		event.OldTarget = oldArch.RelationTarget
-		event.TargetChanged = event.OldMask == event.NewMask
-	}
-
-	start, end := batchArch.StartIndex, batchArch.EndIndex
-	for i = start; i < end; i++ {
-		entity := arch.GetEntity(i)
-		event.Entity = entity
-		w.listener(&event)
+		start, end := batchArch.StartIndex[i], batchArch.EndIndex[i]
+		var e uint32
+		for e = start; e < end; e++ {
+			entity := arch.GetEntity(e)
+			event.Entity = entity
+			w.listener(&event)
+		}
 	}
 }

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -339,6 +339,22 @@ func TestWorldExchangeBatch(t *testing.T) {
 
 	filter = All()
 	w.Batch().Add(filter, velID)
+
+	w.Reset()
+
+	target1 = w.NewEntity(velID)
+	builder = NewBuilder(&w, posID, relID).WithRelation(relID)
+	builder.NewBatch(100, target1)
+
+	filter = All(velID)
+	q = w.Batch().RemoveQuery(filter, velID)
+	assert.Equal(t, 1, q.Count())
+	q.Close()
+
+	filter = All()
+	q = w.Batch().AddQuery(filter, velID)
+	assert.Equal(t, 101, q.Count())
+	q.Close()
 }
 
 func TestWorldAssignSet(t *testing.T) {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -763,45 +763,45 @@ func TestWorldRelationSetBatch(t *testing.T) {
 	builder.NewBatch(100, targ3)
 
 	relFilter := NewRelationFilter(All(relID), targ2)
-	world.Batch().SetRelation(&relFilter, relID, targ1, func(q Query) {
-		assert.Equal(t, 100, q.Count())
-		for q.Next() {
-			assert.Equal(t, targ1, q.Relation(relID))
-		}
-	})
+	q := world.Batch().SetRelationQuery(&relFilter, relID, targ1)
+	assert.Equal(t, 100, q.Count())
+	cnt := 0
+	for q.Next() {
+		assert.Equal(t, targ1, q.Relation(relID))
+		cnt++
+	}
+	assert.Equal(t, 100, cnt)
 
-	total := 0
-	world.Batch().SetRelation(All(relID), relID, targ3, func(q Query) {
-		total += q.Count()
-		for q.Next() {
-			assert.Equal(t, targ3, q.Relation(relID))
-		}
-	})
-	assert.Equal(t, 300, total)
+	q = world.Batch().SetRelationQuery(All(relID), relID, targ3)
+	assert.Equal(t, 300, q.Count())
+	cnt = 0
+	for q.Next() {
+		assert.Equal(t, targ3, q.Relation(relID))
+		cnt++
+	}
+	assert.Equal(t, 300, cnt)
 
 	relFilter = NewRelationFilter(All(relID), targ3)
-	world.Batch().SetRelation(&relFilter, relID, Entity{}, func(q Query) {
-		assert.Equal(t, 300, q.Count())
-		for q.Next() {
-			assert.True(t, q.Relation(relID).IsZero())
-		}
-	})
+	q = world.Batch().SetRelationQuery(&relFilter, relID, Entity{})
+	assert.Equal(t, 300, q.Count())
+	cnt = 0
+	for q.Next() {
+		assert.True(t, q.Relation(relID).IsZero())
+		cnt++
+	}
+	assert.Equal(t, 300, cnt)
 
 	relFilter = NewRelationFilter(All(relID), Entity{})
-	world.Batch().SetRelation(&relFilter, relID, targ1, nil)
+	world.Batch().SetRelation(&relFilter, relID, targ1)
 
 	world.RemoveEntity(targ3)
 	assert.Panics(t, func() {
-		world.Batch().SetRelation(All(relID), relID, targ3, nil)
+		world.Batch().SetRelation(All(relID), relID, targ3)
 	})
 
 	assert.Equal(t, 1304, len(events))
 
-	world.Relations().SetBatch(All(relID), relID, targ1, nil)
-
-	assert.Panics(t, func() {
-		world.Batch().SetRelation(All(relID), relID, targ2, func(q Query) {})
-	})
+	world.Relations().SetBatch(All(relID), relID, targ1)
 
 	fmt.Println(debugPrintWorld(&world))
 }

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -819,7 +819,13 @@ func TestWorldRelationSetBatch(t *testing.T) {
 
 	world.Relations().SetBatch(All(relID), relID, targ1)
 
+	q = world.Relations().SetBatchQuery(All(relID), relID, targ2)
+	assert.Equal(t, 300, q.Count())
+	q.Close()
+
 	fmt.Println(debugPrintWorld(&world))
+
+	world.Reset()
 }
 
 func TestWorldRelationRemove(t *testing.T) {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -287,7 +287,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 	cnt := 0
 	filter := All(posID, relID)
 	w.Batch().Exchange(filter, []ID{velID}, []ID{posID}, func(q Query) {
-		assert.Equal(t, 100, q.Count())
+		assert.Equal(t, 200, q.Count())
 		for q.Next() {
 			assert.True(t, q.Has(velID))
 			assert.True(t, q.Has(relID))
@@ -295,7 +295,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		}
 		cnt++
 	})
-	assert.Equal(t, 2, cnt)
+	assert.Equal(t, 1, cnt)
 
 	query := w.Query(All(posID))
 	assert.Equal(t, 0, query.Count())

--- a/examples/batch_ops/main.go
+++ b/examples/batch_ops/main.go
@@ -51,9 +51,9 @@ func run() {
 	}
 
 	// Batch-remove components.
-	world.Batch().Remove(ecs.All(posID, velID), nil, velID)
+	world.Batch().Remove(ecs.All(posID, velID), velID)
 	// Batch-add components.
-	world.Batch().Add(ecs.All(posID), nil, velID)
+	world.Batch().Add(ecs.All(posID), velID)
 
 	// Batch-remove all entities with exactly the given components.
 	filterExcl := ecs.All(posID, velID).Exclusive()


### PR DESCRIPTION
Before this change, batchoperations take a callback to provide multiple queries: one for each archetypes.

This PR adds support for multiple batch archetypes in a single query. Batch functions return a query instead of taking a callback.