### PR TITLE
Fix relation events, reset target on relation change, document subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Arche supports full world serialization and deserialization, in conjunction with [arche-serde](https://github.com/mlange-42/arche-serde) (#319)
 * Supports 256 instead of 128 component types as well as resource types and engine locks (#313)
 * Generic API supports up to 12 instead of 8 component types (#324)
-* Reworked event system with granular subscription to different event types and components (#333, #334, #335)
+* Reworked event system with granular subscription to different event types and components (#333, #334, #335, #337, #340)
 
 ### Breaking changes
 
@@ -32,7 +32,7 @@ This change was necessary to get the same performance as before, despite the mor
 ### Performance
 
 * Reduces archetype memory footprint by using a dynamically sized slice for storage lookup (#327)
-* Reduces event listener overhead through granular subscriptions and elimination of a heap allocation (#333, #334, #335, #337)
+* Reduces event listener overhead through granular subscriptions and elimination of a heap allocation (#333, #334, #335, #337, #340)
 
 ### Other
 

--- a/ecs/batch.go
+++ b/ecs/batch.go
@@ -86,6 +86,9 @@ func (b *Batch) SetRelationQ(filter Filter, comp ID, target Entity) Query {
 
 // Exchange exchanges components for many entities, matching a filter.
 //
+// When a [Relation] component is removed and another one is added,
+// the target entity of the relation is reset to zero.
+//
 // Panics:
 //   - when called with components that can't be added or removed because they are already present/not present, respectively.
 //   - when called on a locked world. Do not use during [Query] iteration!
@@ -97,6 +100,9 @@ func (b *Batch) Exchange(filter Filter, add []ID, rem []ID) {
 
 // ExchangeQ exchanges components for many entities, matching a filter.
 // It returns a query over the affected entities.
+//
+// When a [Relation] component is removed and another one is added,
+// the target entity of the relation is reset to zero.
 //
 // Panics:
 //   - when called with components that can't be added or removed because they are already present/not present, respectively.

--- a/ecs/event.go
+++ b/ecs/event.go
@@ -6,12 +6,18 @@ import "github.com/mlange-42/arche/ecs/event"
 //
 // To receive change events, register a [Listener] with [World.SetListener].
 //
+// # Event types & subscriptions
+//
 // Events notified are entity creation and removal, component addition and removal,
 // and change of relations and their targets.
 //
-// Event types that are subscribed are determined by [Listener.Subscriptions].
+// Event types that are subscribed are determined by [Listener].Subscriptions.
 // Events that cover multiple types (e.g. entity creation and component addition) are only notified once.
 // Field EventTypes contains the [event.Subscription] bits of covered event types.
+//
+// See module [event] and the [event.Subscription] constants for subscription logic.
+//
+// # Event scheduling
 //
 // Events are emitted immediately after the change is applied.
 //
@@ -41,14 +47,23 @@ func (e *EntityEvent) Contains(bit event.Subscription) bool {
 //
 // A listener can be added to a [World] with [World.SetListener].
 //
-// See [EntityEvent] for details.
+// # Subscriptions
+//
+// Listeners can subscribe to one or more event types via method Subscriptions.
+// Further, subscriptions can be restricted to one or more components via method Components.
+//
+// See module [event] and the [event.Subscription] constants for subscription logic.
+//
+// # See also
+//
+// See [EntityEvent] for more details.
 // See package [github.com/mlange-42/arche/listener] for Listener implementations.
 type Listener interface {
 	// Notify the listener about a subscribed event.
 	Notify(world *World, evt EntityEvent)
 	// Subscriptions to event types.
 	Subscriptions() event.Subscription
-	// Components the listener subscribes to.
+	// Components the listener subscribes to. No component restrictions are indicated by nil.
 	Components() *Mask
 }
 

--- a/ecs/event/event.go
+++ b/ecs/event/event.go
@@ -3,19 +3,64 @@
 // See also ecs.Listener and ecs.EntityEvent.
 package event
 
-// Subscription bits for individual events
+// Subscription bits for individual events.
 const (
-	// EntityCreated subscription bit
+	// EntityCreated subscription bit.
+	//
+	// Without component subscription:
+	//   - Creation of an entity with or without any components
+	// With component subscription:
+	//   - Creation of an entity with any of the given components
 	EntityCreated Subscription = 1
-	// EntityRemoved subscription bit
+
+	// EntityRemoved subscription bit.
+	//
+	// Without component subscription:
+	//   - Removal of an entity, with or without any components
+	// With component subscription:
+	//   - Removal of an entity with any of the given components
 	EntityRemoved Subscription = 1 << 1
-	// ComponentAdded subscription bit
+
+	// ComponentAdded subscription bit.
+	//
+	// Without component subscription:
+	//   - Addition of any component(s) to an entity
+	//   - Creation of an entity with any components
+	// With component subscription:
+	//   - Addition of any of the given components to an entity
+	//   - Creation of an entity with any of the given components
 	ComponentAdded Subscription = 1 << 2
-	// ComponentRemoved subscription bit
+
+	// ComponentRemoved subscription bit.
+	//
+	// Without component subscription:
+	//   - Removal of any component(s) from an entity
+	//   - Removal of an entity with any components
+	// With component subscription:
+	//   - Removal of any of the given components from an entity
+	//   - Removal of an entity with any of the given components
 	ComponentRemoved Subscription = 1 << 3
-	// RelationChanged subscription bit
+
+	// RelationChanged subscription bit.
+	//
+	// Without component subscription:
+	//   - Addition of a relation component
+	//   - Removal of a relation component
+	//   - Exchange of a relation component with another
+	// With component subscription:
+	//   - Addition of any of the given relation components
+	//   - Removal of any of the given relation components
+	//   - Exchange if any of the two is among the given components
 	RelationChanged Subscription = 1 << 4
-	// TargetChanged subscription bit
+
+	// TargetChanged subscription bit.
+	//
+	// Without component subscription:
+	//   - Whenever RelationChanged is triggered
+	//   - Change of the target entity of any relation component
+	// With component subscription:
+	//   - Whenever RelationChanged is triggered
+	//   - Change of the target entity of any of the given (relation) components
 	TargetChanged Subscription = 1 << 5
 )
 

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -212,7 +212,7 @@ func (w *World) NewEntity(comps ...ID) Entity {
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
 		}
-		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, false)
+		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, newRel != nil)
 		trigger := w.listener.Subscriptions() & bits
 		if trigger != 0 && subscribes(trigger, &arch.Mask, nil, w.listener.Components(), nil, newRel) {
 			w.listener.Notify(w, EntityEvent{Entity: entity, Added: arch.Mask, AddedIDs: comps, NewRelation: newRel, EventTypes: bits})
@@ -261,7 +261,7 @@ func (w *World) NewEntityWith(comps ...Component) Entity {
 		if arch.HasRelationComponent {
 			newRel = &arch.RelationComponent
 		}
-		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, false)
+		bits := subscription(true, false, len(comps) > 0, false, newRel != nil, newRel != nil)
 		trigger := w.listener.Subscriptions() & bits
 		if trigger != 0 && subscribes(trigger, &arch.Mask, nil, w.listener.Components(), nil, newRel) {
 			w.listener.Notify(w, EntityEvent{Entity: entity, Added: arch.Mask, AddedIDs: ids, NewRelation: newRel, EventTypes: bits})
@@ -294,7 +294,7 @@ func (w *World) RemoveEntity(entity Entity) {
 			oldIds = oldArch.node.Ids
 		}
 
-		bits := subscription(false, true, false, len(oldIds) > 0, oldRel != nil, !oldArch.RelationTarget.IsZero())
+		bits := subscription(false, true, false, len(oldIds) > 0, oldRel != nil, oldRel != nil)
 		trigger := w.listener.Subscriptions() & bits
 		if trigger != 0 && subscribes(trigger, nil, &oldArch.Mask, w.listener.Components(), oldRel, nil) {
 			lock := w.lock()
@@ -450,7 +450,7 @@ func (w *World) Remove(entity Entity, comps ...ID) {
 // This is more efficient than subsequent use of [World.Add] and [World.Remove].
 //
 // When a [Relation] component is removed and another one is added,
-// the target entity of the relation remains unchanged.
+// the target entity of the relation is reset to zero.
 //
 // Panics:
 //   - when called for a removed (and potentially recycled) entity.

--- a/ecs/world_event_test.go
+++ b/ecs/world_event_test.go
@@ -60,7 +60,7 @@ func TestWorldListener(t *testing.T) {
 		Added:       All(posID, velID, relID),
 		AddedIDs:    []ID{posID, velID, relID},
 		NewRelation: &relID,
-		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	w.Add(e0, rotID)
@@ -132,7 +132,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		Added:       All(posID, relID),
 		AddedIDs:    []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	query := builder.NewBatchQ(10)
@@ -144,7 +144,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		Added:       All(posID, relID),
 		AddedIDs:    []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)
@@ -183,7 +183,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		Added:       All(posID, relID),
 		AddedIDs:    []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	query = builder.NewBatchQ(10)
@@ -195,7 +195,7 @@ func TestWorldListenerBuilder(t *testing.T) {
 		Added:       All(posID, relID),
 		AddedIDs:    []ID{posID, relID},
 		NewRelation: &relID,
-		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged,
+		EventTypes:  event.EntityCreated | event.ComponentAdded | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
 	builder.NewBatch(10, parent)

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -322,7 +322,7 @@ func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRela
 		}
 		targChanged := oldTarget != arch.RelationTarget
 
-		bits := subscription(false, false, len(add) > 0, len(rem) > 0, relChanged, targChanged)
+		bits := subscription(false, false, len(add) > 0, len(rem) > 0, relChanged, relChanged || targChanged)
 		trigger := w.listener.Subscriptions() & bits
 		if trigger != 0 {
 			changed := oldMask.Xor(&arch.Mask)
@@ -1048,7 +1048,7 @@ func (w *World) notifyQuery(batchArch *batchArchetypes) {
 			event.OldRelation = oldRel
 		}
 
-		bits := subscription(oldArch == nil, false, len(batchArch.Added) > 0, len(batchArch.Removed) > 0, relChanged, targChanged)
+		bits := subscription(oldArch == nil, false, len(batchArch.Added) > 0, len(batchArch.Removed) > 0, relChanged, relChanged || targChanged)
 		event.EventTypes = bits
 
 		trigger := w.listener.Subscriptions() & bits

--- a/listener/dispatch_test.go
+++ b/listener/dispatch_test.go
@@ -93,23 +93,23 @@ func TestDispatchRelations(t *testing.T) {
 	builder1.NewBatch(10, parent1)
 
 	assert.Equal(t, 20, len(h1.events))
-	assert.Equal(t, 10, len(h2.events))
+	assert.Equal(t, 20, len(h2.events))
 
 	builder2.NewBatch(10)
 	builder2.NewBatch(10, parent2)
 
 	assert.Equal(t, 20, len(h1.events))
-	assert.Equal(t, 10, len(h2.events))
+	assert.Equal(t, 20, len(h2.events))
 
 	world.Batch().SetRelation(ecs.All(rel1ID), rel1ID, parent2)
 
 	assert.Equal(t, 20, len(h1.events))
-	assert.Equal(t, 30, len(h2.events))
+	assert.Equal(t, 40, len(h2.events))
 
 	world.Batch().RemoveEntities(ecs.All(rel1ID))
 
 	assert.Equal(t, 40, len(h1.events))
-	assert.Equal(t, 50, len(h2.events))
+	assert.Equal(t, 60, len(h2.events))
 }
 
 func TestDispatchAllComps(t *testing.T) {


### PR DESCRIPTION
* Target is reset to zero when (ex)-changing the relation component
* `RelationChanged` always triggers `TargetChanged`
* Document subscription logic