### PR TITLE
Listener subscriptions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
     - main
   pull_request:
-    branches:
-    - main
 
 jobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Arche supports full world serialization and deserialization, in conjunction with [arche-serde](https://github.com/mlange-42/arche-serde) (#319)
 * Supports 256 instead of 128 component types as well as resource types and engine locks (#313)
 * Generic API supports up to 12 instead of 8 component types (#324)
+* Reworked event system with independent subscription for different event types (#333, #334)
 
 ### Breaking changes
 
@@ -16,7 +17,7 @@
 This change was necessary to get the same performance as before, despite the more heavyweight implementation of the now 256 bits `Mask`.
 * Component and resource IDs are now opaque types instead of type aliases for `uint8` (#329)
 * Restructures `EntityEvent` to remove redundant information and better handle relation changes (#333)
-* World event listener function signature changed from `func(*EntityEvent)` to `func(EntityEvent)` (#333)
+* World event listener changed from a simple function to a `Listener` interface (#334)
 
 ### Features
 

--- a/doc.go
+++ b/doc.go
@@ -4,5 +4,6 @@
 //   - Core API -- [github.com/mlange-42/arche/ecs]
 //   - Generic queries -- [github.com/mlange-42/arche/generic]
 //   - Advanced filters -- [github.com/mlange-42/arche/filter]
+//   - Event listeners -- [github.com/mlange-42/arche/listener]
 //   - Usage examples -- [github.com/mlange-42/arche/examples]
 package arche

--- a/ecs/batch.go
+++ b/ecs/batch.go
@@ -55,6 +55,9 @@ func (b *Batch) RemoveQ(filter Filter, comps ...ID) Query {
 
 // SetRelation sets the [Relation] target for many entities, matching a filter.
 //
+// Entities that match the filter but already have the desired target entity are not processed,
+// and no events are emitted for them.
+//
 // Panics:
 //   - when called for a missing component.
 //   - when called for a component that is not a relation.
@@ -67,6 +70,9 @@ func (b *Batch) SetRelation(filter Filter, comp ID, target Entity) {
 
 // SetRelationQ sets the [Relation] target for many entities, matching a filter.
 // It returns a query over the affected entities.
+//
+// Entities that match the filter but already have the desired target entity are not processed,
+// not included in the query, and no events are emitted for them.
 //
 // Panics:
 //   - when called for a missing component.

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -1,5 +1,7 @@
 package ecs
 
+import "github.com/mlange-42/arche/ecs/event"
+
 // EntityEvent contains information about component and relation changes to an [Entity].
 //
 // To receive change events, register a function func(e *EntityEvent) with [World.SetListener].
@@ -16,101 +18,73 @@ package ecs
 // For batch methods that return a [Query], events are fired after the [Query] is closed (or fully iterated).
 // This allows the [World] to be in an unlocked state, and notifies after potential entity initialization.
 type EntityEvent struct {
-	Entity                   Entity       // The entity that was changed.
-	OldMask                  Mask         // The old component masks. Get the new mask with [World.Mask].
-	Added, Removed           []ID         // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
-	OldRelation, NewRelation *ID          // Old and new relation component ID. No relation is indicated by nil.
-	OldTarget                Entity       // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
-	EventTypes               Subscription // Bit mask of event types. See [Subscription].
+	Entity                   Entity             // The entity that was changed.
+	OldMask                  Mask               // The old component masks. Get the new mask with [World.Mask].
+	Added, Removed           []ID               // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
+	OldRelation, NewRelation *ID                // Old and new relation component ID. No relation is indicated by nil.
+	OldTarget                Entity             // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
+	EventTypes               event.Subscription // Bit mask of event types. See [Subscription].
 }
 
 // EntityAdded reports whether the entity was newly added.
 func (e *EntityEvent) EntityAdded() bool {
-	return e.EventTypes.Contains(EntityCreated)
+	return e.EventTypes.Contains(event.EntityCreated)
 }
 
 // EntityRemoved reports whether the entity was removed.
 func (e *EntityEvent) EntityRemoved() bool {
-	return e.EventTypes.Contains(EntityRemoved)
+	return e.EventTypes.Contains(event.EntityRemoved)
 }
 
-// Subscription bits for a [Listener]
-type Subscription uint8
-
-const (
-	// EntityCreated subscription bit
-	EntityCreated Subscription = 0b00000001
-	// EntityRemoved subscription bit
-	EntityRemoved Subscription = 0b00000010
-	// ComponentAdded subscription bit
-	ComponentAdded Subscription = 0b00000100
-	// ComponentRemoved subscription bit
-	ComponentRemoved Subscription = 0b000001000
-	// RelationChanged subscription bit
-	RelationChanged Subscription = 0b000010000
-	// TargetChanged subscription bit
-	TargetChanged Subscription = 0b000100000
-)
-
-func subscription(entityCreated, entityRemoved, componentAdded, componentRemoved, relationChanged, targetChanged bool) Subscription {
-	var bits Subscription = 0
+func subscription(entityCreated, entityRemoved, componentAdded, componentRemoved, relationChanged, targetChanged bool) event.Subscription {
+	var bits event.Subscription = 0
 	if entityCreated {
-		bits |= EntityCreated
+		bits |= event.EntityCreated
 	}
 	if entityRemoved {
-		bits |= EntityRemoved
+		bits |= event.EntityRemoved
 	}
 	if componentAdded {
-		bits |= ComponentAdded
+		bits |= event.ComponentAdded
 	}
 	if componentRemoved {
-		bits |= ComponentRemoved
+		bits |= event.ComponentRemoved
 	}
 	if relationChanged {
-		bits |= RelationChanged
+		bits |= event.RelationChanged
 	}
 	if targetChanged {
-		bits |= TargetChanged
+		bits |= event.TargetChanged
 	}
 	return bits
-}
-
-// Contains checks whether the argument is in this Subscription.
-func (s Subscription) Contains(bit Subscription) bool {
-	return (bit & s) == bit
-}
-
-// ContainsAny checks whether any of the argument's bits is in this Subscription.
-func (s Subscription) ContainsAny(bit Subscription) bool {
-	return (bit & s) != 0
 }
 
 // Listener interface
 type Listener interface {
 	Notify(e EntityEvent)
-	Subscriptions() Subscription
+	Subscriptions() event.Subscription
 }
 
-// CallbackListener for [EntityEvent]s.
-type CallbackListener struct {
+// testListener for [EntityEvent]s.
+type testListener struct {
 	Callback  func(e EntityEvent)
-	Subscribe Subscription
+	Subscribe event.Subscription
 }
 
-// NewCallbackListener creates a new [CallbackListener] that subscribes to all event types.
-func NewCallbackListener(callback func(e EntityEvent)) CallbackListener {
-	return CallbackListener{
+// newTestListener creates a new [CallbackListener] that subscribes to all event types.
+func newTestListener(callback func(e EntityEvent)) testListener {
+	return testListener{
 		Callback:  callback,
-		Subscribe: EntityCreated | EntityRemoved | ComponentAdded | ComponentRemoved | RelationChanged | TargetChanged,
+		Subscribe: event.EntityCreated | event.EntityRemoved | event.ComponentAdded | event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
 	}
 }
 
 // Notify the listener
-func (l *CallbackListener) Notify(e EntityEvent) {
+func (l *testListener) Notify(e EntityEvent) {
 	l.Callback(e)
 }
 
 // Subscriptions of the listener
-func (l *CallbackListener) Subscriptions() Subscription {
+func (l *testListener) Subscriptions() event.Subscription {
 	return l.Subscribe
 }

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -16,14 +16,15 @@ package ecs
 // For batch methods that return a [Query], events are fired after the [Query] is closed (or fully iterated).
 // This allows the [World] to be in an unlocked state, and notifies after potential entity initialization.
 type EntityEvent struct {
-	Entity                   Entity // The entity that was changed.
-	OldMask                  Mask   // The old component masks. Get the new mask with [World.Mask].
-	Added, Removed           []ID   // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
-	OldRelation, NewRelation *ID    // Old and new relation component ID. No relation is indicated by nil.
-	OldTarget                Entity // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
-	AddedRemoved             int8   // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
-	RelationChanged          bool   // Whether the relation component has changed.
-	TargetChanged            bool   // Whether the relation target has changed. Will be false if the relation component changes, but the target does not.
+	Entity                   Entity       // The entity that was changed.
+	OldMask                  Mask         // The old component masks. Get the new mask with [World.Mask].
+	Added, Removed           []ID         // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
+	OldRelation, NewRelation *ID          // Old and new relation component ID. No relation is indicated by nil.
+	OldTarget                Entity       // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
+	EventTypes               Subscription // Bit mask of event types.
+	AddedRemoved             int8         // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
+	RelationChanged          bool         // Whether the relation component has changed.
+	TargetChanged            bool         // Whether the relation target has changed. Will be false if the relation component changes, but the target does not.
 }
 
 // EntityAdded reports whether the entity was newly added.
@@ -36,26 +37,83 @@ func (e *EntityEvent) EntityRemoved() bool {
 	return e.AddedRemoved < 0
 }
 
-// Listener for [EntityEvent]s.
-type Listener struct {
-	Callback         func(e EntityEvent)
-	EntityCreated    bool
-	EntityRemoved    bool
-	ComponentAdded   bool
-	ComponentRemoved bool
-	RelationChanged  bool
-	TargetChanged    bool
+// Subscription bits for a [Listener]
+type Subscription uint8
+
+const (
+	// EntityCreated subscription bit
+	EntityCreated Subscription = 0b00000001
+	// EntityRemoved subscription bit
+	EntityRemoved Subscription = 0b00000010
+	// ComponentAdded subscription bit
+	ComponentAdded Subscription = 0b00000100
+	// ComponentRemoved subscription bit
+	ComponentRemoved Subscription = 0b000001000
+	// RelationChanged subscription bit
+	RelationChanged Subscription = 0b000010000
+	// TargetChanged subscription bit
+	TargetChanged Subscription = 0b000100000
+)
+
+func subscription(entityCreated, entityRemoved, componentAdded, componentRemoved, relationChanged, targetChanged bool) Subscription {
+	var bits Subscription = 0
+	if entityCreated {
+		bits |= EntityCreated
+	}
+	if entityRemoved {
+		bits |= EntityRemoved
+	}
+	if componentAdded {
+		bits |= ComponentAdded
+	}
+	if componentRemoved {
+		bits |= ComponentRemoved
+	}
+	if relationChanged {
+		bits |= RelationChanged
+	}
+	if targetChanged {
+		bits |= TargetChanged
+	}
+	return bits
 }
 
-// NewListener creates a new [Listener] that subscribes to all event types.
-func NewListener(callback func(e EntityEvent)) Listener {
-	return Listener{
-		Callback:         callback,
-		EntityCreated:    true,
-		EntityRemoved:    true,
-		ComponentAdded:   true,
-		ComponentRemoved: true,
-		RelationChanged:  true,
-		TargetChanged:    true,
+// Contains checks whether the argument is in this Subscription.
+func (s Subscription) Contains(bit Subscription) bool {
+	return (bit & s) == bit
+}
+
+// ContainsAny checks whether any of the argument's bits is in this Subscription.
+func (s Subscription) ContainsAny(bit Subscription) bool {
+	return (bit & s) != 0
+}
+
+// Listener interface
+type Listener interface {
+	Notify(e EntityEvent)
+	Subscriptions() Subscription
+}
+
+// CallbackListener for [EntityEvent]s.
+type CallbackListener struct {
+	Callback  func(e EntityEvent)
+	Subscribe Subscription
+}
+
+// NewCallbackListener creates a new [CallbackListener] that subscribes to all event types.
+func NewCallbackListener(callback func(e EntityEvent)) CallbackListener {
+	return CallbackListener{
+		Callback:  callback,
+		Subscribe: EntityCreated | EntityRemoved | ComponentAdded | ComponentRemoved | RelationChanged | TargetChanged,
 	}
+}
+
+// Notify the listener
+func (l *CallbackListener) Notify(e EntityEvent) {
+	l.Callback(e)
+}
+
+// Subscriptions of the listener
+func (l *CallbackListener) Subscriptions() Subscription {
+	return l.Subscribe
 }

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -21,20 +21,17 @@ type EntityEvent struct {
 	Added, Removed           []ID         // Components added and removed. DO NOT MODIFY! Get the current components with [World.Ids].
 	OldRelation, NewRelation *ID          // Old and new relation component ID. No relation is indicated by nil.
 	OldTarget                Entity       // Old relation target entity. Get the new target with [World.Relations] and [Relations.Get].
-	EventTypes               Subscription // Bit mask of event types.
-	AddedRemoved             int8         // Whether the entity itself was added (> 0), removed (< 0), or only changed (= 0).
-	RelationChanged          bool         // Whether the relation component has changed.
-	TargetChanged            bool         // Whether the relation target has changed. Will be false if the relation component changes, but the target does not.
+	EventTypes               Subscription // Bit mask of event types. See [Subscription].
 }
 
 // EntityAdded reports whether the entity was newly added.
 func (e *EntityEvent) EntityAdded() bool {
-	return e.AddedRemoved > 0
+	return e.EventTypes.Contains(EntityCreated)
 }
 
 // EntityRemoved reports whether the entity was removed.
 func (e *EntityEvent) EntityRemoved() bool {
-	return e.AddedRemoved < 0
+	return e.EventTypes.Contains(EntityRemoved)
 }
 
 // Subscription bits for a [Listener]

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -41,7 +41,7 @@ func (e *EntityEvent) Contains(bit event.Subscription) bool {
 // See [EntityEvent] for details.
 type Listener interface {
 	// Notify the listener about a subscribed event.
-	Notify(e EntityEvent)
+	Notify(evt EntityEvent)
 	// Subscriptions to event types.
 	Subscriptions() event.Subscription
 }

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -35,3 +35,27 @@ func (e *EntityEvent) EntityAdded() bool {
 func (e *EntityEvent) EntityRemoved() bool {
 	return e.AddedRemoved < 0
 }
+
+// Listener for [EntityEvent]s.
+type Listener struct {
+	Callback         func(e EntityEvent)
+	EntityCreated    bool
+	EntityRemoved    bool
+	ComponentAdded   bool
+	ComponentRemoved bool
+	RelationChanged  bool
+	TargetChanged    bool
+}
+
+// NewListener creates a new [Listener] that subscribes to all event types.
+func NewListener(callback func(e EntityEvent)) Listener {
+	return Listener{
+		Callback:         callback,
+		EntityCreated:    true,
+		EntityRemoved:    true,
+		ComponentAdded:   true,
+		ComponentRemoved: true,
+		RelationChanged:  true,
+		TargetChanged:    true,
+	}
+}

--- a/ecs/event/event.go
+++ b/ecs/event/event.go
@@ -3,6 +3,7 @@
 // See also ecs.Listener and ecs.EntityEvent.
 package event
 
+// Subscription bits for individual events
 const (
 	// EntityCreated subscription bit
 	EntityCreated Subscription = 0b00000001
@@ -17,26 +18,28 @@ const (
 	// TargetChanged subscription bit
 	TargetChanged Subscription = 0b000100000
 )
+
+// Subscription bits for groups of events
 const (
-	// All subscriptions
-	All Subscription = EntityCreated | EntityRemoved | ComponentAdded | ComponentRemoved | RelationChanged | TargetChanged
 	// Entities subscription for entity creation or removal
 	Entities Subscription = EntityCreated | EntityRemoved
 	// Components subscription for component addition or removal
 	Components Subscription = ComponentAdded | ComponentRemoved
 	// Relations subscription for relation and target changes
 	Relations Subscription = RelationChanged | TargetChanged
+	// All subscriptions
+	All Subscription = Entities | Components | Relations
 )
 
 // Subscription bits for an ecs.Listener
 type Subscription uint8
 
-// Contains checks whether the argument is in this Subscription.
-func (s Subscription) Contains(bit Subscription) bool {
-	return (bit & s) == bit
+// Contains checks whether all the argument's bits are contained in this Subscription.
+func (s Subscription) Contains(bits Subscription) bool {
+	return (bits & s) == bits
 }
 
-// ContainsAny checks whether any of the argument's bits is in this Subscription.
-func (s Subscription) ContainsAny(bit Subscription) bool {
-	return (bit & s) != 0
+// ContainsAny checks whether any of the argument's bits are contained in this Subscription.
+func (s Subscription) ContainsAny(bits Subscription) bool {
+	return (bits & s) != 0
 }

--- a/ecs/event/event.go
+++ b/ecs/event/event.go
@@ -1,0 +1,42 @@
+// Package event contains a mask type and bit switches for listener subscriptions.
+//
+// See also ecs.Listener and ecs.EntityEvent.
+package event
+
+const (
+	// EntityCreated subscription bit
+	EntityCreated Subscription = 0b00000001
+	// EntityRemoved subscription bit
+	EntityRemoved Subscription = 0b00000010
+	// ComponentAdded subscription bit
+	ComponentAdded Subscription = 0b00000100
+	// ComponentRemoved subscription bit
+	ComponentRemoved Subscription = 0b000001000
+	// RelationChanged subscription bit
+	RelationChanged Subscription = 0b000010000
+	// TargetChanged subscription bit
+	TargetChanged Subscription = 0b000100000
+)
+const (
+	// All subscriptions
+	All Subscription = EntityCreated | EntityRemoved | ComponentAdded | ComponentRemoved | RelationChanged | TargetChanged
+	// Entities subscription for entity creation or removal
+	Entities Subscription = EntityCreated | EntityRemoved
+	// Components subscription for component addition or removal
+	Components Subscription = ComponentAdded | ComponentRemoved
+	// Relations subscription for relation and target changes
+	Relations Subscription = RelationChanged | TargetChanged
+)
+
+// Subscription bits for an ecs.Listener
+type Subscription uint8
+
+// Contains checks whether the argument is in this Subscription.
+func (s Subscription) Contains(bit Subscription) bool {
+	return (bit & s) == bit
+}
+
+// ContainsAny checks whether any of the argument's bits is in this Subscription.
+func (s Subscription) ContainsAny(bit Subscription) bool {
+	return (bit & s) != 0
+}

--- a/ecs/event/event_test.go
+++ b/ecs/event/event_test.go
@@ -1,0 +1,18 @@
+package event_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscriptions(t *testing.T) {
+	m1 := event.EntityCreated | event.TargetChanged
+
+	assert.True(t, m1.Contains(event.EntityCreated))
+	assert.False(t, m1.Contains(event.EntityRemoved))
+
+	assert.True(t, m1.ContainsAny(event.ComponentAdded|event.TargetChanged))
+	assert.False(t, m1.Contains(event.ComponentAdded|event.RelationChanged))
+}

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -12,18 +12,18 @@ import (
 func TestEntityEvent(t *testing.T) {
 	e := ecs.EntityEvent{EventTypes: event.ComponentAdded}
 
-	assert.False(t, e.EntityAdded())
-	assert.False(t, e.EntityRemoved())
+	assert.False(t, e.Contains(event.EntityCreated))
+	assert.False(t, e.Contains(event.EntityRemoved))
 
 	e = ecs.EntityEvent{EventTypes: event.EntityCreated | event.ComponentAdded}
 
-	assert.True(t, e.EntityAdded())
-	assert.False(t, e.EntityRemoved())
+	assert.True(t, e.Contains(event.EntityCreated))
+	assert.False(t, e.Contains(event.EntityRemoved))
 
 	e = ecs.EntityEvent{EventTypes: event.EntityRemoved | event.ComponentRemoved}
 
-	assert.False(t, e.EntityAdded())
-	assert.True(t, e.EntityRemoved())
+	assert.False(t, e.Contains(event.EntityCreated))
+	assert.True(t, e.Contains(event.EntityRemoved))
 }
 
 type eventHandler struct {
@@ -118,4 +118,13 @@ func ExampleEntityEvent() {
 
 	world.NewEntity()
 	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1}
+}
+
+func ExampleEntityEvent_Contains() {
+	mask := event.EntityCreated | event.EntityRemoved
+
+	fmt.Println(mask.Contains(event.EntityRemoved))
+	fmt.Println(mask.Contains(event.RelationChanged))
+	// Output: true
+	// false
 }

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 func TestEntityEvent(t *testing.T) {
-	e := ecs.EntityEvent{AddedRemoved: 0}
+	e := ecs.EntityEvent{EventTypes: ecs.ComponentAdded}
 
 	assert.False(t, e.EntityAdded())
 	assert.False(t, e.EntityRemoved())
 
-	e = ecs.EntityEvent{AddedRemoved: 1}
+	e = ecs.EntityEvent{EventTypes: ecs.EntityCreated | ecs.ComponentAdded}
 
 	assert.True(t, e.EntityAdded())
 	assert.False(t, e.EntityRemoved())
 
-	e = ecs.EntityEvent{AddedRemoved: -1}
+	e = ecs.EntityEvent{EventTypes: ecs.EntityRemoved | ecs.ComponentRemoved}
 
 	assert.False(t, e.EntityAdded())
 	assert.True(t, e.EntityRemoved())
@@ -49,7 +49,7 @@ func BenchmarkEntityEventCreate(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		event = ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
+		event = ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil}
 	}
 	b.StopTimer()
 	_ = event
@@ -67,7 +67,7 @@ func BenchmarkEntityEventHeapPointer(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		event = &ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil, AddedRemoved: 0}
+		event = &ecs.EntityEvent{Entity: e, OldMask: mask, Added: added, Removed: nil}
 	}
 	b.StopTimer()
 	_ = event
@@ -77,13 +77,13 @@ func BenchmarkEntityEventCopy(b *testing.B) {
 	handler := eventHandler{}
 
 	for i := 0; i < b.N; i++ {
-		handler.ListenCopy(ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0})
+		handler.ListenCopy(ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil})
 	}
 }
 
 func BenchmarkEntityEventCopyReuse(b *testing.B) {
 	handler := eventHandler{}
-	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0}
+	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil}
 
 	for i := 0; i < b.N; i++ {
 		handler.ListenCopy(event)
@@ -94,13 +94,13 @@ func BenchmarkEntityEventPointer(b *testing.B) {
 	handler := eventHandler{}
 
 	for i := 0; i < b.N; i++ {
-		handler.ListenPointer(&ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0})
+		handler.ListenPointer(&ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil})
 	}
 }
 
 func BenchmarkEntityEventPointerReuse(b *testing.B) {
 	handler := eventHandler{}
-	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil, AddedRemoved: 0}
+	event := ecs.EntityEvent{Entity: ecs.Entity{}, OldMask: ecs.Mask{}, Added: nil, Removed: nil}
 
 	for i := 0; i < b.N; i++ {
 		handler.ListenPointer(&event)
@@ -116,5 +116,5 @@ func ExampleEntityEvent() {
 	world.SetListener(&listener)
 
 	world.NewEntity()
-	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1}
 }

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -110,11 +110,11 @@ func BenchmarkEntityEventPointerReuse(b *testing.B) {
 func ExampleEntityEvent() {
 	world := ecs.NewWorld()
 
-	listener := ecs.NewListener(
+	listener := ecs.NewCallbackListener(
 		func(evt ecs.EntityEvent) { fmt.Println(evt) },
 	)
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	world.NewEntity()
-	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 1 false false}
 }

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -5,21 +5,22 @@ import (
 	"testing"
 
 	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEntityEvent(t *testing.T) {
-	e := ecs.EntityEvent{EventTypes: ecs.ComponentAdded}
+	e := ecs.EntityEvent{EventTypes: event.ComponentAdded}
 
 	assert.False(t, e.EntityAdded())
 	assert.False(t, e.EntityRemoved())
 
-	e = ecs.EntityEvent{EventTypes: ecs.EntityCreated | ecs.ComponentAdded}
+	e = ecs.EntityEvent{EventTypes: event.EntityCreated | event.ComponentAdded}
 
 	assert.True(t, e.EntityAdded())
 	assert.False(t, e.EntityRemoved())
 
-	e = ecs.EntityEvent{EventTypes: ecs.EntityRemoved | ecs.ComponentRemoved}
+	e = ecs.EntityEvent{EventTypes: event.EntityRemoved | event.ComponentRemoved}
 
 	assert.False(t, e.EntityAdded())
 	assert.True(t, e.EntityRemoved())
@@ -110,7 +111,7 @@ func BenchmarkEntityEventPointerReuse(b *testing.B) {
 func ExampleEntityEvent() {
 	world := ecs.NewWorld()
 
-	listener := ecs.NewCallbackListener(
+	listener := NewTestListener(
 		func(evt ecs.EntityEvent) { fmt.Println(evt) },
 	)
 	world.SetListener(&listener)

--- a/ecs/event_test.go
+++ b/ecs/event_test.go
@@ -110,9 +110,9 @@ func BenchmarkEntityEventPointerReuse(b *testing.B) {
 func ExampleEntityEvent() {
 	world := ecs.NewWorld()
 
-	listener := func(evt ecs.EntityEvent) {
-		fmt.Println(evt)
-	}
+	listener := ecs.NewListener(
+		func(evt ecs.EntityEvent) { fmt.Println(evt) },
+	)
 	world.SetListener(listener)
 
 	world.NewEntity()

--- a/ecs/util.go
+++ b/ecs/util.go
@@ -3,6 +3,8 @@ package ecs
 import (
 	"fmt"
 	"strings"
+
+	"github.com/mlange-42/arche/ecs/event"
 )
 
 // Page size of pagedSlice type
@@ -37,6 +39,30 @@ func capacityU32(size, increment uint32) uint32 {
 		cap += increment
 	}
 	return cap
+}
+
+// Creates an [event.Subscription] mask from the given booleans.
+func subscription(entityCreated, entityRemoved, componentAdded, componentRemoved, relationChanged, targetChanged bool) event.Subscription {
+	var bits event.Subscription = 0
+	if entityCreated {
+		bits |= event.EntityCreated
+	}
+	if entityRemoved {
+		bits |= event.EntityRemoved
+	}
+	if componentAdded {
+		bits |= event.ComponentAdded
+	}
+	if componentRemoved {
+		bits |= event.ComponentRemoved
+	}
+	if relationChanged {
+		bits |= event.RelationChanged
+	}
+	if targetChanged {
+		bits |= event.TargetChanged
+	}
+	return bits
 }
 
 func maskToTypes(mask Mask, reg *componentRegistry) []componentType {

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -114,7 +114,7 @@ func AddResource[T any](w *World, res *T) ResID {
 // [World.Batch], [World.Cache] and [Builder].
 type World struct {
 	config         Config                // World configuration.
-	listener       func(e EntityEvent)   // Component change listener.
+	listener       Listener              // EntityEvent listener.
 	resources      Resources             // World resources.
 	entities       []entityIndex         // Mapping from entities to archetype and index.
 	targetEntities bitSet                // Whether entities are potential relation targets.
@@ -169,7 +169,7 @@ func fromConfig(conf Config) World {
 		nodes:          pagedSlice[archNode]{},
 		relationNodes:  []*archNode{},
 		locks:          lockMask{},
-		listener:       nil,
+		listener:       Listener{},
 		resources:      newResources(),
 		filterCache:    newCache(),
 	}
@@ -207,12 +207,12 @@ func (w *World) NewEntity(comps ...ID) Entity {
 
 	entity := w.createEntity(arch)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.EntityCreated {
 		var newRel *ID
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
 		}
-		w.listener(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, 1, newRel != nil, false})
+		w.listener.Callback(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, 1, newRel != nil, false})
 	}
 	return entity
 }
@@ -252,12 +252,12 @@ func (w *World) NewEntityWith(comps ...Component) Entity {
 		w.copyTo(entity, c.ID, c.Comp)
 	}
 
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.EntityCreated {
 		var newRel *ID
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
 		}
-		w.listener(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, newRel != nil, false})
+		w.listener.Callback(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, newRel != nil, false})
 	}
 	return entity
 }
@@ -283,8 +283,8 @@ func (w *World) newEntityTarget(targetID ID, target Entity, comps ...ID) Entity 
 		w.targetEntities.Set(target.id, true)
 	}
 
-	if w.listener != nil {
-		w.listener(EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
+	if w.listener.Callback != nil && w.listener.EntityCreated {
+		w.listener.Callback(EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
 	}
 	return entity
 }
@@ -316,8 +316,8 @@ func (w *World) newEntityTargetWith(targetID ID, target Entity, comps ...Compone
 		w.copyTo(entity, c.ID, c.Comp)
 	}
 
-	if w.listener != nil {
-		w.listener(EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
+	if w.listener.Callback != nil && w.listener.EntityCreated {
+		w.listener.Callback(EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, 1, true, !target.IsZero()})
 	}
 	return entity
 }
@@ -327,7 +327,7 @@ func (w *World) newEntityTargetWith(targetID ID, target Entity, comps ...Compone
 func (w *World) newEntities(count int, targetID ID, hasTarget bool, target Entity, comps ...ID) (*archetype, uint32) {
 	arch, startIdx := w.newEntitiesNoNotify(count, targetID, hasTarget, target, comps...)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.EntityCreated {
 		var newRel *ID
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
@@ -338,7 +338,7 @@ func (w *World) newEntities(count int, targetID ID, hasTarget bool, target Entit
 		for i = 0; i < cnt; i++ {
 			idx := startIdx + i
 			entity := arch.GetEntity(idx)
-			w.listener(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, 1, newRel != nil, !target.IsZero()})
+			w.listener.Callback(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, 1, newRel != nil, !target.IsZero()})
 		}
 	}
 
@@ -369,7 +369,7 @@ func (w *World) newEntitiesWith(count int, targetID ID, hasTarget bool, target E
 
 	arch, startIdx := w.newEntitiesWithNoNotify(count, targetID, hasTarget, target, ids, comps...)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.EntityCreated {
 		var newRel *ID
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
@@ -380,7 +380,7 @@ func (w *World) newEntitiesWith(count int, targetID ID, hasTarget bool, target E
 		for i = 0; i < cnt; i++ {
 			idx := startIdx + i
 			entity := arch.GetEntity(idx)
-			w.listener(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, newRel != nil, !target.IsZero()})
+			w.listener.Callback(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, 1, newRel != nil, !target.IsZero()})
 		}
 	}
 
@@ -419,7 +419,7 @@ func (w *World) RemoveEntity(entity Entity) {
 	index := &w.entities[entity.id]
 	oldArch := index.arch
 
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.EntityRemoved {
 		var oldRel *ID
 		if oldArch.HasRelationComponent {
 			oldRel = &oldArch.RelationComponent
@@ -430,7 +430,7 @@ func (w *World) RemoveEntity(entity Entity) {
 		}
 
 		lock := w.lock()
-		w.listener(EntityEvent{entity, oldArch.Mask, nil, oldIds, oldRel, nil, oldArch.RelationTarget, -1, oldRel != nil, !oldArch.RelationTarget.IsZero()})
+		w.listener.Callback(EntityEvent{entity, oldArch.Mask, nil, oldIds, oldRel, nil, oldArch.RelationTarget, -1, oldRel != nil, !oldArch.RelationTarget.IsZero()})
 		w.unlock(lock)
 	}
 
@@ -463,6 +463,8 @@ func (w *World) removeEntities(filter Filter) int {
 
 	lock := w.lock()
 
+	listen := w.listener.Callback != nil && w.listener.EntityRemoved
+
 	var count uint32
 
 	arches := w.getArchetypes(filter)
@@ -477,19 +479,22 @@ func (w *World) removeEntities(filter Filter) int {
 
 		count += ln
 
+		var oldRel *ID
+		var oldIds []ID
+		if listen {
+			if arch.HasRelationComponent {
+				oldRel = &arch.RelationComponent
+			}
+			if len(arch.node.Ids) > 0 {
+				oldIds = arch.node.Ids
+			}
+		}
+
 		var j uint32
 		for j = 0; j < ln; j++ {
 			entity := arch.GetEntity(j)
-			if w.listener != nil {
-				var oldRel *ID
-				if arch.HasRelationComponent {
-					oldRel = &arch.RelationComponent
-				}
-				var oldIds []ID
-				if len(arch.node.Ids) > 0 {
-					oldIds = arch.node.Ids
-				}
-				w.listener(EntityEvent{entity, arch.Mask, nil, oldIds, oldRel, nil, Entity{}, -1, oldRel != nil, !arch.RelationTarget.IsZero()})
+			if listen {
+				w.listener.Callback(EntityEvent{entity, arch.Mask, nil, oldIds, oldRel, nil, Entity{}, -1, oldRel != nil, !arch.RelationTarget.IsZero()})
 			}
 			index := &w.entities[entity.id]
 			index.arch = nil
@@ -730,7 +735,7 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRela
 
 	w.cleanupArchetype(oldArch)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil {
 		var newRel *ID
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
@@ -739,7 +744,16 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRela
 		if oldRel != nil || newRel != nil {
 			relChanged = (oldRel == nil) != (newRel == nil) || *oldRel != *newRel
 		}
-		w.listener(EntityEvent{entity, oldMask, add, rem, oldRel, newRel, oldTarget, 0, relChanged, oldTarget != arch.RelationTarget})
+		targChanged := oldTarget != arch.RelationTarget
+
+		listen := (w.listener.ComponentAdded && len(add) > 0) ||
+			(w.listener.ComponentRemoved && len(rem) > 0) ||
+			(w.listener.RelationChanged && relChanged) ||
+			(w.listener.TargetChanged && targChanged)
+
+		if listen {
+			w.listener.Callback(EntityEvent{entity, oldMask, add, rem, oldRel, newRel, oldTarget, 0, relChanged, targChanged})
+		}
 	}
 }
 
@@ -778,7 +792,7 @@ func (w *World) exchangeBatch(filter Filter, add []ID, rem []ID) {
 
 	w.exchangeBatchNoNotify(filter, add, rem, &batches)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil {
 		w.notifyQuery(&batches)
 	}
 }
@@ -936,8 +950,8 @@ func (w *World) setRelation(entity Entity, comp ID, target Entity) {
 	oldTarget := oldArch.RelationTarget
 	w.cleanupArchetype(oldArch)
 
-	if w.listener != nil {
-		w.listener(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, 0, false, true})
+	if w.listener.Callback != nil && w.listener.TargetChanged {
+		w.listener.Callback(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, 0, false, true})
 	}
 }
 
@@ -945,7 +959,7 @@ func (w *World) setRelation(entity Entity, comp ID, target Entity) {
 func (w *World) setRelationBatch(filter Filter, comp ID, target Entity) {
 	batches := batchArchetypes{}
 	w.setRelationBatchNoNotify(filter, comp, target, &batches)
-	if w.listener != nil {
+	if w.listener.Callback != nil && w.listener.TargetChanged {
 		w.notifyQuery(&batches)
 	}
 }
@@ -974,6 +988,10 @@ func (w *World) setRelationBatchNoNotify(filter Filter, comp ID, target Entity, 
 		archLen := lengths[i]
 
 		if archLen == 0 {
+			continue
+		}
+
+		if arch.RelationTarget == target {
 			continue
 		}
 
@@ -1145,7 +1163,7 @@ func (w *World) ComponentType(id ID) (reflect.Type, bool) {
 // Replaces the current listener. Call with nil to remove a listener.
 //
 // For details, see [EntityEvent].
-func (w *World) SetListener(listener func(e EntityEvent)) {
+func (w *World) SetListener(listener Listener) {
 	w.listener = listener
 }
 
@@ -1618,7 +1636,7 @@ func (w *World) closeQuery(query *Query) {
 	query.archIndex = -2
 	w.unlock(query.lockBit)
 
-	if w.listener != nil {
+	if w.listener.Callback != nil {
 		if arch, ok := query.nodeArchetypes.(*batchArchetypes); ok {
 			w.notifyQuery(arch)
 		}
@@ -1661,12 +1679,21 @@ func (w *World) notifyQuery(batchArch *batchArchetypes) {
 			event.TargetChanged = oldArch.RelationTarget != arch.RelationTarget
 		}
 
-		start, end := batchArch.StartIndex[i], batchArch.EndIndex[i]
-		var e uint32
-		for e = start; e < end; e++ {
-			entity := arch.GetEntity(e)
-			event.Entity = entity
-			w.listener(event)
+		listen := (w.listener.EntityCreated && event.AddedRemoved > 0) ||
+			(w.listener.EntityRemoved && event.AddedRemoved < 0) ||
+			(w.listener.ComponentAdded && len(event.Added) > 0) ||
+			(w.listener.ComponentRemoved && len(event.Removed) > 0) ||
+			(w.listener.RelationChanged && event.RelationChanged) ||
+			(w.listener.TargetChanged && event.TargetChanged)
+
+		if listen {
+			start, end := batchArch.StartIndex[i], batchArch.EndIndex[i]
+			var e uint32
+			for e = start; e < end; e++ {
+				entity := arch.GetEntity(e)
+				event.Entity = entity
+				w.listener.Callback(event)
+			}
 		}
 	}
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
+	"github.com/mlange-42/arche/ecs/event"
 	"github.com/mlange-42/arche/ecs/stats"
 )
 
@@ -482,7 +483,7 @@ func (w *World) removeEntities(filter Filter) int {
 
 	lock := w.lock()
 
-	var bits Subscription
+	var bits event.Subscription
 	var listen bool
 
 	var count uint32
@@ -968,8 +969,8 @@ func (w *World) setRelation(entity Entity, comp ID, target Entity) {
 	oldTarget := oldArch.RelationTarget
 	w.cleanupArchetype(oldArch)
 
-	if w.listener != nil && w.listener.Subscriptions().Contains(TargetChanged) {
-		w.listener.Notify(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, TargetChanged})
+	if w.listener != nil && w.listener.Subscriptions().Contains(event.TargetChanged) {
+		w.listener.Notify(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, event.TargetChanged})
 	}
 }
 
@@ -977,7 +978,7 @@ func (w *World) setRelation(entity Entity, comp ID, target Entity) {
 func (w *World) setRelationBatch(filter Filter, comp ID, target Entity) {
 	batches := batchArchetypes{}
 	w.setRelationBatchNoNotify(filter, comp, target, &batches)
-	if w.listener != nil && w.listener.Subscriptions().Contains(TargetChanged) {
+	if w.listener != nil && w.listener.Subscriptions().Contains(event.TargetChanged) {
 		w.notifyQuery(&batches)
 	}
 }

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -214,7 +214,7 @@ func (w *World) NewEntity(comps ...ID) Entity {
 		}
 		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, false)
 		if w.listener.Subscriptions().ContainsAny(bits) {
-			w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, bits, 1, newRel != nil, false})
+			w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, bits})
 		}
 	}
 	return entity
@@ -262,7 +262,7 @@ func (w *World) NewEntityWith(comps ...Component) Entity {
 		}
 		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, false)
 		if w.listener.Subscriptions().ContainsAny(bits) {
-			w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, bits, 1, newRel != nil, false})
+			w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, bits})
 		}
 	}
 	return entity
@@ -292,7 +292,7 @@ func (w *World) newEntityTarget(targetID ID, target Entity, comps ...ID) Entity 
 	if w.listener != nil {
 		bits := subscription(true, false, len(comps) > 0, false, true, !target.IsZero())
 		if w.listener.Subscriptions().ContainsAny(bits) {
-			w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, bits, 1, true, !target.IsZero()})
+			w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, &targetID, Entity{}, bits})
 		}
 	}
 	return entity
@@ -328,7 +328,7 @@ func (w *World) newEntityTargetWith(targetID ID, target Entity, comps ...Compone
 	if w.listener != nil {
 		bits := subscription(true, false, len(comps) > 0, false, true, !target.IsZero())
 		if w.listener.Subscriptions().ContainsAny(bits) {
-			w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, bits, 1, true, !target.IsZero()})
+			w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, &targetID, Entity{}, bits})
 		}
 	}
 	return entity
@@ -351,7 +351,7 @@ func (w *World) newEntities(count int, targetID ID, hasTarget bool, target Entit
 			for i = 0; i < cnt; i++ {
 				idx := startIdx + i
 				entity := arch.GetEntity(idx)
-				w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, bits, 1, newRel != nil, !target.IsZero()})
+				w.listener.Notify(EntityEvent{entity, Mask{}, comps, nil, nil, newRel, Entity{}, bits})
 			}
 		}
 	}
@@ -395,7 +395,7 @@ func (w *World) newEntitiesWith(count int, targetID ID, hasTarget bool, target E
 			for i = 0; i < cnt; i++ {
 				idx := startIdx + i
 				entity := arch.GetEntity(idx)
-				w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, bits, 1, newRel != nil, !target.IsZero()})
+				w.listener.Notify(EntityEvent{entity, Mask{}, ids, nil, nil, newRel, Entity{}, bits})
 			}
 		}
 	}
@@ -448,7 +448,7 @@ func (w *World) RemoveEntity(entity Entity) {
 		bits := subscription(false, true, false, len(oldIds) > 0, oldRel != nil, !oldArch.RelationTarget.IsZero())
 		if w.listener.Subscriptions().ContainsAny(bits) {
 			lock := w.lock()
-			w.listener.Notify(EntityEvent{entity, oldArch.Mask, nil, oldIds, oldRel, nil, oldArch.RelationTarget, bits, -1, oldRel != nil, !oldArch.RelationTarget.IsZero()})
+			w.listener.Notify(EntityEvent{entity, oldArch.Mask, nil, oldIds, oldRel, nil, oldArch.RelationTarget, bits})
 			w.unlock(lock)
 		}
 	}
@@ -516,7 +516,7 @@ func (w *World) removeEntities(filter Filter) int {
 		for j = 0; j < ln; j++ {
 			entity := arch.GetEntity(j)
 			if listen {
-				w.listener.Notify(EntityEvent{entity, arch.Mask, nil, oldIds, oldRel, nil, Entity{}, bits, -1, oldRel != nil, !arch.RelationTarget.IsZero()})
+				w.listener.Notify(EntityEvent{entity, arch.Mask, nil, oldIds, oldRel, nil, Entity{}, bits})
 			}
 			index := &w.entities[entity.id]
 			index.arch = nil
@@ -770,7 +770,7 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRela
 
 		bits := subscription(false, false, len(add) > 0, len(rem) > 0, relChanged, targChanged)
 		if w.listener.Subscriptions().ContainsAny(bits) {
-			w.listener.Notify(EntityEvent{entity, oldMask, add, rem, oldRel, newRel, oldTarget, bits, 0, relChanged, targChanged})
+			w.listener.Notify(EntityEvent{entity, oldMask, add, rem, oldRel, newRel, oldTarget, bits})
 		}
 	}
 }
@@ -969,7 +969,7 @@ func (w *World) setRelation(entity Entity, comp ID, target Entity) {
 	w.cleanupArchetype(oldArch)
 
 	if w.listener != nil && w.listener.Subscriptions().Contains(TargetChanged) {
-		w.listener.Notify(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, TargetChanged, 0, false, true})
+		w.listener.Notify(EntityEvent{entity, arch.Mask, nil, nil, &comp, &comp, oldTarget, TargetChanged})
 	}
 }
 
@@ -1680,12 +1680,12 @@ func (w *World) notifyQuery(batchArch *batchArchetypes) {
 		event := EntityEvent{
 			Entity{}, Mask{}, batchArch.Added, batchArch.Removed,
 			nil, newRel,
-			Entity{}, 0, 1, newRel != nil, !arch.RelationTarget.IsZero(),
+			Entity{}, 0,
 		}
 
 		oldArch := batchArch.OldArchetype[i]
-		relChanged := event.RelationChanged
-		targChanged := event.TargetChanged
+		relChanged := newRel != nil
+		targChanged := !arch.RelationTarget.IsZero()
 
 		if oldArch != nil {
 			var oldRel *ID
@@ -1700,9 +1700,6 @@ func (w *World) notifyQuery(batchArch *batchArchetypes) {
 			event.OldMask = oldArch.node.Mask
 			event.OldTarget = oldArch.RelationTarget
 			event.OldRelation = oldRel
-			event.AddedRemoved = 0
-			event.RelationChanged = relChanged
-			event.TargetChanged = targChanged
 		}
 
 		bits := subscription(oldArch == nil, false, len(batchArch.Added) > 0, len(batchArch.Removed) > 0, relChanged, targChanged)

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -320,7 +320,8 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 	world.Batch().RemoveEntities(filterPos)
 
 	var temp int8
-	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(listener)
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
@@ -398,7 +399,8 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterVel, pos, vel)
 
 	var temp int8
-	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(listener)
 
 	b.StartTimer()
 	hasPos := true
@@ -470,7 +472,8 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterVel, pos, vel)
 
 	var temp int8
-	world.SetListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(listener)
 
 	b.StartTimer()
 	hasPos := true

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -319,8 +319,8 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 	builder.NewBatch(1000)
 	world.Batch().RemoveEntities(filterPos)
 
-	var temp int8
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	var temp Subscription
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	for i := 0; i < b.N; i++ {
@@ -398,8 +398,8 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
 
-	var temp int8
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	var temp Subscription
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	b.StartTimer()
@@ -471,8 +471,8 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
 
-	var temp int8
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	var temp Subscription
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	b.StartTimer()

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"testing"
 
+	"github.com/mlange-42/arche/ecs/event"
 	"github.com/mlange-42/arche/ecs/stats"
 )
 
@@ -319,8 +320,8 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 	builder.NewBatch(1000)
 	world.Batch().RemoveEntities(filterPos)
 
-	var temp Subscription
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
+	var temp event.Subscription
+	listener := newTestListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	for i := 0; i < b.N; i++ {
@@ -398,8 +399,8 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
 
-	var temp Subscription
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
+	var temp event.Subscription
+	listener := newTestListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	b.StartTimer()
@@ -471,8 +472,8 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterPos, vel, pos)
 	world.Batch().Exchange(filterVel, pos, vel)
 
-	var temp Subscription
-	listener := NewCallbackListener(func(e EntityEvent) { temp = e.EventTypes })
+	var temp event.Subscription
+	listener := newTestListener(func(e EntityEvent) { temp = e.EventTypes })
 	world.SetListener(&listener)
 
 	b.StartTimer()

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -320,8 +320,8 @@ func BenchmarkWorldNewEntityEvent_1000(b *testing.B) {
 	world.Batch().RemoveEntities(filterPos)
 
 	var temp int8
-	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(&listener)
 
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
@@ -399,8 +399,8 @@ func BenchmarkWorldExchangeEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterVel, pos, vel)
 
 	var temp int8
-	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(&listener)
 
 	b.StartTimer()
 	hasPos := true
@@ -472,8 +472,8 @@ func BenchmarkWorldExchangeBatchEvent_1000(b *testing.B) {
 	world.Batch().Exchange(filterVel, pos, vel)
 
 	var temp int8
-	listener := NewListener(func(e EntityEvent) { temp = e.AddedRemoved })
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) { temp = e.AddedRemoved })
+	world.SetListener(&listener)
 
 	b.StartTimer()
 	hasPos := true

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -294,17 +294,15 @@ func ExampleWorld_Stats() {
 	// Output: Entities -- Used: 0, Recycled: 0, Total: 0, Capacity: 128
 }
 
-// TestListener for [EntityEvent]s.
+// TestListener for all [EntityEvent]s.
 type TestListener struct {
-	Callback  func(e ecs.EntityEvent)
-	Subscribe event.Subscription
+	Callback func(e ecs.EntityEvent)
 }
 
 // NewTestListener creates a new [TestListener] that subscribes to all event types.
 func NewTestListener(callback func(e ecs.EntityEvent)) TestListener {
 	return TestListener{
-		Callback:  callback,
-		Subscribe: event.EntityCreated | event.EntityRemoved | event.ComponentAdded | event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
+		Callback: callback,
 	}
 }
 
@@ -315,5 +313,5 @@ func (l *TestListener) Notify(e ecs.EntityEvent) {
 
 // Subscriptions of the listener
 func (l *TestListener) Subscriptions() event.Subscription {
-	return l.Subscribe
+	return event.All
 }

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -275,9 +275,9 @@ func ExampleWorld_Batch() {
 func ExampleWorld_SetListener() {
 	world := ecs.NewWorld()
 
-	listener := func(evt ecs.EntityEvent) {
+	listener := ecs.NewListener(func(evt ecs.EntityEvent) {
 		fmt.Println(evt)
-	}
+	})
 	world.SetListener(listener)
 
 	world.NewEntity()

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
 )
 
 func ExampleComponentID() {
@@ -275,9 +276,11 @@ func ExampleWorld_Batch() {
 func ExampleWorld_SetListener() {
 	world := ecs.NewWorld()
 
-	listener := ecs.NewCallbackListener(func(evt ecs.EntityEvent) {
-		fmt.Println(evt)
-	})
+	listener := NewTestListener(
+		func(evt ecs.EntityEvent) {
+			fmt.Println(evt)
+		},
+	)
 	world.SetListener(&listener)
 
 	world.NewEntity()
@@ -289,4 +292,28 @@ func ExampleWorld_Stats() {
 	stats := world.Stats()
 	fmt.Println(stats.Entities.String())
 	// Output: Entities -- Used: 0, Recycled: 0, Total: 0, Capacity: 128
+}
+
+// TestListener for [EntityEvent]s.
+type TestListener struct {
+	Callback  func(e ecs.EntityEvent)
+	Subscribe event.Subscription
+}
+
+// NewTestListener creates a new [TestListener] that subscribes to all event types.
+func NewTestListener(callback func(e ecs.EntityEvent)) TestListener {
+	return TestListener{
+		Callback:  callback,
+		Subscribe: event.EntityCreated | event.EntityRemoved | event.ComponentAdded | event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
+	}
+}
+
+// Notify the listener
+func (l *TestListener) Notify(e ecs.EntityEvent) {
+	l.Callback(e)
+}
+
+// Subscriptions of the listener
+func (l *TestListener) Subscriptions() event.Subscription {
+	return l.Subscribe
 }

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -275,13 +275,13 @@ func ExampleWorld_Batch() {
 func ExampleWorld_SetListener() {
 	world := ecs.NewWorld()
 
-	listener := ecs.NewListener(func(evt ecs.EntityEvent) {
+	listener := ecs.NewCallbackListener(func(evt ecs.EntityEvent) {
 		fmt.Println(evt)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	world.NewEntity()
-	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 1 false false}
 }
 
 func ExampleWorld_Stats() {

--- a/ecs/world_examples_test.go
+++ b/ecs/world_examples_test.go
@@ -281,7 +281,7 @@ func ExampleWorld_SetListener() {
 	world.SetListener(&listener)
 
 	world.NewEntity()
-	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1 1 false false}
+	// Output: {{1 0} {[0 0 0 0]} [] [] <nil> <nil> {0 0} 1}
 }
 
 func ExampleWorld_Stats() {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -330,10 +330,10 @@ func TestWorldExchangeBatch(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	w.SetListener(listener)
+	w.SetListener(&listener)
 
 	posID := ComponentID[Position](&w)
 	velID := ComponentID[Velocity](&w)
@@ -351,6 +351,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		Entity:          Entity{202, 0},
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		AddedRemoved:    1,
 		RelationChanged: true,
 		TargetChanged:   true,
@@ -388,6 +389,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		OldRelation:     &relID,
 		NewRelation:     &relID,
 		OldTarget:       target1,
+		EventTypes:      ComponentAdded | ComponentRemoved,
 		AddedRemoved:    0,
 		RelationChanged: false,
 		TargetChanged:   false,
@@ -411,6 +413,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		OldRelation:     &relID,
 		NewRelation:     nil,
 		OldTarget:       target1,
+		EventTypes:      ComponentRemoved | RelationChanged | TargetChanged,
 		AddedRemoved:    0,
 		RelationChanged: true,
 		TargetChanged:   true,
@@ -424,6 +427,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		Entity:          Entity{102, 0},
 		OldMask:         All(posID),
 		Removed:         []ID{posID},
+		EventTypes:      EntityRemoved | ComponentRemoved,
 		AddedRemoved:    -1,
 		RelationChanged: false,
 		TargetChanged:   false,
@@ -614,11 +618,11 @@ func TestWorldNewEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	rotID := ComponentID[rotation](&world)
@@ -690,11 +694,11 @@ func TestWorldNewEntitiesWith(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	rotID := ComponentID[rotation](&world)
@@ -765,11 +769,11 @@ func TestWorldRemoveEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	rotID := ComponentID[rotation](&world)
@@ -806,10 +810,10 @@ func TestWorldRelationSet(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	rotID := ComponentID[rotation](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -834,6 +838,7 @@ func TestWorldRelationSet(t *testing.T) {
 		OldRelation:   &relID,
 		NewRelation:   &relID,
 		OldTarget:     Entity{},
+		EventTypes:    TargetChanged,
 		TargetChanged: true,
 	}, events[len(events)-1])
 
@@ -852,6 +857,7 @@ func TestWorldRelationSet(t *testing.T) {
 		OldRelation:   &relID,
 		NewRelation:   &relID,
 		OldTarget:     targ,
+		EventTypes:    TargetChanged,
 		TargetChanged: true,
 	}, events[len(events)-1])
 
@@ -877,6 +883,7 @@ func TestWorldRelationSet(t *testing.T) {
 		Removed:         []ID{relID},
 		OldRelation:     &relID,
 		NewRelation:     nil,
+		EventTypes:      ComponentRemoved | RelationChanged,
 		RelationChanged: true,
 		TargetChanged:   false,
 	}, events[len(events)-1])
@@ -906,10 +913,10 @@ func TestWorldRelationSetBatch(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	rotID := ComponentID[rotation](&world)
@@ -995,10 +1002,10 @@ func TestWorldRelationRemove(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	rotID := ComponentID[rotation](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1215,8 +1222,8 @@ func TestWorldRelation(t *testing.T) {
 func TestWorldRelationCreate(t *testing.T) {
 	world := NewWorld()
 
-	listener := NewListener(func(e EntityEvent) {})
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) {})
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1256,8 +1263,8 @@ func TestWorldRelationCreate(t *testing.T) {
 
 func TestWorldRelationMove(t *testing.T) {
 	world := NewWorld()
-	listener := NewListener(func(e EntityEvent) {})
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) {})
+	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1454,10 +1461,10 @@ func TestWorldBatchRemove(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	world.SetListener(listener)
+	world.SetListener(&listener)
 
 	rotID := ComponentID[rotation](&world)
 	relID := ComponentID[testRelationA](&world)
@@ -1469,6 +1476,7 @@ func TestWorldBatchRemove(t *testing.T) {
 	assert.Equal(t, 3, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:       target3,
+		EventTypes:   EntityCreated,
 		AddedRemoved: 1,
 	}, events[len(events)-1])
 
@@ -1483,6 +1491,7 @@ func TestWorldBatchRemove(t *testing.T) {
 		Entity:          Entity{33, 0},
 		Added:           []ID{rotID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		AddedRemoved:    1,
 		RelationChanged: true,
 		TargetChanged:   true,
@@ -1504,6 +1513,7 @@ func TestWorldBatchRemove(t *testing.T) {
 		OldMask:         All(rotID, relID),
 		Removed:         []ID{rotID, relID},
 		OldRelation:     &relID,
+		EventTypes:      EntityRemoved | ComponentRemoved | RelationChanged | TargetChanged,
 		AddedRemoved:    -1,
 		RelationChanged: true,
 		TargetChanged:   true,
@@ -1520,6 +1530,7 @@ func TestWorldBatchRemove(t *testing.T) {
 	assert.Equal(t, 56, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:       Entity{3, 0},
+		EventTypes:   EntityRemoved,
 		AddedRemoved: -1,
 	}, events[len(events)-1])
 
@@ -1535,8 +1546,8 @@ func TestWorldBatchRemove(t *testing.T) {
 
 func TestWorldReset(t *testing.T) {
 	world := NewWorld()
-	listener := NewListener(func(e EntityEvent) {})
-	world.SetListener(listener)
+	listener := NewCallbackListener(func(e EntityEvent) {})
+	world.SetListener(&listener)
 
 	AddResource(&world, &rotation{100})
 
@@ -1615,10 +1626,10 @@ func TestWorldListener(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	w.SetListener(listener)
+	w.SetListener(&listener)
 
 	posID := ComponentID[Position](&w)
 	velID := ComponentID[Velocity](&w)
@@ -1628,13 +1639,17 @@ func TestWorldListener(t *testing.T) {
 	e0 := w.NewEntity()
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity: e0, AddedRemoved: 1,
+		Entity:       e0,
+		EventTypes:   EntityCreated,
+		AddedRemoved: 1,
 	}, events[len(events)-1])
 
 	w.RemoveEntity(e0)
 	assert.Equal(t, 2, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity: e0, AddedRemoved: -1,
+		Entity:       e0,
+		EventTypes:   EntityRemoved,
+		AddedRemoved: -1,
 	}, events[len(events)-1])
 
 	e0 = w.NewEntity(posID, velID)
@@ -1642,6 +1657,7 @@ func TestWorldListener(t *testing.T) {
 	assert.Equal(t, EntityEvent{
 		Entity:       e0,
 		Added:        []ID{posID, velID},
+		EventTypes:   EntityCreated | ComponentAdded,
 		AddedRemoved: 1,
 	}, events[len(events)-1])
 
@@ -1651,6 +1667,7 @@ func TestWorldListener(t *testing.T) {
 		Entity:       e0,
 		OldMask:      All(posID, velID),
 		Removed:      []ID{posID, velID},
+		EventTypes:   EntityRemoved | ComponentRemoved,
 		AddedRemoved: -1,
 	}, events[len(events)-1])
 
@@ -1660,6 +1677,7 @@ func TestWorldListener(t *testing.T) {
 		Entity:          e0,
 		Added:           []ID{posID, velID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
 		AddedRemoved:    1,
 		RelationChanged: true,
 	}, events[len(events)-1])
@@ -1672,6 +1690,7 @@ func TestWorldListener(t *testing.T) {
 		Added:        []ID{rotID},
 		OldRelation:  &relID,
 		NewRelation:  &relID,
+		EventTypes:   ComponentAdded,
 		AddedRemoved: 0,
 	}, events[len(events)-1])
 
@@ -1683,6 +1702,7 @@ func TestWorldListener(t *testing.T) {
 		Removed:      []ID{posID},
 		OldRelation:  &relID,
 		NewRelation:  &relID,
+		EventTypes:   ComponentRemoved,
 		AddedRemoved: 0,
 	}, events[len(events)-1])
 
@@ -1694,6 +1714,7 @@ func TestWorldListener(t *testing.T) {
 		OldMask:       All(velID, rotID, relID),
 		OldRelation:   &relID,
 		NewRelation:   &relID,
+		EventTypes:    TargetChanged,
 		TargetChanged: true,
 		AddedRemoved:  0,
 	}, events[len(events)-1])
@@ -1707,6 +1728,7 @@ func TestWorldListener(t *testing.T) {
 		OldRelation:     &relID,
 		NewRelation:     nil,
 		OldTarget:       e1,
+		EventTypes:      ComponentRemoved | RelationChanged | TargetChanged,
 		RelationChanged: true,
 		TargetChanged:   true,
 		AddedRemoved:    0,
@@ -1718,10 +1740,10 @@ func TestWorldListenerBuilder(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewListener(func(e EntityEvent) {
+	listener := NewCallbackListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
-	w.SetListener(listener)
+	w.SetListener(&listener)
 
 	posID := ComponentID[Position](&w)
 	relID := ComponentID[relationComp](&w)
@@ -1737,6 +1759,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
 		RelationChanged: true,
 		TargetChanged:   false,
 		AddedRemoved:    1,
@@ -1751,6 +1774,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
 		RelationChanged: true,
 		TargetChanged:   false,
 		AddedRemoved:    1,
@@ -1764,6 +1788,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		RelationChanged: true,
 		TargetChanged:   true,
 		AddedRemoved:    1,
@@ -1778,6 +1803,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		RelationChanged: true,
 		TargetChanged:   true,
 		AddedRemoved:    1,
@@ -1796,6 +1822,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
 		RelationChanged: true,
 		TargetChanged:   false,
 		AddedRemoved:    1,
@@ -1810,6 +1837,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
 		RelationChanged: true,
 		TargetChanged:   false,
 		AddedRemoved:    1,
@@ -1823,6 +1851,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		RelationChanged: true,
 		TargetChanged:   true,
 		AddedRemoved:    1,
@@ -1837,6 +1866,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:         All(),
 		Added:           []ID{posID, relID},
 		NewRelation:     &relID,
+		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 		RelationChanged: true,
 		TargetChanged:   true,
 		AddedRemoved:    1,

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -602,7 +602,7 @@ func TestWorldNewEntities(t *testing.T) {
 
 	events := []EntityEvent{}
 	listener := newTestListener(func(e EntityEvent) {
-		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
+		assert.Equal(t, world.IsLocked(), e.Contains(event.EntityRemoved))
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -678,7 +678,7 @@ func TestWorldNewEntitiesWith(t *testing.T) {
 
 	events := []EntityEvent{}
 	listener := newTestListener(func(e EntityEvent) {
-		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
+		assert.Equal(t, world.IsLocked(), e.Contains(event.EntityRemoved))
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -753,7 +753,7 @@ func TestWorldRemoveEntities(t *testing.T) {
 
 	events := []EntityEvent{}
 	listener := newTestListener(func(e EntityEvent) {
-		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
+		assert.Equal(t, world.IsLocked(), e.Contains(event.EntityRemoved))
 		events = append(events, e)
 	})
 	world.SetListener(&listener)

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/mlange-42/arche/ecs/event"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -330,7 +331,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	w.SetListener(&listener)
@@ -351,7 +352,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		Entity:      Entity{202, 0},
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[201])
 
 	filter := All(posID, relID)
@@ -386,7 +387,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		OldRelation: &relID,
 		NewRelation: &relID,
 		OldTarget:   target1,
-		EventTypes:  ComponentAdded | ComponentRemoved,
+		EventTypes:  event.ComponentAdded | event.ComponentRemoved,
 	}, events[501])
 
 	query = w.Query(All(posID))
@@ -407,7 +408,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		OldRelation: &relID,
 		NewRelation: nil,
 		OldTarget:   target1,
-		EventTypes:  ComponentRemoved | RelationChanged | TargetChanged,
+		EventTypes:  event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
 	}, events[701])
 
 	w.Batch().RemoveEntities(All(posID))
@@ -418,7 +419,7 @@ func TestWorldExchangeBatch(t *testing.T) {
 		Entity:     Entity{102, 0},
 		OldMask:    All(posID),
 		Removed:    []ID{posID},
-		EventTypes: EntityRemoved | ComponentRemoved,
+		EventTypes: event.EntityRemoved | event.ComponentRemoved,
 	}, events[801])
 
 	assert.Equal(t, []ID{velID}, events[202].Added)
@@ -600,7 +601,7 @@ func TestWorldNewEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
@@ -676,7 +677,7 @@ func TestWorldNewEntitiesWith(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
@@ -751,7 +752,7 @@ func TestWorldRemoveEntities(t *testing.T) {
 	world := NewWorld(NewConfig().WithCapacityIncrement(16))
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		assert.Equal(t, world.IsLocked(), e.EntityRemoved())
 		events = append(events, e)
 	})
@@ -792,7 +793,7 @@ func TestWorldRelationSet(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -820,7 +821,7 @@ func TestWorldRelationSet(t *testing.T) {
 		OldRelation: &relID,
 		NewRelation: &relID,
 		OldTarget:   Entity{},
-		EventTypes:  TargetChanged,
+		EventTypes:  event.TargetChanged,
 	}, events[len(events)-1])
 
 	assert.Equal(t, targ, world.Relations().Get(e1, relID))
@@ -838,7 +839,7 @@ func TestWorldRelationSet(t *testing.T) {
 		OldRelation: &relID,
 		NewRelation: &relID,
 		OldTarget:   targ,
-		EventTypes:  TargetChanged,
+		EventTypes:  event.TargetChanged,
 	}, events[len(events)-1])
 
 	assert.Panics(t, func() { world.Relations().Get(e1, rotID) })
@@ -863,7 +864,7 @@ func TestWorldRelationSet(t *testing.T) {
 		Removed:     []ID{relID},
 		OldRelation: &relID,
 		NewRelation: nil,
-		EventTypes:  ComponentRemoved | RelationChanged,
+		EventTypes:  event.ComponentRemoved | event.RelationChanged,
 	}, events[len(events)-1])
 
 	assert.Panics(t, func() { world.Relations().Get(e2, relID) })
@@ -891,7 +892,7 @@ func TestWorldRelationSetBatch(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -980,7 +981,7 @@ func TestWorldRelationRemove(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -1200,7 +1201,7 @@ func TestWorldRelation(t *testing.T) {
 func TestWorldRelationCreate(t *testing.T) {
 	world := NewWorld()
 
-	listener := NewCallbackListener(func(e EntityEvent) {})
+	listener := newTestListener(func(e EntityEvent) {})
 	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
@@ -1241,7 +1242,7 @@ func TestWorldRelationCreate(t *testing.T) {
 
 func TestWorldRelationMove(t *testing.T) {
 	world := NewWorld()
-	listener := NewCallbackListener(func(e EntityEvent) {})
+	listener := newTestListener(func(e EntityEvent) {})
 	world.SetListener(&listener)
 
 	posID := ComponentID[Position](&world)
@@ -1439,7 +1440,7 @@ func TestWorldBatchRemove(t *testing.T) {
 	world := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	world.SetListener(&listener)
@@ -1454,7 +1455,7 @@ func TestWorldBatchRemove(t *testing.T) {
 	assert.Equal(t, 3, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:     target3,
-		EventTypes: EntityCreated,
+		EventTypes: event.EntityCreated,
 	}, events[len(events)-1])
 
 	builder := NewBuilder(&world, rotID, relID).WithRelation(relID)
@@ -1468,7 +1469,7 @@ func TestWorldBatchRemove(t *testing.T) {
 		Entity:      Entity{33, 0},
 		Added:       []ID{rotID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	filter := All(rotID).Exclusive()
@@ -1487,7 +1488,7 @@ func TestWorldBatchRemove(t *testing.T) {
 		OldMask:     All(rotID, relID),
 		Removed:     []ID{rotID, relID},
 		OldRelation: &relID,
-		EventTypes:  EntityRemoved | ComponentRemoved | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityRemoved | event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	relFilter = NewRelationFilter(All(rotID, relID), target2)
@@ -1501,7 +1502,7 @@ func TestWorldBatchRemove(t *testing.T) {
 	assert.Equal(t, 56, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:     Entity{3, 0},
-		EventTypes: EntityRemoved,
+		EventTypes: event.EntityRemoved,
 	}, events[len(events)-1])
 
 	relFilter = NewRelationFilter(All(rotID, relID), target3)
@@ -1516,7 +1517,7 @@ func TestWorldBatchRemove(t *testing.T) {
 
 func TestWorldReset(t *testing.T) {
 	world := NewWorld()
-	listener := NewCallbackListener(func(e EntityEvent) {})
+	listener := newTestListener(func(e EntityEvent) {})
 	world.SetListener(&listener)
 
 	AddResource(&world, &rotation{100})
@@ -1596,7 +1597,7 @@ func TestWorldListener(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	w.SetListener(&listener)
@@ -1610,14 +1611,14 @@ func TestWorldListener(t *testing.T) {
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:     e0,
-		EventTypes: EntityCreated,
+		EventTypes: event.EntityCreated,
 	}, events[len(events)-1])
 
 	w.RemoveEntity(e0)
 	assert.Equal(t, 2, len(events))
 	assert.Equal(t, EntityEvent{
 		Entity:     e0,
-		EventTypes: EntityRemoved,
+		EventTypes: event.EntityRemoved,
 	}, events[len(events)-1])
 
 	e0 = w.NewEntity(posID, velID)
@@ -1625,7 +1626,7 @@ func TestWorldListener(t *testing.T) {
 	assert.Equal(t, EntityEvent{
 		Entity:     e0,
 		Added:      []ID{posID, velID},
-		EventTypes: EntityCreated | ComponentAdded,
+		EventTypes: event.EntityCreated | event.ComponentAdded,
 	}, events[len(events)-1])
 
 	w.RemoveEntity(e0)
@@ -1634,7 +1635,7 @@ func TestWorldListener(t *testing.T) {
 		Entity:     e0,
 		OldMask:    All(posID, velID),
 		Removed:    []ID{posID, velID},
-		EventTypes: EntityRemoved | ComponentRemoved,
+		EventTypes: event.EntityRemoved | event.ComponentRemoved,
 	}, events[len(events)-1])
 
 	e0 = w.NewEntityWith(Component{posID, &Position{}}, Component{velID, &Velocity{}}, Component{relID, &relationComp{}})
@@ -1643,7 +1644,7 @@ func TestWorldListener(t *testing.T) {
 		Entity:      e0,
 		Added:       []ID{posID, velID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
 	}, events[len(events)-1])
 
 	w.Add(e0, rotID)
@@ -1654,7 +1655,7 @@ func TestWorldListener(t *testing.T) {
 		Added:       []ID{rotID},
 		OldRelation: &relID,
 		NewRelation: &relID,
-		EventTypes:  ComponentAdded,
+		EventTypes:  event.ComponentAdded,
 	}, events[len(events)-1])
 
 	w.Remove(e0, posID)
@@ -1665,7 +1666,7 @@ func TestWorldListener(t *testing.T) {
 		Removed:     []ID{posID},
 		OldRelation: &relID,
 		NewRelation: &relID,
-		EventTypes:  ComponentRemoved,
+		EventTypes:  event.ComponentRemoved,
 	}, events[len(events)-1])
 
 	e1 := w.NewEntity(posID)
@@ -1676,7 +1677,7 @@ func TestWorldListener(t *testing.T) {
 		OldMask:     All(velID, rotID, relID),
 		OldRelation: &relID,
 		NewRelation: &relID,
-		EventTypes:  TargetChanged,
+		EventTypes:  event.TargetChanged,
 	}, events[len(events)-1])
 
 	w.Remove(e0, relID)
@@ -1688,7 +1689,7 @@ func TestWorldListener(t *testing.T) {
 		OldRelation: &relID,
 		NewRelation: nil,
 		OldTarget:   e1,
-		EventTypes:  ComponentRemoved | RelationChanged | TargetChanged,
+		EventTypes:  event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 }
@@ -1697,7 +1698,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 	w := NewWorld()
 
 	events := []EntityEvent{}
-	listener := NewCallbackListener(func(e EntityEvent) {
+	listener := newTestListener(func(e EntityEvent) {
 		events = append(events, e)
 	})
 	w.SetListener(&listener)
@@ -1716,7 +1717,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
 	}, events[len(events)-1])
 
 	query := builder.NewBatchQ(10)
@@ -1728,7 +1729,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)
@@ -1739,7 +1740,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10, parent)
@@ -1751,7 +1752,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	builder = NewBuilderWith(&w,
@@ -1767,7 +1768,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10)
@@ -1779,7 +1780,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)
@@ -1790,7 +1791,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10, parent)
@@ -1802,7 +1803,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		OldMask:     All(),
 		Added:       []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 }
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -348,13 +348,10 @@ func TestWorldExchangeBatch(t *testing.T) {
 
 	assert.Equal(t, 202, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{202, 0},
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		AddedRemoved:    1,
-		RelationChanged: true,
-		TargetChanged:   true,
+		Entity:      Entity{202, 0},
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[201])
 
 	filter := All(posID, relID)
@@ -382,17 +379,14 @@ func TestWorldExchangeBatch(t *testing.T) {
 
 	assert.Equal(t, 502, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{102, 0},
-		OldMask:         All(velID, relID),
-		Added:           []ID{posID},
-		Removed:         []ID{velID},
-		OldRelation:     &relID,
-		NewRelation:     &relID,
-		OldTarget:       target1,
-		EventTypes:      ComponentAdded | ComponentRemoved,
-		AddedRemoved:    0,
-		RelationChanged: false,
-		TargetChanged:   false,
+		Entity:      Entity{102, 0},
+		OldMask:     All(velID, relID),
+		Added:       []ID{posID},
+		Removed:     []ID{velID},
+		OldRelation: &relID,
+		NewRelation: &relID,
+		OldTarget:   target1,
+		EventTypes:  ComponentAdded | ComponentRemoved,
 	}, events[501])
 
 	query = w.Query(All(posID))
@@ -407,16 +401,13 @@ func TestWorldExchangeBatch(t *testing.T) {
 
 	assert.Equal(t, 702, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{102, 0},
-		OldMask:         All(posID, relID),
-		Removed:         []ID{relID},
-		OldRelation:     &relID,
-		NewRelation:     nil,
-		OldTarget:       target1,
-		EventTypes:      ComponentRemoved | RelationChanged | TargetChanged,
-		AddedRemoved:    0,
-		RelationChanged: true,
-		TargetChanged:   true,
+		Entity:      Entity{102, 0},
+		OldMask:     All(posID, relID),
+		Removed:     []ID{relID},
+		OldRelation: &relID,
+		NewRelation: nil,
+		OldTarget:   target1,
+		EventTypes:  ComponentRemoved | RelationChanged | TargetChanged,
 	}, events[701])
 
 	w.Batch().RemoveEntities(All(posID))
@@ -424,21 +415,12 @@ func TestWorldExchangeBatch(t *testing.T) {
 	assert.Equal(t, 802, len(events))
 
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{102, 0},
-		OldMask:         All(posID),
-		Removed:         []ID{posID},
-		EventTypes:      EntityRemoved | ComponentRemoved,
-		AddedRemoved:    -1,
-		RelationChanged: false,
-		TargetChanged:   false,
+		Entity:     Entity{102, 0},
+		OldMask:    All(posID),
+		Removed:    []ID{posID},
+		EventTypes: EntityRemoved | ComponentRemoved,
 	}, events[801])
 
-	assert.Equal(t, int8(1), events[0].AddedRemoved)
-	assert.Equal(t, int8(1), events[1].AddedRemoved)
-	assert.Equal(t, int8(1), events[2].AddedRemoved)
-	assert.Equal(t, int8(1), events[201].AddedRemoved)
-
-	assert.Equal(t, int8(0), events[202].AddedRemoved)
 	assert.Equal(t, []ID{velID}, events[202].Added)
 	assert.Equal(t, []ID{posID}, events[202].Removed)
 
@@ -833,13 +815,12 @@ func TestWorldRelationSet(t *testing.T) {
 
 	assert.Equal(t, 4, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:        e1,
-		OldMask:       All(relID, rotID),
-		OldRelation:   &relID,
-		NewRelation:   &relID,
-		OldTarget:     Entity{},
-		EventTypes:    TargetChanged,
-		TargetChanged: true,
+		Entity:      e1,
+		OldMask:     All(relID, rotID),
+		OldRelation: &relID,
+		NewRelation: &relID,
+		OldTarget:   Entity{},
+		EventTypes:  TargetChanged,
 	}, events[len(events)-1])
 
 	assert.Equal(t, targ, world.Relations().Get(e1, relID))
@@ -852,13 +833,12 @@ func TestWorldRelationSet(t *testing.T) {
 
 	assert.Equal(t, 5, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:        e1,
-		OldMask:       All(relID, rotID),
-		OldRelation:   &relID,
-		NewRelation:   &relID,
-		OldTarget:     targ,
-		EventTypes:    TargetChanged,
-		TargetChanged: true,
+		Entity:      e1,
+		OldMask:     All(relID, rotID),
+		OldRelation: &relID,
+		NewRelation: &relID,
+		OldTarget:   targ,
+		EventTypes:  TargetChanged,
 	}, events[len(events)-1])
 
 	assert.Panics(t, func() { world.Relations().Get(e1, rotID) })
@@ -878,14 +858,12 @@ func TestWorldRelationSet(t *testing.T) {
 
 	assert.Equal(t, 6, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          e2,
-		OldMask:         All(relID, rotID),
-		Removed:         []ID{relID},
-		OldRelation:     &relID,
-		NewRelation:     nil,
-		EventTypes:      ComponentRemoved | RelationChanged,
-		RelationChanged: true,
-		TargetChanged:   false,
+		Entity:      e2,
+		OldMask:     All(relID, rotID),
+		Removed:     []ID{relID},
+		OldRelation: &relID,
+		NewRelation: nil,
+		EventTypes:  ComponentRemoved | RelationChanged,
 	}, events[len(events)-1])
 
 	assert.Panics(t, func() { world.Relations().Get(e2, relID) })
@@ -1475,9 +1453,8 @@ func TestWorldBatchRemove(t *testing.T) {
 
 	assert.Equal(t, 3, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       target3,
-		EventTypes:   EntityCreated,
-		AddedRemoved: 1,
+		Entity:     target3,
+		EventTypes: EntityCreated,
 	}, events[len(events)-1])
 
 	builder := NewBuilder(&world, rotID, relID).WithRelation(relID)
@@ -1488,13 +1465,10 @@ func TestWorldBatchRemove(t *testing.T) {
 
 	assert.Equal(t, 33, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{33, 0},
-		Added:           []ID{rotID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		AddedRemoved:    1,
-		RelationChanged: true,
-		TargetChanged:   true,
+		Entity:      Entity{33, 0},
+		Added:       []ID{rotID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 	filter := All(rotID).Exclusive()
@@ -1509,14 +1483,11 @@ func TestWorldBatchRemove(t *testing.T) {
 
 	assert.Equal(t, 43, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{13, 0},
-		OldMask:         All(rotID, relID),
-		Removed:         []ID{rotID, relID},
-		OldRelation:     &relID,
-		EventTypes:      EntityRemoved | ComponentRemoved | RelationChanged | TargetChanged,
-		AddedRemoved:    -1,
-		RelationChanged: true,
-		TargetChanged:   true,
+		Entity:      Entity{13, 0},
+		OldMask:     All(rotID, relID),
+		Removed:     []ID{rotID, relID},
+		OldRelation: &relID,
+		EventTypes:  EntityRemoved | ComponentRemoved | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 	relFilter = NewRelationFilter(All(rotID, relID), target2)
@@ -1529,9 +1500,8 @@ func TestWorldBatchRemove(t *testing.T) {
 
 	assert.Equal(t, 56, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       Entity{3, 0},
-		EventTypes:   EntityRemoved,
-		AddedRemoved: -1,
+		Entity:     Entity{3, 0},
+		EventTypes: EntityRemoved,
 	}, events[len(events)-1])
 
 	relFilter = NewRelationFilter(All(rotID, relID), target3)
@@ -1639,99 +1609,86 @@ func TestWorldListener(t *testing.T) {
 	e0 := w.NewEntity()
 	assert.Equal(t, 1, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		EventTypes:   EntityCreated,
-		AddedRemoved: 1,
+		Entity:     e0,
+		EventTypes: EntityCreated,
 	}, events[len(events)-1])
 
 	w.RemoveEntity(e0)
 	assert.Equal(t, 2, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		EventTypes:   EntityRemoved,
-		AddedRemoved: -1,
+		Entity:     e0,
+		EventTypes: EntityRemoved,
 	}, events[len(events)-1])
 
 	e0 = w.NewEntity(posID, velID)
 	assert.Equal(t, 3, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		Added:        []ID{posID, velID},
-		EventTypes:   EntityCreated | ComponentAdded,
-		AddedRemoved: 1,
+		Entity:     e0,
+		Added:      []ID{posID, velID},
+		EventTypes: EntityCreated | ComponentAdded,
 	}, events[len(events)-1])
 
 	w.RemoveEntity(e0)
 	assert.Equal(t, 4, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		OldMask:      All(posID, velID),
-		Removed:      []ID{posID, velID},
-		EventTypes:   EntityRemoved | ComponentRemoved,
-		AddedRemoved: -1,
+		Entity:     e0,
+		OldMask:    All(posID, velID),
+		Removed:    []ID{posID, velID},
+		EventTypes: EntityRemoved | ComponentRemoved,
 	}, events[len(events)-1])
 
 	e0 = w.NewEntityWith(Component{posID, &Position{}}, Component{velID, &Velocity{}}, Component{relID, &relationComp{}})
 	assert.Equal(t, 5, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          e0,
-		Added:           []ID{posID, velID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
-		AddedRemoved:    1,
-		RelationChanged: true,
+		Entity:      e0,
+		Added:       []ID{posID, velID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
 	}, events[len(events)-1])
 
 	w.Add(e0, rotID)
 	assert.Equal(t, 6, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		OldMask:      All(posID, velID, relID),
-		Added:        []ID{rotID},
-		OldRelation:  &relID,
-		NewRelation:  &relID,
-		EventTypes:   ComponentAdded,
-		AddedRemoved: 0,
+		Entity:      e0,
+		OldMask:     All(posID, velID, relID),
+		Added:       []ID{rotID},
+		OldRelation: &relID,
+		NewRelation: &relID,
+		EventTypes:  ComponentAdded,
 	}, events[len(events)-1])
 
 	w.Remove(e0, posID)
 	assert.Equal(t, 7, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:       e0,
-		OldMask:      All(posID, velID, rotID, relID),
-		Removed:      []ID{posID},
-		OldRelation:  &relID,
-		NewRelation:  &relID,
-		EventTypes:   ComponentRemoved,
-		AddedRemoved: 0,
+		Entity:      e0,
+		OldMask:     All(posID, velID, rotID, relID),
+		Removed:     []ID{posID},
+		OldRelation: &relID,
+		NewRelation: &relID,
+		EventTypes:  ComponentRemoved,
 	}, events[len(events)-1])
 
 	e1 := w.NewEntity(posID)
 	w.Relations().Set(e0, relID, e1)
 	assert.Equal(t, 9, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:        e0,
-		OldMask:       All(velID, rotID, relID),
-		OldRelation:   &relID,
-		NewRelation:   &relID,
-		EventTypes:    TargetChanged,
-		TargetChanged: true,
-		AddedRemoved:  0,
+		Entity:      e0,
+		OldMask:     All(velID, rotID, relID),
+		OldRelation: &relID,
+		NewRelation: &relID,
+		EventTypes:  TargetChanged,
 	}, events[len(events)-1])
 
 	w.Remove(e0, relID)
 	assert.Equal(t, 10, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          e0,
-		OldMask:         All(velID, rotID, relID),
-		Removed:         []ID{relID},
-		OldRelation:     &relID,
-		NewRelation:     nil,
-		OldTarget:       e1,
-		EventTypes:      ComponentRemoved | RelationChanged | TargetChanged,
-		RelationChanged: true,
-		TargetChanged:   true,
-		AddedRemoved:    0,
+		Entity:      e0,
+		OldMask:     All(velID, rotID, relID),
+		Removed:     []ID{relID},
+		OldRelation: &relID,
+		NewRelation: nil,
+		OldTarget:   e1,
+		EventTypes:  ComponentRemoved | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 }
@@ -1755,14 +1712,11 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 11, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{11, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
-		RelationChanged: true,
-		TargetChanged:   false,
-		AddedRemoved:    1,
+		Entity:      Entity{11, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
 	}, events[len(events)-1])
 
 	query := builder.NewBatchQ(10)
@@ -1770,28 +1724,22 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 21, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{21, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
-		RelationChanged: true,
-		TargetChanged:   false,
-		AddedRemoved:    1,
+		Entity:      Entity{21, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)
 
 	assert.Equal(t, 31, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{31, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		RelationChanged: true,
-		TargetChanged:   true,
-		AddedRemoved:    1,
+		Entity:      Entity{31, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10, parent)
@@ -1799,14 +1747,11 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 41, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{41, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		RelationChanged: true,
-		TargetChanged:   true,
-		AddedRemoved:    1,
+		Entity:      Entity{41, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 	builder = NewBuilderWith(&w,
@@ -1818,14 +1763,11 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 51, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{51, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
-		RelationChanged: true,
-		TargetChanged:   false,
-		AddedRemoved:    1,
+		Entity:      Entity{51, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10)
@@ -1833,28 +1775,22 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 61, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{61, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged,
-		RelationChanged: true,
-		TargetChanged:   false,
-		AddedRemoved:    1,
+		Entity:      Entity{61, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)
 
 	assert.Equal(t, 71, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{71, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		RelationChanged: true,
-		TargetChanged:   true,
-		AddedRemoved:    1,
+		Entity:      Entity{71, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10, parent)
@@ -1862,14 +1798,11 @@ func TestWorldListenerBuilder(t *testing.T) {
 
 	assert.Equal(t, 81, len(events))
 	assert.Equal(t, EntityEvent{
-		Entity:          Entity{81, 0},
-		OldMask:         All(),
-		Added:           []ID{posID, relID},
-		NewRelation:     &relID,
-		EventTypes:      EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
-		RelationChanged: true,
-		TargetChanged:   true,
-		AddedRemoved:    1,
+		Entity:      Entity{81, 0},
+		OldMask:     All(),
+		Added:       []ID{posID, relID},
+		NewRelation: &relID,
+		EventTypes:  EntityCreated | ComponentAdded | RelationChanged | TargetChanged,
 	}, events[len(events)-1])
 }
 

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -27,19 +27,19 @@ type Rotation struct {
 	A float64
 }
 
-// Listener type
-type Listener struct {
+// TestListener type
+type TestListener struct {
 	World *ecs.World
 }
 
-// Listen is called on entity changes.
-func (l *Listener) Listen(evt ecs.EntityEvent) {
+// Notify is called on entity changes.
+func (l *TestListener) Notify(evt ecs.EntityEvent) {
 	// Just prints out what the event is about.
 	// This could also be a method of a type that manages events.
 	// Could use e.g. filters to distribute events to interested/registered systems.
-	if evt.EntityAdded() {
+	if evt.Contains(event.EntityCreated) {
 		fmt.Printf("Entity added, has components %v\n", l.World.Ids(evt.Entity))
-	} else if evt.EntityRemoved() {
+	} else if evt.Contains(event.EntityRemoved) {
 		fmt.Printf("Entity removed, had components %v\n", l.World.Ids(evt.Entity))
 	} else {
 		fmt.Printf("Entity changed, has components %v\n", l.World.Ids(evt.Entity))
@@ -49,8 +49,8 @@ func (l *Listener) Listen(evt ecs.EntityEvent) {
 func main() {
 	// Create a World.
 	world := ecs.NewWorld()
-	ls := Listener{World: &world}
-	wrapper := listener.NewCallback(event.Entities|event.Components, ls.Listen)
+	ls := TestListener{World: &world}
+	wrapper := listener.NewCallback(event.Entities|event.Components, ls.Notify)
 
 	// Get component IDs
 	posID := ecs.ComponentID[Position](&world)

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -48,7 +48,7 @@ func main() {
 	// Create a World.
 	world := ecs.NewWorld()
 	listener := Listener{World: &world}
-	wrapper := ecs.NewListener(listener.Listen)
+	wrapper := ecs.NewCallbackListener(listener.Listen)
 
 	// Get component IDs
 	posID := ecs.ComponentID[Position](&world)
@@ -56,7 +56,7 @@ func main() {
 	rotID := ecs.ComponentID[Rotation](&world)
 
 	// Register a listener function.
-	world.SetListener(wrapper)
+	world.SetListener(&wrapper)
 
 	// Create/manipulate/delete entities and observe the listener's output
 	e0 := world.NewEntity(posID)

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -48,6 +48,7 @@ func main() {
 	// Create a World.
 	world := ecs.NewWorld()
 	listener := Listener{World: &world}
+	wrapper := ecs.NewListener(listener.Listen)
 
 	// Get component IDs
 	posID := ecs.ComponentID[Position](&world)
@@ -55,7 +56,7 @@ func main() {
 	rotID := ecs.ComponentID[Rotation](&world)
 
 	// Register a listener function.
-	world.SetListener(listener.Listen)
+	world.SetListener(wrapper)
 
 	// Create/manipulate/delete entities and observe the listener's output
 	e0 := world.NewEntity(posID)

--- a/examples/change_listener/main.go
+++ b/examples/change_listener/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 
 	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
+	"github.com/mlange-42/arche/listener"
 )
 
 // Position component
@@ -47,8 +49,8 @@ func (l *Listener) Listen(evt ecs.EntityEvent) {
 func main() {
 	// Create a World.
 	world := ecs.NewWorld()
-	listener := Listener{World: &world}
-	wrapper := ecs.NewCallbackListener(listener.Listen)
+	ls := Listener{World: &world}
+	wrapper := listener.NewCallback(event.Entities|event.Components, ls.Listen)
 
 	// Get component IDs
 	posID := ecs.ComponentID[Position](&world)

--- a/listener/callback.go
+++ b/listener/callback.go
@@ -5,9 +5,9 @@ import (
 	"github.com/mlange-42/arche/ecs/event"
 )
 
-// Callback listener for [EntityEvent]s.
+// Callback listener for ecs.EntityEvent.
 //
-// Calls function Callback on events that are contained in the Subscribe mask.
+// Calls a function on events that are contained in the subscription mask.
 type Callback struct {
 	callback func(e ecs.EntityEvent)
 	events   event.Subscription
@@ -21,12 +21,12 @@ func NewCallback(events event.Subscription, callback func(ecs.EntityEvent)) Call
 	}
 }
 
-// Notify the listener
+// Notify the listener.
 func (l *Callback) Notify(e ecs.EntityEvent) {
 	l.callback(e)
 }
 
-// Subscriptions of the listener
+// Subscriptions of the listener.
 func (l *Callback) Subscriptions() event.Subscription {
 	return l.events
 }

--- a/listener/callback.go
+++ b/listener/callback.go
@@ -1,0 +1,32 @@
+package listener
+
+import (
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
+)
+
+// Callback listener for [EntityEvent]s.
+//
+// Calls function Callback on events that are contained in the Subscribe mask.
+type Callback struct {
+	callback func(e ecs.EntityEvent)
+	events   event.Subscription
+}
+
+// NewCallback creates a new Callback listener for the given events.
+func NewCallback(events event.Subscription, callback func(ecs.EntityEvent)) Callback {
+	return Callback{
+		callback: callback,
+		events:   events,
+	}
+}
+
+// Notify the listener
+func (l *Callback) Notify(e ecs.EntityEvent) {
+	l.callback(e)
+}
+
+// Subscriptions of the listener
+func (l *Callback) Subscriptions() event.Subscription {
+	return l.events
+}

--- a/listener/callback_test.go
+++ b/listener/callback_test.go
@@ -1,0 +1,23 @@
+package listener_test
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
+	"github.com/mlange-42/arche/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallback(t *testing.T) {
+	evt := []ecs.EntityEvent{}
+	ls := listener.NewCallback(
+		event.All,
+		func(e ecs.EntityEvent) {
+			evt = append(evt, e)
+		},
+	)
+	assert.Equal(t, event.All, ls.Subscriptions())
+	ls.Notify(ecs.EntityEvent{})
+	assert.Equal(t, 1, len(evt))
+}

--- a/listener/callback_test.go
+++ b/listener/callback_test.go
@@ -1,6 +1,7 @@
 package listener_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mlange-42/arche/ecs"
@@ -20,4 +21,18 @@ func TestCallback(t *testing.T) {
 	assert.Equal(t, event.All, ls.Subscriptions())
 	ls.Notify(ecs.EntityEvent{})
 	assert.Equal(t, 1, len(evt))
+}
+
+func ExampleCallback() {
+	world := ecs.NewWorld()
+
+	ls := listener.NewCallback(
+		event.Entities|event.Components,
+		func(e ecs.EntityEvent) {
+			fmt.Println(e)
+		},
+	)
+	world.SetListener(&ls)
+
+	world.NewEntity()
 }

--- a/listener/dispatched.go
+++ b/listener/dispatched.go
@@ -1,0 +1,44 @@
+package listener
+
+import (
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
+)
+
+// Dispatched event listener.
+type Dispatched struct {
+	listeners []ecs.Listener
+	events    event.Subscription
+}
+
+// NewDispatched returns a new [Dispatched] listener with sub-listeners.
+func NewDispatched(listeners ...ecs.Listener) Dispatched {
+	var events event.Subscription = 0
+	for _, l := range listeners {
+		events |= l.Subscriptions()
+	}
+	return Dispatched{
+		listeners: listeners,
+		events:    events,
+	}
+}
+
+// AddListener adds a listener to this listener.
+func (l *Dispatched) AddListener(ls ecs.Listener) {
+	l.listeners = append(l.listeners, ls)
+	l.events |= ls.Subscriptions()
+}
+
+// Notify the listener.
+func (l *Dispatched) Notify(e ecs.EntityEvent) {
+	for _, ls := range l.listeners {
+		if ls.Subscriptions().ContainsAny(e.EventTypes) {
+			ls.Notify(e)
+		}
+	}
+}
+
+// Subscriptions of the listener.
+func (l *Dispatched) Subscriptions() event.Subscription {
+	return l.events
+}

--- a/listener/dispatched_test.go
+++ b/listener/dispatched_test.go
@@ -1,0 +1,70 @@
+package listener_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+	"github.com/mlange-42/arche/ecs/event"
+	"github.com/mlange-42/arche/listener"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDispatched(t *testing.T) {
+	entityEvents := []ecs.EntityEvent{}
+	componentEvents := []ecs.EntityEvent{}
+
+	l1 := listener.NewCallback(event.Entities, func(evt ecs.EntityEvent) { entityEvents = append(entityEvents, evt) })
+	l2 := listener.NewCallback(event.Components, func(evt ecs.EntityEvent) { componentEvents = append(componentEvents, evt) })
+
+	ls := listener.NewDispatched(&l1)
+	ls.AddListener(&l2)
+
+	assert.Equal(t, event.Entities|event.Components, ls.Subscriptions())
+
+	ls.Notify(ecs.EntityEvent{EventTypes: event.EntityCreated | event.ComponentAdded})
+	ls.Notify(ecs.EntityEvent{EventTypes: event.EntityCreated | event.RelationChanged})
+	ls.Notify(ecs.EntityEvent{EventTypes: event.Relations})
+
+	assert.Equal(t, 2, len(entityEvents))
+	assert.Equal(t, 1, len(componentEvents))
+}
+
+type Position struct {
+	X float64
+	Y float64
+}
+
+func ExampleDispatched() {
+	world := ecs.NewWorld()
+
+	posID := ecs.ComponentID[Position](&world)
+
+	entityListener := listener.NewCallback(
+		event.EntityCreated|event.EntityRemoved,
+		func(evt ecs.EntityEvent) { fmt.Println("Entity event") },
+	)
+	componentListener := listener.NewCallback(
+		event.ComponentAdded|event.ComponentRemoved,
+		func(evt ecs.EntityEvent) { fmt.Println("Component event") },
+	)
+
+	mainListener := listener.NewDispatched(
+		&entityListener,
+		&componentListener,
+	)
+
+	world.SetListener(&mainListener)
+
+	// Triggers event.EntityCreated
+	e := world.NewEntity()
+	// Triggers event.ComponentAdded
+	world.Add(e, posID)
+
+	// Triggers event.EntityCreated and event.ComponentAdded
+	_ = world.NewEntity(posID)
+	// Output: Entity event
+	// Component event
+	// Entity event
+	// Component event
+}

--- a/listener/doc.go
+++ b/listener/doc.go
@@ -1,8 +1,4 @@
-// Package listener event listener implementations for Arche.
+// Package listener provides event listener implementations for Arche.
 //
 // See the top level module [github.com/mlange-42/arche] for an overview.
-//
-// # Outline
-//
-//   - TODO
 package listener

--- a/listener/doc.go
+++ b/listener/doc.go
@@ -1,0 +1,8 @@
+// Package listener event listener implementations for Arche.
+//
+// See the top level module [github.com/mlange-42/arche] for an overview.
+//
+// # Outline
+//
+//   - TODO
+package listener


### PR DESCRIPTION
* Replaces some fields of `EntityEvent` by a bitmask of triggered event types
* Allows filtering events by a subscriptions mask
* Introduces a `Listener` interface
* Splits out subscriptions and default `Listener` implementation into packages