### PR TITLE
Better document that queries can be iterated only once

### DIFF
--- a/ecs/query.go
+++ b/ecs/query.go
@@ -7,7 +7,7 @@ import (
 
 // Query is an iterator to iterate entities, filtered by a [Filter].
 //
-// Create queries through the [World] using [World.Query].
+// Create queries through the [World] using [World.Query]. See there for more details.
 //
 // See also the generic alternatives [github.com/mlange-42/arche/generic.Query1],
 // [github.com/mlange-42/arche/generic.Query2], etc.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -358,7 +358,9 @@ func (w *World) Reset() {
 //
 // Locks the world to prevent changes to component compositions.
 // The lock is released automatically when the query finishes iteration, or when [Query.Close] is called.
-// The number of simultaneous locks (and thus open queries) at a given time is limited to [MaskTotalBits].
+// The number of simultaneous locks (and thus open queries) at a given time is limited to [MaskTotalBits] (256).
+//
+// A query can iterate through it's entities only once, and can't be used anymore afterwards.
 //
 // To create a [Filter] for querying, see [All], [Mask.Without], [Mask.Exclusive] and [RelationFilter].
 //


### PR DESCRIPTION
State explicitly that queries can't be re-used, as a lesson learned from #362.