### PR TITLE
Improve `EntityEvent` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * `Filters.Matches(Mask)` became `Filters.Matches(*Mask)`; same for all `Filter` implementations (#313)  
 This change was necessary to get the same performance as before, despite the more heavyweight implementation of the now 256 bits `Mask`.
 * Component and resource IDs are now opaque types instead of type aliases for `uint8` (#329)
+* Restructures `EntityEvent` to remove redundant information and better handle relation changes (#333)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 This change was necessary to get the same performance as before, despite the more heavyweight implementation of the now 256 bits `Mask`.
 * Component and resource IDs are now opaque types instead of type aliases for `uint8` (#329)
 * Restructures `EntityEvent` to remove redundant information and better handle relation changes (#333)
+* World event listener function signature changed from `func(*EntityEvent)` to `func(EntityEvent)` (#333)
 
 ### Features
 

--- a/ecs/bitmask_test.go
+++ b/ecs/bitmask_test.go
@@ -51,6 +51,22 @@ func TestBitMask(t *testing.T) {
 	assert.False(t, mask.ContainsAny(&other2))
 }
 
+func TestBitMaskCopy(t *testing.T) {
+	mask := All(id(1), id(2), id(13), id(27), id(200))
+	mask2 := mask
+	mask3 := &mask
+
+	mask2.Set(id(1), false)
+	mask3.Set(id(2), false)
+
+	assert.True(t, mask.Get(id(1)))
+	assert.False(t, mask2.Get(id(1)))
+
+	assert.True(t, mask2.Get(id(2)))
+	assert.False(t, mask.Get(id(2)))
+	assert.False(t, mask3.Get(id(2)))
+}
+
 func TestBitMaskWithoutExclusive(t *testing.T) {
 	mask := All(id(1), id(2), id(13))
 

--- a/ecs/bitmask_test.go
+++ b/ecs/bitmask_test.go
@@ -250,7 +250,7 @@ func BenchmarkMaskPointer(b *testing.B) {
 	_ = v
 }
 
-func BenchmarkMask(b *testing.B) {
+func BenchmarkMaskMatch(b *testing.B) {
 	b.StopTimer()
 	mask := All(id(0), id(1), id(2))
 	bits := All(id(0), id(1), id(2))
@@ -262,6 +262,18 @@ func BenchmarkMask(b *testing.B) {
 	b.StopTimer()
 	v = !v
 	_ = v
+}
+
+func BenchmarkMaskCopy(b *testing.B) {
+	b.StopTimer()
+	mask := All(id(0), id(1), id(2))
+	var tempMask Mask
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		tempMask = mask
+	}
+	b.StopTimer()
+	_ = tempMask
 }
 
 // bitMask64 is there just for performance comparison with the new 256 bit Mask.

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -1,10 +1,10 @@
 package ecs
 
-// EntityEvent contains information about component changes to an [Entity].
+// EntityEvent contains information about component and relation changes to an [Entity].
 //
 // To receive change events, register a function func(e *EntityEvent) with [World.SetListener].
 //
-// Events notified are entity creation, removal and changes to the component composition.
+// Events notified are entity creation, removal, changes to the component composition and change of relation targets.
 // Events are emitted immediately after the change is applied.
 //
 // Except for removed entities, events are always fired when the [World] is in an unlocked state.
@@ -20,10 +20,10 @@ package ecs
 // as the instance behind the pointer might be reused for further notifications.
 type EntityEvent struct {
 	Entity                   Entity // The entity that was changed.
-	OldMask                  Mask   // The old and new component masks.
-	Added, Removed           []ID   // Components added and removed. DO NOT MODIFY!
-	OldRelation, NewRelation *ID    // Old and new relation component ID. No relation id indicated by nil.
-	OldTarget                Entity // Old and new target entity.
+	OldMask                  Mask   // The old component masks. Get the new mask with [World.Mask].
+	Added, Removed           []ID   // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
+	OldRelation, NewRelation *ID    // Old and new relation component ID. No relation is indicated by nil.
+	OldTarget                Entity // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
 	AddedRemoved             int8   // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
 	RelationChanged          bool   // Whether the relation component has changed.
 	TargetChanged            bool   // Whether the relation target has changed. Will be false if the relation component changes, but the target does not.

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -15,9 +15,6 @@ package ecs
 // Events for batch-creation of entities using a [Builder] are fired after all entities are created.
 // For batch methods that return a [Query], events are fired after the [Query] is closed (or fully iterated).
 // This allows the [World] to be in an unlocked state, and notifies after potential entity initialization.
-//
-// Note that the event pointer received by the listener function should not be stored,
-// as the instance behind the pointer might be reused for further notifications.
 type EntityEvent struct {
 	Entity                   Entity // The entity that was changed.
 	OldMask                  Mask   // The old component masks. Get the new mask with [World.Mask].

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -19,12 +19,14 @@ package ecs
 // Note that the event pointer received by the listener function should not be stored,
 // as the instance behind the pointer might be reused for further notifications.
 type EntityEvent struct {
-	Entity                  Entity // The entity that was changed.
-	OldMask, NewMask        Mask   // The old and new component masks.
-	Added, Removed, Current []ID   // Components added, removed, and after the change. DO NOT MODIFY!
-	AddedRemoved            int    // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
-	OldTarget, NewTarget    Entity // Old and new target entity
-	TargetChanged           bool   // Whether this is (only) a change of the relation target.
+	Entity                   Entity // The entity that was changed.
+	OldMask                  Mask   // The old and new component masks.
+	Added, Removed           []ID   // Components added and removed. DO NOT MODIFY!
+	OldRelation, NewRelation *ID    // Old and new relation component ID. No relation id indicated by nil.
+	OldTarget                Entity // Old and new target entity.
+	AddedRemoved             int8   // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
+	RelationChanged          bool   // Whether the relation component has changed.
+	TargetChanged            bool   // Whether the relation target has changed. Will be false if the relation component changes, but the target does not.
 }
 
 // EntityAdded reports whether the entity was newly added.

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -45,12 +45,29 @@ func BenchmarkEntityEventCreate(b *testing.B) {
 	mask := ecs.All(posID)
 	added := []ecs.ID{posID}
 
+	var event ecs.EntityEvent
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		event = ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
+	}
+	b.StopTimer()
+	_ = event
+}
+
+func BenchmarkEntityEventHeapPointer(b *testing.B) {
+	b.StopTimer()
+	world := ecs.NewWorld()
+	posID := ecs.ComponentID[Position](&world)
+	e := world.NewEntity()
+	mask := ecs.All(posID)
+	added := []ecs.ID{posID}
+
 	var event *ecs.EntityEvent
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		temp := ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
-		event = &temp
+		event = &ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
 	}
 	b.StopTimer()
 	_ = event
@@ -93,11 +110,11 @@ func BenchmarkEntityEventPointerReuse(b *testing.B) {
 func ExampleEntityEvent() {
 	world := ecs.NewWorld()
 
-	listener := func(evt *ecs.EntityEvent) {
+	listener := func(evt ecs.EntityEvent) {
 		fmt.Println(evt)
 	}
 	world.SetListener(listener)
 
 	world.NewEntity()
-	// Output: &{{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
 }

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -37,6 +37,25 @@ func (h *eventHandler) ListenPointer(e *ecs.EntityEvent) {
 	h.LastEntity = e.Entity
 }
 
+func BenchmarkEntityEventCreate(b *testing.B) {
+	b.StopTimer()
+	world := ecs.NewWorld()
+	posID := ecs.ComponentID[Position](&world)
+	e := world.NewEntity()
+	mask := ecs.All(posID)
+	added := []ecs.ID{posID}
+
+	var event *ecs.EntityEvent
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		temp := ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
+		event = &temp
+	}
+	b.StopTimer()
+	_ = event
+}
+
 func BenchmarkEntityEventCopy(b *testing.B) {
 	handler := eventHandler{}
 

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -41,13 +41,13 @@ func BenchmarkEntityEventCopy(b *testing.B) {
 	handler := eventHandler{}
 
 	for i := 0; i < b.N; i++ {
-		handler.ListenCopy(ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, NewMask: ecs.Mask{}, Added: nil, Removed: nil, Current: nil, AddedRemoved: 0})
+		handler.ListenCopy(ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0})
 	}
 }
 
 func BenchmarkEntityEventCopyReuse(b *testing.B) {
 	handler := eventHandler{}
-	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, NewMask: ecs.Mask{}, Added: nil, Removed: nil, Current: nil, AddedRemoved: 0}
+	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0}
 
 	for i := 0; i < b.N; i++ {
 		handler.ListenCopy(event)
@@ -58,13 +58,13 @@ func BenchmarkEntityEventPointer(b *testing.B) {
 	handler := eventHandler{}
 
 	for i := 0; i < b.N; i++ {
-		handler.ListenPointer(&ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, NewMask: ecs.Mask{}, Added: nil, Removed: nil, Current: nil, AddedRemoved: 0})
+		handler.ListenPointer(&ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0})
 	}
 }
 
 func BenchmarkEntityEventPointerReuse(b *testing.B) {
 	handler := eventHandler{}
-	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, NewMask: ecs.Mask{}, Added: nil, Removed: nil, Current: nil, AddedRemoved: 0}
+	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0}
 
 	for i := 0; i < b.N; i++ {
 		handler.ListenPointer(&event)
@@ -80,5 +80,5 @@ func ExampleEntityEvent() {
 	world.SetListener(listener)
 
 	world.NewEntity()
-	// Output: &{{1 0} {[0 0 0 0]} {[0 0 0 0]} [] [] [] 1 {0 0} {0 0} false}
+	// Output: &{{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -680,10 +680,12 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRela
 
 	if hasRelation {
 		if !mask.Get(relation) {
-			panic("can't add relation: resulting entity has no relation")
+			tp, _ := w.registry.ComponentType(relation.id)
+			panic(fmt.Sprintf("can't add relation: resulting entity has no component %s", tp.Name()))
 		}
 		if !w.registry.IsRelation.Get(relation) {
-			panic("can't add relation: this is not a relation component")
+			tp, _ := w.registry.ComponentType(relation.id)
+			panic(fmt.Sprintf("can't add relation: %s is not a relation component", tp.Name()))
 		}
 	} else {
 		target = oldArch.RelationTarget

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -651,6 +651,9 @@ func (w *World) Remove(entity Entity, comps ...ID) {
 // Exchange adds and removes components in one pass.
 // This is more efficient than subsequent use of [World.Add] and [World.Remove].
 //
+// When a [Relation] component is removed and another one is added,
+// the target entity of the relation remains unchanged.
+//
 // Panics:
 //   - when called for a removed (and potentially recycled) entity.
 //   - when called with components that can't be added or removed because they are already present/not present, respectively.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -284,7 +284,7 @@ func (w *World) newEntityTarget(targetID ID, target Entity, comps ...ID) Entity 
 	}
 
 	if w.listener != nil {
-		w.listener(&EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, 1, !target.IsZero(), false})
+		w.listener(&EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
 	}
 	return entity
 }
@@ -317,7 +317,7 @@ func (w *World) newEntityTargetWith(targetID ID, target Entity, comps ...Compone
 	}
 
 	if w.listener != nil {
-		w.listener(&EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, 1, !target.IsZero(), false})
+		w.listener(&EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
 	}
 	return entity
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -329,8 +329,8 @@ func (w *World) newEntities(count int, targetID ID, hasTarget bool, target Entit
 
 	if w.listener != nil {
 		var newRel *ID
-		if hasTarget {
-			newRel = &targetID
+		if arch.HasRelationComponent {
+			newRel = &arch.RelationComponent
 		}
 
 		cnt := uint32(count)
@@ -371,8 +371,8 @@ func (w *World) newEntitiesWith(count int, targetID ID, hasTarget bool, target E
 
 	if w.listener != nil {
 		var newRel *ID
-		if hasTarget {
-			newRel = &targetID
+		if arch.HasRelationComponent {
+			newRel = &arch.RelationComponent
 		}
 
 		var i uint32
@@ -380,7 +380,7 @@ func (w *World) newEntitiesWith(count int, targetID ID, hasTarget bool, target E
 		for i = 0; i < cnt; i++ {
 			idx := startIdx + i
 			entity := arch.GetEntity(idx)
-			w.listener(&EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, hasTarget, !target.IsZero()})
+			w.listener(&EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, newRel != nil, !target.IsZero()})
 		}
 	}
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -424,9 +424,13 @@ func (w *World) RemoveEntity(entity Entity) {
 		if oldArch.HasRelationComponent {
 			oldRel = &oldArch.RelationComponent
 		}
+		var oldIds []ID
+		if len(oldArch.node.Ids) > 0 {
+			oldIds = oldArch.node.Ids
+		}
 
 		lock := w.lock()
-		w.listener(&EntityEvent{entity, oldArch.Mask, nil, oldArch.node.Ids, oldRel, nil, oldArch.RelationTarget, -1, oldRel != nil, !oldArch.RelationTarget.IsZero()})
+		w.listener(&EntityEvent{entity, oldArch.Mask, nil, oldIds, oldRel, nil, oldArch.RelationTarget, -1, oldRel != nil, !oldArch.RelationTarget.IsZero()})
 		w.unlock(lock)
 	}
 
@@ -466,22 +470,26 @@ func (w *World) removeEntities(filter Filter) int {
 	var i int32
 	for i = 0; i < numArches; i++ {
 		arch := arches[i]
-		len := arch.Len()
-		if len == 0 {
+		ln := arch.Len()
+		if ln == 0 {
 			continue
 		}
 
-		count += len
+		count += ln
 
 		var j uint32
-		for j = 0; j < len; j++ {
+		for j = 0; j < ln; j++ {
 			entity := arch.GetEntity(j)
 			if w.listener != nil {
 				var oldRel *ID
 				if arch.HasRelationComponent {
 					oldRel = &arch.RelationComponent
 				}
-				w.listener(&EntityEvent{entity, arch.Mask, nil, arch.node.Ids, oldRel, nil, Entity{}, -1, oldRel != nil, !arch.RelationTarget.IsZero()})
+				var oldIds []ID
+				if len(arch.node.Ids) > 0 {
+					oldIds = arch.node.Ids
+				}
+				w.listener(&EntityEvent{entity, arch.Mask, nil, oldIds, oldRel, nil, Entity{}, -1, oldRel != nil, !arch.RelationTarget.IsZero()})
 			}
 			index := &w.entities[entity.id]
 			index.arch = nil

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -319,7 +319,8 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 	builder.NewBatch(1000)
 	world.Batch().RemoveEntities(filterPos)
 
-	world.SetListener(func(e *EntityEvent) {})
+	var temp int8
+	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
@@ -329,6 +330,7 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 		b.StopTimer()
 		world.Batch().RemoveEntities(filterPos)
 	}
+	_ = temp
 }
 
 func BenchmarkWorldExchangeNoEvent_1000(b *testing.B) {
@@ -395,7 +397,8 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
 
-	world.SetListener(func(e *EntityEvent) {})
+	var temp int8
+	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
 
 	b.StartTimer()
 	hasPos := true
@@ -411,6 +414,7 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 		}
 		hasPos = !hasPos
 	}
+	_ = temp
 }
 
 func BenchmarkWorldExchangeBatchNoEvent_1000(b *testing.B) {
@@ -422,11 +426,7 @@ func BenchmarkWorldExchangeBatchNoEvent_1000(b *testing.B) {
 	velID := ComponentID[Velocity](&world)
 
 	builder := NewBuilder(&world, posID)
-	entities := make([]Entity, 0, 1000)
-	query := builder.NewBatchQ(1000)
-	for query.Next() {
-		entities = append(entities, query.Entity())
-	}
+	builder.NewBatch(1000)
 
 	filterPos := All(posID)
 	filterVel := All(velID)
@@ -453,17 +453,12 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 	b.StopTimer()
 
 	world := NewWorld()
-	world.SetListener(func(e *EntityEvent) {})
 
 	posID := ComponentID[Position](&world)
 	velID := ComponentID[Velocity](&world)
 
 	builder := NewBuilder(&world, posID)
-	entities := make([]Entity, 0, 1000)
-	query := builder.NewBatchQ(1000)
-	for query.Next() {
-		entities = append(entities, query.Entity())
-	}
+	builder.NewBatch(1000)
 
 	filterPos := All(posID)
 	filterVel := All(velID)
@@ -473,6 +468,9 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
+
+	var temp int8
+	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
 
 	b.StartTimer()
 	hasPos := true
@@ -484,4 +482,5 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 		}
 		hasPos = !hasPos
 	}
+	_ = temp
 }

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -284,3 +284,204 @@ func BenchmarkWorldStats_10Arch(b *testing.B) {
 	}
 	_ = st
 }
+
+func BenchmarkWorldNewEntityNoEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	filterPos := All(posID)
+
+	builder := NewBuilder(&world, posID)
+	builder.NewBatch(1000)
+	world.Batch().RemoveEntities(filterPos)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			world.NewEntity(posID)
+		}
+		b.StopTimer()
+		world.Batch().RemoveEntities(filterPos)
+	}
+}
+
+func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	filterPos := All(posID)
+
+	builder := NewBuilder(&world, posID)
+	builder.NewBatch(1000)
+	world.Batch().RemoveEntities(filterPos)
+
+	world.SetListener(func(e *EntityEvent) {})
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			world.NewEntity(posID)
+		}
+		b.StopTimer()
+		world.Batch().RemoveEntities(filterPos)
+	}
+}
+
+func BenchmarkWorldExchangeNoEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	builder := NewBuilder(&world, posID)
+	entities := make([]Entity, 0, 1000)
+	query := builder.NewBatchQ(1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			for _, e := range entities {
+				world.Exchange(e, vel, pos)
+			}
+		} else {
+			for _, e := range entities {
+				world.Exchange(e, pos, vel)
+			}
+		}
+		hasPos = !hasPos
+	}
+}
+
+func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	builder := NewBuilder(&world, posID)
+	entities := make([]Entity, 0, 1000)
+	query := builder.NewBatchQ(1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	world.SetListener(func(e *EntityEvent) {})
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			for _, e := range entities {
+				world.Exchange(e, vel, pos)
+			}
+		} else {
+			for _, e := range entities {
+				world.Exchange(e, pos, vel)
+			}
+		}
+		hasPos = !hasPos
+	}
+}
+
+func BenchmarkWorldExchangeBatchNoEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	builder := NewBuilder(&world, posID)
+	entities := make([]Entity, 0, 1000)
+	query := builder.NewBatchQ(1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			world.Batch().Exchange(filterPos, vel, pos)
+		} else {
+			world.Batch().Exchange(filterVel, pos, vel)
+		}
+		hasPos = !hasPos
+	}
+}
+
+func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+	world.SetListener(func(e *EntityEvent) {})
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	builder := NewBuilder(&world, posID)
+	entities := make([]Entity, 0, 1000)
+	query := builder.NewBatchQ(1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			world.Batch().Exchange(filterPos, vel, pos)
+		} else {
+			world.Batch().Exchange(filterVel, pos, vel)
+		}
+		hasPos = !hasPos
+	}
+}

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -275,13 +275,13 @@ func ExampleWorld_Batch() {
 func ExampleWorld_SetListener() {
 	world := ecs.NewWorld()
 
-	listener := func(evt *ecs.EntityEvent) {
+	listener := func(evt ecs.EntityEvent) {
 		fmt.Println(evt)
 	}
 	world.SetListener(listener)
 
 	world.NewEntity()
-	// Output: &{{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
 }
 
 func ExampleWorld_Stats() {

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -281,7 +281,7 @@ func ExampleWorld_SetListener() {
 	world.SetListener(listener)
 
 	world.NewEntity()
-	// Output: &{{1 0} {[0 0 0 0]} {[0 0 0 0]} [] [] [] 1 {0 0} {0 0} false}
+	// Output: &{{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
 }
 
 func ExampleWorld_Stats() {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -330,8 +330,8 @@ func TestWorldExchangeBatch(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	w.SetListener(func(e *EntityEvent) {
-		events = append(events, *e)
+	w.SetListener(func(e EntityEvent) {
+		events = append(events, e)
 	})
 
 	posID := ComponentID[Position](&w)
@@ -613,9 +613,9 @@ func TestWorldNewEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) {
+	world.SetListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
-		events = append(events, *e)
+		events = append(events, e)
 	})
 
 	posID := ComponentID[Position](&world)
@@ -688,9 +688,9 @@ func TestWorldNewEntitiesWith(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) {
+	world.SetListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
-		events = append(events, *e)
+		events = append(events, e)
 	})
 
 	posID := ComponentID[Position](&world)
@@ -762,9 +762,9 @@ func TestWorldRemoveEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) {
+	world.SetListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
-		events = append(events, *e)
+		events = append(events, e)
 	})
 
 	posID := ComponentID[Position](&world)
@@ -802,8 +802,8 @@ func TestWorldRelationSet(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) {
-		events = append(events, *e)
+	world.SetListener(func(e EntityEvent) {
+		events = append(events, e)
 	})
 
 	rotID := ComponentID[rotation](&world)
@@ -901,8 +901,8 @@ func TestWorldRelationSetBatch(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) {
-		events = append(events, *e)
+	world.SetListener(func(e EntityEvent) {
+		events = append(events, e)
 	})
 
 	posID := ComponentID[Position](&world)
@@ -972,7 +972,7 @@ func TestWorldRelationRemove(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	world.SetListener(func(e *EntityEvent) { events = append(events, *e) })
+	world.SetListener(func(e EntityEvent) { events = append(events, e) })
 
 	rotID := ComponentID[rotation](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1188,7 +1188,7 @@ func TestWorldRelation(t *testing.T) {
 
 func TestWorldRelationCreate(t *testing.T) {
 	world := NewWorld()
-	world.SetListener(func(e *EntityEvent) {})
+	world.SetListener(func(e EntityEvent) {})
 
 	posID := ComponentID[Position](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1228,7 +1228,7 @@ func TestWorldRelationCreate(t *testing.T) {
 
 func TestWorldRelationMove(t *testing.T) {
 	world := NewWorld()
-	world.SetListener(func(e *EntityEvent) {})
+	world.SetListener(func(e EntityEvent) {})
 
 	posID := ComponentID[Position](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1423,8 +1423,8 @@ func TestRegisterComponents(t *testing.T) {
 
 func TestWorldBatchRemove(t *testing.T) {
 	events := []EntityEvent{}
-	listen := func(e *EntityEvent) {
-		events = append(events, *e)
+	listen := func(e EntityEvent) {
+		events = append(events, e)
 	}
 
 	world := NewWorld()
@@ -1507,7 +1507,7 @@ func TestWorldBatchRemove(t *testing.T) {
 func TestWorldReset(t *testing.T) {
 	world := NewWorld()
 
-	world.SetListener(func(e *EntityEvent) {})
+	world.SetListener(func(e EntityEvent) {})
 	AddResource(&world, &rotation{100})
 
 	posID := ComponentID[Position](&world)
@@ -1583,8 +1583,8 @@ func TestArchetypeGraph(t *testing.T) {
 
 func TestWorldListener(t *testing.T) {
 	events := []EntityEvent{}
-	listen := func(e *EntityEvent) {
-		events = append(events, *e)
+	listen := func(e EntityEvent) {
+		events = append(events, e)
 	}
 
 	w := NewWorld()
@@ -1687,8 +1687,8 @@ func TestWorldListener(t *testing.T) {
 
 func TestWorldListenerBuilder(t *testing.T) {
 	events := []EntityEvent{}
-	listen := func(e *EntityEvent) {
-		events = append(events, *e)
+	listen := func(e EntityEvent) {
+		events = append(events, e)
 	}
 
 	w := NewWorld()

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -1609,6 +1609,136 @@ func TestWorldListener(t *testing.T) {
 
 }
 
+func TestWorldListenerBuilder(t *testing.T) {
+	events := []EntityEvent{}
+	listen := func(e *EntityEvent) {
+		events = append(events, *e)
+	}
+
+	w := NewWorld()
+
+	w.SetListener(listen)
+
+	posID := ComponentID[Position](&w)
+	relID := ComponentID[relationComp](&w)
+
+	parent := w.NewEntity(posID)
+
+	builder := NewBuilder(&w, posID, relID).WithRelation(relID)
+	builder.NewBatch(10)
+
+	assert.Equal(t, 11, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{11, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   false,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	query := builder.NewBatchQ(10)
+	query.Close()
+
+	assert.Equal(t, 21, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{21, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   false,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	builder.NewBatch(10, parent)
+
+	assert.Equal(t, 31, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{31, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   true,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	query = builder.NewBatchQ(10, parent)
+	query.Close()
+
+	assert.Equal(t, 41, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{41, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   true,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	builder = NewBuilderWith(&w,
+		Component{ID: posID, Comp: &Position{}},
+		Component{ID: relID, Comp: &relationComp{}},
+	).WithRelation(relID)
+
+	builder.NewBatch(10)
+
+	assert.Equal(t, 51, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{51, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   false,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	query = builder.NewBatchQ(10)
+	query.Close()
+
+	assert.Equal(t, 61, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{61, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   false,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	builder.NewBatch(10, parent)
+
+	assert.Equal(t, 71, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{71, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   true,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+
+	query = builder.NewBatchQ(10, parent)
+	query.Close()
+
+	assert.Equal(t, 81, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:          Entity{81, 0},
+		OldMask:         All(),
+		Added:           []ID{posID, relID},
+		NewRelation:     &relID,
+		RelationChanged: true,
+		TargetChanged:   true,
+		AddedRemoved:    1,
+	}, events[len(events)-1])
+}
+
 type withSlice struct {
 	Slice []int
 }

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -31,7 +31,7 @@ type Listener struct {
 }
 
 // Listen is called on entity changes.
-func (l *Listener) Listen(evt *ecs.EntityEvent) {
+func (l *Listener) Listen(evt ecs.EntityEvent) {
 	// Just prints out what the event is about.
 	// This could also be a method of a type that manages events.
 	// Could use e.g. filters to distribute events to interested/registered systems.

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -25,23 +25,29 @@ type Rotation struct {
 	A float64
 }
 
+// Listener type
+type Listener struct {
+	World *ecs.World
+}
+
 // Listen is called on entity changes.
-func Listen(evt *ecs.EntityEvent) {
+func (l *Listener) Listen(evt *ecs.EntityEvent) {
 	// Just prints out what the event is about.
 	// This could also be a method of a type that manages events.
 	// Could use e.g. filters to distribute events to interested/registered systems.
 	if evt.EntityAdded() {
-		fmt.Printf("Entity added, has components %v\n", evt.Current)
+		fmt.Printf("Entity added, has components %v\n", l.World.Ids(evt.Entity))
 	} else if evt.EntityRemoved() {
-		fmt.Printf("Entity removed, had components %v\n", evt.Current)
+		fmt.Printf("Entity removed, had components %v\n", l.World.Ids(evt.Entity))
 	} else {
-		fmt.Printf("Entity changed, has components %v\n", evt.Current)
+		fmt.Printf("Entity changed, has components %v\n", l.World.Ids(evt.Entity))
 	}
 }
 
 func main() {
 	// Create a World.
 	world := ecs.NewWorld()
+	listener := Listener{World: &world}
 
 	// Get component IDs
 	posID := ecs.ComponentID[Position](&world)
@@ -49,7 +55,7 @@ func main() {
 	rotID := ecs.ComponentID[Rotation](&world)
 
 	// Register a listener function.
-	world.SetListener(Listen)
+	world.SetListener(listener.Listen)
 
 	// Create/manipulate/delete entities and observe the listener's output
 	e0 := world.NewEntity(posID)

--- a/generic/exchange.go
+++ b/generic/exchange.go
@@ -67,6 +67,9 @@ func (m *Exchange) Remove(entity ecs.Entity) {
 // Removes the components set via [Exchange.Removes].
 // Adds the components set via [Exchange.Adds].
 //
+// When a [Relation] component is removed and another one is added,
+// the target entity of the relation remains unchanged.
+//
 // See also [ecs.World.Exchange].
 func (m *Exchange) Exchange(entity ecs.Entity) {
 	m.world.Exchange(entity, m.add, m.remove)


### PR DESCRIPTION
* Pass events by value/copy instead of by pointer. It torned out heap escape is much more expensive than copying.
* Removes event fields that are accessible from the world.
* Adds event fields to better identify relation changes.
* Reduces the size of `EntityEvent` by 30%.