### PR TITLE
Component ID getters in world and query copy ID slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ This change was necessary to get the same performance as before, despite the mor
 ### Features
 
 * Adds functions `ComponentInfo(*World, ID)` and `ResourceType(*World, ResID)` (#315, #318)
-* Adds methods `World.Ids(Entity)` and `Query.Ids()` (#315)
+* Adds methods `World.Ids(Entity)` and `Query.Ids()` to get component IDs for an entity (#315, #325)
 * Entities support JSON marshalling/unmarshalling (#319)
 * The world's entity state can be extracted and re-established via `World.GetEntityData()` and `World.SetEntityData()` (#319)
 

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -166,8 +166,12 @@ func (q *Query) Mask() Mask {
 }
 
 // Ids returns the component IDs for the archetype of the [Entity] at the iterator's current position.
+//
+// Returns a copy of the archetype's component IDs slice, for safety.
+// This means that the result can be manipulated safely,
+// but also that calling the method may incur some significant cost.
 func (q *Query) Ids() []ID {
-	return q.archetype.node.Ids
+	return append([]ID{}, q.archetype.node.Ids...)
 }
 
 // Close closes the Query and unlocks the world.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -1045,11 +1045,15 @@ func (w *World) Mask(entity Entity) Mask {
 }
 
 // Ids returns the component IDs for the archetype of the given [Entity].
+//
+// Returns a copy of the archetype's component IDs slice, for safety.
+// This means that the result can be manipulated safely,
+// but also that calling the method may incur some significant cost.
 func (w *World) Ids(entity Entity) []ID {
 	if !w.entityPool.Alive(entity) {
-		panic("can't get mask for a dead entity")
+		panic("can't get component IDs for a dead entity")
 	}
-	return w.entities[entity.id].arch.node.Ids
+	return append([]ID{}, w.entities[entity.id].arch.node.Ids...)
 }
 
 // ComponentType returns the reflect.Type for a given component ID, as well as whether the ID is in use.


### PR DESCRIPTION
Both return a copy of the archetype's component IDs slice, for safety.
This means that the result can be manipulated safely,
but also that calling the method may incur some significant cost.