### PR TITLE
Allow to save / load state in terms of assigned entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Highlights
 
 * Arche now supports 256 instead of 128 component types as well as resource types and engine locks (#313)
+* Arche supports full world serialization and deserialization, in conjunction with [arche-serde](https://github.com/mlange-42/arche-serde) (#319)
 
 ### Breaking changes
 
@@ -17,6 +18,8 @@ This change was necessary to get the same performance as before, despite the mor
 
 * Adds functions `ComponentInfo(*World, ID)` and `ResourceType(*World, ResID)` (#315, #318)
 * Adds methods `World.Ids(Entity)` and `Query.Ids()` (#315)
+* Entities support JSON marshalling/unmarshalling (#319)
+* The world's entity state can be extracted and re-established via `World.GetEntityData()` and `World.SetEntityData()` (#319)
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * Entity relations as first-class feature. See [Architecture](https://github.com/mlange-42/arche/blob/main/ARCHITECTURE.md#entity-relations).
 * No systems. Just queries. Use your own structure (or the [Tools](#tools)).
 * No dependencies. Except for unit tests ([100% coverage](https://coveralls.io/github/mlange-42/arche)).
+* Supports serialization and deserialization of the entire world state via [arche-serde](https://github.com/mlange-42/arche-serde).
 * Probably the fastest Go ECS out there. See the [Benchmarks](#benchmarks).
 
 ## Installation

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -43,17 +43,23 @@ func (e Entity) IsZero() bool {
 	return e.id == 0
 }
 
-// ID of the entity. For serialization purposes.
+// ID of the entity. For serialization purposes only!
+//
+// Do not use this in normal model or game code!
 func (e Entity) ID() uint32 {
 	return uint32(e.id)
 }
 
-// Gen returns the generation of the entity. For serialization purposes.
+// Gen returns the generation of the entity. For serialization purposes only!
+//
+// Do not use this in normal model or game code!
 func (e Entity) Gen() uint32 {
 	return e.gen
 }
 
 // MarshalJSON returns a JSON representation of the entity, for serialization purposes.
+//
+// The JSON representation of an entity is a two-element array of entity ID and generation.
 func (e Entity) MarshalJSON() ([]byte, error) {
 	arr := [2]uint32{uint32(e.id), e.gen}
 	jsonValue, _ := json.Marshal(arr) // Ignore the error, as we can be sure this works.
@@ -62,7 +68,7 @@ func (e Entity) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON into an entity.
 //
-// Only for serialization purposes. Do not use this to create entities!
+// For serialization purposes only. Do not use this to create entities!
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	arr := [2]uint32{}
 	if err := json.Unmarshal(data, &arr); err != nil {

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -65,6 +65,8 @@ type entityHelper struct {
 }
 
 // UnmarshalJSON into an entity.
+//
+// Only for serialization purposes. Do not use this to create entities!
 func (e *Entity) UnmarshalJSON(data []byte) error {
 	helper := entityHelper{}
 	if err := json.Unmarshal(data, &helper); err != nil {

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -1,6 +1,10 @@
 package ecs
 
-import "reflect"
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
 
 // Reflection type of an [Entity].
 var entityType = reflect.TypeOf(Entity{})
@@ -38,6 +42,37 @@ func newEntityGen(id eid, gen uint32) Entity {
 // IsZero returns whether this entity is the reserved zero entity.
 func (e Entity) IsZero() bool {
 	return e.id == 0
+}
+
+// ID of the entity. For serialization purposes.
+func (e Entity) ID() uint32 {
+	return uint32(e.id)
+}
+
+// Gen returns the generation of the entity. For serialization purposes.
+func (e Entity) Gen() uint32 {
+	return e.gen
+}
+
+// MarshalJSON returns a JSON representation of the entity, for serialization purposes.
+func (e Entity) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("{\"ID\": %d, \"Gen\": %d}", e.id, e.gen)), nil
+}
+
+type entityHelper struct {
+	ID  eid
+	Gen uint32
+}
+
+// UnmarshalJSON into an entity.
+func (e *Entity) UnmarshalJSON(data []byte) error {
+	helper := entityHelper{}
+	if err := json.Unmarshal(data, &helper); err != nil {
+		return err
+	}
+	e.id = helper.ID
+	e.gen = helper.Gen
+	return nil
 }
 
 // entityIndex indicates where an entity is currently stored.

--- a/ecs/entity.go
+++ b/ecs/entity.go
@@ -2,7 +2,6 @@ package ecs
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 )
 
@@ -56,24 +55,22 @@ func (e Entity) Gen() uint32 {
 
 // MarshalJSON returns a JSON representation of the entity, for serialization purposes.
 func (e Entity) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("{\"ID\": %d, \"Gen\": %d}", e.id, e.gen)), nil
-}
-
-type entityHelper struct {
-	ID  eid
-	Gen uint32
+	arr := [2]uint32{uint32(e.id), e.gen}
+	jsonValue, _ := json.Marshal(arr) // Ignore the error, as we can be sure this works.
+	return jsonValue, nil
 }
 
 // UnmarshalJSON into an entity.
 //
 // Only for serialization purposes. Do not use this to create entities!
 func (e *Entity) UnmarshalJSON(data []byte) error {
-	helper := entityHelper{}
-	if err := json.Unmarshal(data, &helper); err != nil {
+	arr := [2]uint32{}
+	if err := json.Unmarshal(data, &arr); err != nil {
 		return err
 	}
-	e.id = helper.ID
-	e.gen = helper.Gen
+	e.id = eid(arr[0])
+	e.gen = arr[1]
+
 	return nil
 }
 

--- a/ecs/entity_test.go
+++ b/ecs/entity_test.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -18,6 +19,32 @@ func TestEntityAsIndex(t *testing.T) {
 func TestZeroEntity(t *testing.T) {
 	assert.True(t, Entity{}.IsZero())
 	assert.False(t, Entity{1, 0}.IsZero())
+}
+
+func TestEntityGetters(t *testing.T) {
+	e := newEntityGen(2, 3)
+	assert.Equal(t, e.ID(), uint32(2))
+	assert.Equal(t, e.Gen(), uint32(3))
+}
+
+func TestEntityMarshal(t *testing.T) {
+	e := newEntityGen(2, 3)
+
+	jsonData, err := json.Marshal(&e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e2 := Entity{}
+	err = json.Unmarshal(jsonData, &e2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, e2, e)
+
+	err = json.Unmarshal([]byte("pft"), &e2)
+	assert.NotNil(t, err)
 }
 
 func BenchmarkEntityIsZero(b *testing.B) {

--- a/ecs/entity_test.go
+++ b/ecs/entity_test.go
@@ -43,7 +43,7 @@ func TestEntityMarshal(t *testing.T) {
 
 	assert.Equal(t, e2, e)
 
-	err = json.Unmarshal([]byte("pft"), &e2)
+	err = e2.UnmarshalJSON([]byte("pft"))
 	assert.NotNil(t, err)
 }
 

--- a/ecs/types.go
+++ b/ecs/types.go
@@ -33,3 +33,14 @@ type CompInfo struct {
 	Type       reflect.Type
 	IsRelation bool
 }
+
+// EntityData is a dump of the entire entity data of the world.
+//
+// See [World.GetEntityData] and [World.SetEntityData].
+type EntityData struct {
+	Ids       []uint32 // Entity IDs in the World's entity pool.
+	Gens      []uint32 // Entity generations in the World's entity pool.
+	Alive     []uint32 // IDs of all alive entities in query iteration order.
+	Next      uint32   // The next free entity of the World's entity pool.
+	Available uint32   // The number of allocated and available entities in the World's entity pool.
+}

--- a/ecs/types.go
+++ b/ecs/types.go
@@ -38,8 +38,7 @@ type CompInfo struct {
 //
 // See [World.GetEntityData] and [World.SetEntityData].
 type EntityData struct {
-	Ids       []uint32 // Entity IDs in the World's entity pool.
-	Gens      []uint32 // Entity generations in the World's entity pool.
+	Entities  []Entity // Entities in the World's entity pool.
 	Alive     []uint32 // IDs of all alive entities in query iteration order.
 	Next      uint32   // The next free entity of the World's entity pool.
 	Available uint32   // The number of allocated and available entities in the World's entity pool.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1157,10 +1157,7 @@ func (w *World) MarshalEntities() ([]byte, error) {
 		Alive:             alive,
 	}
 
-	jsonData, err := json.Marshal(&data)
-	if err != nil {
-		return nil, err
-	}
+	jsonData, _ := json.Marshal(&data)
 	return jsonData, nil
 }
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1118,6 +1118,8 @@ func (w *World) Stats() *stats.WorldStats {
 
 // GetEntityData dumps entity information into an [EntityData] object.
 // This dump can be used with [World.SetEntityData] to set the World's entity state.
+//
+// For world serialization with components and resources, see module [github.com/mlange-42/arche-serde].
 func (w *World) GetEntityData() EntityData {
 	alive := []uint32{}
 
@@ -1138,11 +1140,15 @@ func (w *World) GetEntityData() EntityData {
 
 // SetEntityData resets all entities to the state saved with [World.GetEntityData].
 //
+// Use this only on an empty world! Can be used after [World.Reset].
+//
 // The resulting world will have the same entities (in terms of ID, generation and alive state)
 // as the original world. This is necessary for proper serialization of entity relations.
 // However, the entities will not have any components.
 //
-// Panics if the world is not fresh or was reset.
+// Panics if the world has any dead or alive entities.
+//
+// For world serialization with components and resources, see module [github.com/mlange-42/arche-serde].
 func (w *World) SetEntityData(data *EntityData) {
 	w.checkLocked()
 
@@ -1150,7 +1156,6 @@ func (w *World) SetEntityData(data *EntityData) {
 		panic("can set entity data only on a fresh or reset world")
 	}
 
-	// TODO: only allow on a fresh world!
 	capacity := capacity(len(data.Entities), w.config.CapacityIncrement)
 
 	entities := make([]Entity, 0, capacity)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1724,6 +1724,21 @@ func TestWorldEntityDataEmpty(t *testing.T) {
 	query.Close()
 }
 
+func TestWorldEntityDataFail(t *testing.T) {
+	w := NewWorld()
+	_ = w.NewEntity()
+
+	eData := w.GetEntityData()
+
+	w2 := NewWorld()
+	e1 := w2.NewEntity()
+	w2.RemoveEntity(e1)
+
+	assert.Panics(t, func() {
+		w2.SetEntityData(&eData)
+	})
+}
+
 func printTypeSize[T any]() {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	fmt.Printf("%18s: %5d B\n", tp.Name(), tp.Size())

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1673,6 +1673,45 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSizeName[idMap[uint32]]("idMap")
 }
 
+func TestMarshalEntities(t *testing.T) {
+	w := NewWorld()
+
+	e1 := w.NewEntity()
+	e2 := w.NewEntity()
+	e3 := w.NewEntity()
+	e4 := w.NewEntity()
+
+	w.RemoveEntity(e2)
+	w.RemoveEntity(e3)
+	e5 := w.NewEntity()
+
+	jsonData, err := w.MarshalEntities()
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	fmt.Println(string(jsonData))
+
+	w2 := NewWorld()
+	err = w2.UnmarshalEntities(jsonData)
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	assert.True(t, w2.Alive(e1))
+	assert.True(t, w2.Alive(e4))
+	assert.True(t, w2.Alive(e5))
+
+	assert.False(t, w2.Alive(e2))
+	assert.False(t, w2.Alive(e3))
+
+	assert.Equal(t, w.Ids(e1), []ID{})
+
+	query := w2.Query(All())
+	assert.Equal(t, query.Count(), 3)
+	query.Close()
+}
+
 func printTypeSize[T any]() {
 	tp := reflect.TypeOf((*T)(nil)).Elem()
 	fmt.Printf("%18s: %5d B\n", tp.Name(), tp.Size())

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1673,7 +1673,7 @@ func TestTypeSizes(t *testing.T) {
 	printTypeSizeName[idMap[uint32]]("idMap")
 }
 
-func TestMarshalEntities(t *testing.T) {
+func TestWorldEntityData(t *testing.T) {
 	w := NewWorld()
 
 	e1 := w.NewEntity()
@@ -1685,18 +1685,11 @@ func TestMarshalEntities(t *testing.T) {
 	w.RemoveEntity(e3)
 	e5 := w.NewEntity()
 
-	jsonData, err := w.MarshalEntities()
-	if err != nil {
-		assert.Fail(t, err.Error())
-	}
-
-	fmt.Println(string(jsonData))
+	eData := w.GetEntityData()
+	fmt.Println(eData)
 
 	w2 := NewWorld()
-	err = w2.UnmarshalEntities(jsonData)
-	if err != nil {
-		assert.Fail(t, err.Error())
-	}
+	w2.SetEntityData(&eData)
 
 	assert.True(t, w2.Alive(e1))
 	assert.True(t, w2.Alive(e4))
@@ -1710,10 +1703,25 @@ func TestMarshalEntities(t *testing.T) {
 	query := w2.Query(All())
 	assert.Equal(t, query.Count(), 3)
 	query.Close()
+}
 
-	w2 = NewWorld()
-	err = w2.UnmarshalEntities([]byte("pft"))
-	assert.NotNil(t, err)
+func TestWorldEntityDataEmpty(t *testing.T) {
+	w := NewWorld()
+
+	eData := w.GetEntityData()
+
+	w2 := NewWorld()
+	w2.SetEntityData(&eData)
+
+	e1 := w2.NewEntity()
+	e2 := w2.NewEntity()
+
+	assert.True(t, w2.Alive(e1))
+	assert.True(t, w2.Alive(e2))
+
+	query := w2.Query(All())
+	assert.Equal(t, query.Count(), 2)
+	query.Close()
 }
 
 func printTypeSize[T any]() {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1710,6 +1710,10 @@ func TestMarshalEntities(t *testing.T) {
 	query := w2.Query(All())
 	assert.Equal(t, query.Count(), 3)
 	query.Close()
+
+	w2 = NewWorld()
+	err = w2.UnmarshalEntities([]byte("pft"))
+	assert.NotNil(t, err)
 }
 
 func printTypeSize[T any]() {


### PR DESCRIPTION
Allows the world to serialize and deserialize the exact state of all entites (ids, generation, alive; but not components!)

This is required to make it possible to serialize (implicit or explicit) entity relations.

TODO:

* [x] Get rid of JSON
* [x] Infer pool and entity list capacity
* [x] Document the new functionality more comprehensively