### PR TITLE
Query indexing with `EntityAt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.10.1...main)
 
+### Features
+
+* Adds method `Query.EntityAt()`, useful for things like random sampling of entities (#358)
+
 ### Bugfixes
 
 * Prevents using the same component multiple times in any operations, through panic (#357)

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -111,11 +111,14 @@ func (q *Query) Entity() Entity {
 // It is recommended to use a filter which is registered via the [World.Cache],
 // This increases performance at least by factor 4.
 //
-// Some numbers for comparison:
+// Some numbers for comparison, with given number of archetypes in the query:
 //   - 1 archetype, filter not registered: ≈ 11ns
 //   - 1 archetype, filter registered: ≈ 3ns
 //   - 10 archetypes, filter not registered: ≈ 50ns
 //   - 10 archetypes, filter registered: ≈ 10ns
+//
+// The total number of archetypes in the world has no performance impact for registered filters,
+// while for filters that are not registered, it has.
 //
 // Panics if the index is out of range, as indicated by [Query.Count].
 func (q *Query) EntityAt(index int) Entity {

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -147,10 +147,11 @@ func (q *Query) relationUnchecked(comp ID) Entity {
 }
 
 // Step advances the query iterator by the given number of entities.
+// Returns whether the query is still at a valid position.
+// Returning false indicates that the step exceeded the Query's entities.
+// The query is closed in this case.
 //
-// Query.Step(1) is equivalent to [Query.Next]().
-//
-// This method, used together with [Query.Count], can be useful for the selection of random entities.
+// Query.Step(1) is equivalent to [Query.Next](), although probably slower.
 func (q *Query) Step(step int) bool {
 	if step <= 0 {
 		panic("step size must be positive")

--- a/ecs/query_examples_test.go
+++ b/ecs/query_examples_test.go
@@ -2,6 +2,7 @@ package ecs_test
 
 import (
 	"fmt"
+	"math/rand"
 
 	"github.com/mlange-42/arche/ecs"
 )
@@ -46,4 +47,39 @@ func ExampleQuery_Close() {
 
 	query.Close()
 	// Output: 1
+}
+
+func ExampleQuery_EntityAt() {
+	// Set up the world.
+	world := ecs.NewWorld()
+	posID := ecs.ComponentID[Position](&world)
+
+	// Create entities.
+	builder := ecs.NewBuilder(&world, posID)
+	builder.NewBatch(100)
+
+	// Create a random generator.
+	rng := rand.New(rand.NewSource(42))
+
+	// Register a filter (optional, but recommended).
+	filter := world.Cache().Register(ecs.All(posID))
+
+	// Query some entities.
+	query := world.Query(&filter)
+	// Get the number of entities in the query
+	cnt := query.Count()
+
+	// Sample some random entities.
+	for i := 0; i < 5; i++ {
+		randomEntity := query.EntityAt(rng.Intn(cnt))
+		fmt.Println(randomEntity)
+	}
+
+	// Close the query.
+	query.Close()
+	// Output: {6 0}
+	// {88 0}
+	// {69 0}
+	// {51 0}
+	// {24 0}
 }

--- a/ecs/query_test.go
+++ b/ecs/query_test.go
@@ -317,6 +317,7 @@ func TestQueryStep(t *testing.T) {
 	q := w.Query(All(posID))
 	cnt := 0
 	for q.Next() {
+		assert.Equal(t, cnt+1, int(q.Entity().id))
 		cnt++
 	}
 	assert.Equal(t, 10, cnt)

--- a/examples/random_sampling/main.go
+++ b/examples/random_sampling/main.go
@@ -1,10 +1,9 @@
-// Demonstrates random sampling of a fixed number of entities from a query using Query.Step().
+// Demonstrates random sampling of a fixed number of entities from a query using Query.EntityAt().
 package main
 
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
@@ -21,31 +20,28 @@ func main() {
 
 	// Create a generic filter.
 	filter := generic.NewFilter0()
+	// Register the filter. Optional, but recommended for query random access.
+	filter.Register(&world)
 
 	// Get a fresh query iterator.
 	query := filter.Query(&world)
 	// Get the number of entities in the query
 	count := query.Count()
-	// Get sorted random indices
-	sample := sortedSample(25, count)
+	// Get random indices without replacement
+	sample := sample(25, count)
 	fmt.Println(sample)
 
-	// Iterate, only visiting the entities at the given indices.
-	last := -1
+	// Iterate over sampled indices.
 	for _, idx := range sample {
-		// Calculate the step size (can be 0)
-		step := idx - last
-		// Advance the query iterator
-		query.Step(step)
+		// Get the entity at the random index.
+		entity := query.EntityAt(idx)
 		// Do something with the entity and/or components at the current iterator position.
-		fmt.Println(query.Entity())
-		// Required for calculating the step size.
-		last = idx
+		fmt.Println(entity)
 	}
 }
 
-// Returns a sorted random sample of indices of size k, for a "thing" of length n.
-func sortedSample(k, n int) []int {
+// Returns a random sample of indices without replacement.Take k of n sample.
+func sample(k, n int) []int {
 	m := make([]int, n)
 	for i := 0; i < n; i++ {
 		j := rand.Intn(i + 1)
@@ -53,6 +49,5 @@ func sortedSample(k, n int) []int {
 		m[j] = i
 	}
 	m = m[:k]
-	sort.Ints(m)
 	return m
 }


### PR DESCRIPTION
Adds method `Query.EntityAt()`, useful for things like random sampling of entities.