### PR TITLE
Benchmark tables for lookup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -157,4 +157,9 @@ jobs:
         run: go get .
       - name: Benchmark tables
         run: |
-          go run ./benchmark/table
+          go run ./benchmark/table | tee BENCHMARKS.md
+      - name: Archive benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: BENCHMARKS.md
+          path: BENCHMARKS.md

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -143,3 +143,18 @@ jobs:
         run: |
           cd benchmark
           go test -tags tiny -benchmem -run=^$ -bench ^.*$ ./competition/add_remove/... --count 5
+
+  tables:
+    name: Benchmark Tables
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.21.x'
+      - name: Install dependencies
+        run: go get .
+      - name: Benchmark tables
+        run: |
+          go run ./benchmark/table

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,41 @@
+# Benchmarks
+
+This document gives an overview over the runtime cost of typical Arche operations.
+If not stated differently, time is per entity or per single operation.
+
+## Query
+
+| Operation                        | Time         | Remark                       |
+|----------------------------------|-------------:|------------------------------|
+| Query.Next                       |       1.6 ns |                              |
+| Query.Next + 1x Get              |       1.9 ns |                              |
+| Query.Next + 2x Get              |       2.6 ns |                              |
+| Query.Next + 5x Get              |       4.8 ns |                              |
+| Query.EntityAt, 1 arch           |      11.3 ns |                              |
+| Query.EntityAt, 1 arch           |       3.0 ns | registered filter            |
+| Query.EntityAt, 5 arch           |      15.9 ns |                              |
+| Query.EntityAt, 5 arch           |       3.1 ns | registered filter            |
+| World.Query                      |      50.7 ns |                              |
+| World.Query                      |      30.6 ns | registered filter            |
+
+## Entities
+
+| Operation                        | Time         | Remark                       |
+|----------------------------------|-------------:|------------------------------|
+| World.NewEntity                  |      16.5 ns | memory already allocated     |
+| World.NewEntity w/ 1 Comp        |      33.1 ns | memory already allocated     |
+| World.NewEntity w/ 5 Comps       |      58.5 ns | memory already allocated     |
+| World.RemoveEntity               |      13.2 ns |                              |
+| World.RemoveEntity w/ 1 Comp     |      20.0 ns |                              |
+| World.RemoveEntity w/ 5 Comps    |      44.0 ns |                              |
+
+## Entities, batched
+
+| Operation                        | Time         | Remark                       |
+|----------------------------------|-------------:|------------------------------|
+| Builder.NewBatch                 |       8.7 ns | 1/1000, memory already allocated |
+| Builder.NewBatch w/ 1 Comp       |       9.3 ns | 1000, memory already allocated |
+| Builder.NewBatch w/ 5 Comps      |      10.4 ns | 1000, memory already allocated |
+| Batch.RemoveEntities             |       6.6 ns | 1/1000                       |
+| Batch.RemoveEntities w/ 1 Comp   |       5.8 ns | 1000                         |
+| Batch.RemoveEntities w/ 5 Comps  |       6.6 ns | 1000                         |

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,41 +1,65 @@
 # Benchmarks
 
-This document gives an overview over the runtime cost of typical Arche operations.
-If not stated differently, time is per entity or per single operation.
+This document gives an overview of the runtime cost of typical Arche operations.
+All time information is per entity.
+Batch oerations are performed in batches of 1000 entities.
+
+Absolute numbers are not  really meaningful, as they heavily depend on the hardware.
+However, all benchmarks run in the CI in the same job and hence on the same machine, and can be compared.
 
 ## Query
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| Query.Next                       |       1.6 ns |                              |
-| Query.Next + 1x Get              |       1.9 ns |                              |
-| Query.Next + 2x Get              |       2.6 ns |                              |
-| Query.Next + 5x Get              |       4.8 ns |                              |
-| Query.EntityAt, 1 arch           |      11.3 ns |                              |
-| Query.EntityAt, 1 arch           |       3.0 ns | registered filter            |
-| Query.EntityAt, 5 arch           |      15.9 ns |                              |
+| Query.Next                       |       1.0 ns |                              |
+| Query.Next + 1x Get              |       1.6 ns |                              |
+| Query.Next + 2x Get              |       2.3 ns |                              |
+| Query.Next + 5x Get              |       4.4 ns |                              |
+| Query.EntityAt, 1 arch           |      11.7 ns |                              |
+| Query.EntityAt, 1 arch           |       2.8 ns | registered filter            |
+| Query.EntityAt, 5 arch           |      14.9 ns |                              |
 | Query.EntityAt, 5 arch           |       3.1 ns | registered filter            |
-| World.Query                      |      50.7 ns |                              |
-| World.Query                      |      30.6 ns | registered filter            |
+| World.Query                      |      46.3 ns |                              |
+| World.Query                      |      34.1 ns | registered filter            |
 
 ## Entities
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| World.NewEntity                  |      16.5 ns | memory already allocated     |
-| World.NewEntity w/ 1 Comp        |      33.1 ns | memory already allocated     |
-| World.NewEntity w/ 5 Comps       |      58.5 ns | memory already allocated     |
-| World.RemoveEntity               |      13.2 ns |                              |
-| World.RemoveEntity w/ 1 Comp     |      20.0 ns |                              |
-| World.RemoveEntity w/ 5 Comps    |      44.0 ns |                              |
+| World.NewEntity                  |      16.1 ns | memory already allocated     |
+| World.NewEntity w/ 1 Comp        |      34.2 ns | memory already allocated     |
+| World.NewEntity w/ 5 Comps       |      59.4 ns | memory already allocated     |
+| World.RemoveEntity               |      15.6 ns |                              |
+| World.RemoveEntity w/ 1 Comp     |      26.1 ns |                              |
+| World.RemoveEntity w/ 5 Comps    |      54.8 ns |                              |
 
 ## Entities, batched
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| Builder.NewBatch                 |       8.7 ns | 1/1000, memory already allocated |
-| Builder.NewBatch w/ 1 Comp       |       9.3 ns | 1000, memory already allocated |
-| Builder.NewBatch w/ 5 Comps      |      10.4 ns | 1000, memory already allocated |
-| Batch.RemoveEntities             |       6.6 ns | 1/1000                       |
-| Batch.RemoveEntities w/ 1 Comp   |       5.8 ns | 1000                         |
-| Batch.RemoveEntities w/ 5 Comps  |       6.6 ns | 1000                         |
+| Builder.NewBatch                 |       9.9 ns | 1000, memory already allocated |
+| Builder.NewBatch w/ 1 Comp       |      10.0 ns | 1000, memory already allocated |
+| Builder.NewBatch w/ 5 Comps      |      10.0 ns | 1000, memory already allocated |
+| Batch.RemoveEntities             |       7.5 ns | 1000                         |
+| Batch.RemoveEntities w/ 1 Comp   |       7.2 ns | 1000                         |
+| Batch.RemoveEntities w/ 5 Comps  |       8.5 ns | 1000                         |
+
+## Components
+
+| Operation                        | Time         | Remark                       |
+|----------------------------------|-------------:|------------------------------|
+| World.Add 1 Comp                 |      49.4 ns | memory already allocated     |
+| World.Add 5 Comps                |      79.0 ns | memory already allocated     |
+| World.Remove 1 Comp              |      59.8 ns |                              |
+| World.Remove 5 Comps             |     121.8 ns |                              |
+| World.Exchange 1 Comp            |      56.4 ns | memory already allocated     |
+
+## Components, batched
+
+| Operation                        | Time         | Remark                       |
+|----------------------------------|-------------:|------------------------------|
+| Batch.Add 1 Comp                 |       8.8 ns | 1000, memory already allocated |
+| Batch.Add 5 Comps                |       8.9 ns | 1000, memory already allocated |
+| Batch.Remove 1 Comp              |      10.3 ns | 1000                         |
+| Batch.Remove 5 Comps             |      16.1 ns | 1000                         |
+| Batch.Exchange 1 Comp            |      10.3 ns | 1000, memory already allocated |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Adds method `Query.EntityAt()`, useful for things like random sampling of entities (#358)
 
+### Documentation
+
+* Adds [BENCHMARKS.md](https://github.com/mlange-42/arche/blob/main/BENCHMARKS.md) for a tabular overview of the runtime cost of typical *Arche* ECS operations (#367)
+
 ### Bugfixes
 
 * Prevents using the same component multiple times in any operations, through panic (#357)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Neither is silent failure, given the scientific background.
 
 ## Benchmarks
 
+A tabular overview of the runtime cost of typical *Arche* ECS operations is provided in [BENCHMARKS.md](https://github.com/mlange-42/arche/blob/main/BENCHMARKS.md).
+
 See also the latest [Benchmarks CI run](https://github.com/mlange-42/arche/actions/workflows/benchmarks.yml).
 
 ### Arche vs. other Go ECS implementations

--- a/benchmark/table/components.go
+++ b/benchmark/table/components.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+)
+
+func benchesComponents() []bench {
+	return []bench{
+		{Name: "World.Add 1 Comp", Desc: "memory already allocated", F: componentsAdd1_1000, N: 1000},
+		{Name: "World.Add 5 Comps", Desc: "memory already allocated", F: componentsAdd5_1000, N: 1000},
+
+		{Name: "World.Remove 1 Comp", Desc: "", F: componentsRemove1_1000, N: 1000},
+		{Name: "World.Remove 5 Comps", Desc: "", F: componentsRemove5_1000, N: 1000},
+
+		{Name: "World.Exchange 1 Comp", Desc: "memory already allocated", F: componentsExchange1_1000, N: 1000},
+	}
+}
+
+func componentsAdd1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	filter := ecs.All(id1)
+
+	builder := ecs.NewBuilder(&w)
+	query := builder.NewBatchQ(1000)
+
+	entities := make([]ecs.Entity, 0, 1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, e := range entities {
+			w.Add(e, id1)
+		}
+		b.StopTimer()
+		w.Batch().Remove(filter, id1)
+	}
+}
+
+func componentsAdd5_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	filter := ecs.All(id1, id2, id3, id4, id5)
+
+	builder := ecs.NewBuilder(&w)
+	query := builder.NewBatchQ(1000)
+
+	entities := make([]ecs.Entity, 0, 1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, e := range entities {
+			w.Add(e, id1, id2, id3, id4, id5)
+		}
+		b.StopTimer()
+		w.Batch().Remove(filter, id1, id2, id3, id4, id5)
+	}
+}
+
+func componentsRemove1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	filter := ecs.All()
+
+	builder := ecs.NewBuilder(&w, id1)
+	query := builder.NewBatchQ(1000)
+
+	entities := make([]ecs.Entity, 0, 1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, e := range entities {
+			w.Remove(e, id1)
+		}
+		b.StopTimer()
+		w.Batch().Add(filter, id1)
+	}
+}
+
+func componentsRemove5_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	filter := ecs.All()
+
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+	query := builder.NewBatchQ(1000)
+
+	entities := make([]ecs.Entity, 0, 1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, e := range entities {
+			w.Remove(e, id1, id2, id3, id4, id5)
+		}
+		b.StopTimer()
+		w.Batch().Add(filter, id1, id2, id3, id4, id5)
+	}
+}
+
+func componentsExchange1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	filter := ecs.All(id2)
+	ex1 := []ecs.ID{id1}
+	ex2 := []ecs.ID{id2}
+
+	builder := ecs.NewBuilder(&w, id1)
+	query := builder.NewBatchQ(1000)
+
+	entities := make([]ecs.Entity, 0, 1000)
+	for query.Next() {
+		entities = append(entities, query.Entity())
+	}
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for _, e := range entities {
+			w.Exchange(e, ex2, ex1)
+		}
+		b.StopTimer()
+		w.Batch().Exchange(filter, ex1, ex2)
+	}
+}

--- a/benchmark/table/components_batch.go
+++ b/benchmark/table/components_batch.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+)
+
+func benchesComponentsBatch() []bench {
+	return []bench{
+		{Name: "Batch.Add 1 Comp", Desc: "memory already allocated", F: componentsBatchAdd1_1000, N: 1000},
+		{Name: "Batch.Add 5 Comps", Desc: "memory already allocated", F: componentsBatchAdd5_1000, N: 1000},
+
+		{Name: "Batch.Remove 1 Comp", Desc: "", F: componentsBatchRemove1_1000, N: 1000},
+		{Name: "Batch.Remove 5 Comps", Desc: "", F: componentsBatchRemove5_1000, N: 1000},
+
+		{Name: "Batch.Exchange 1 Comp", Desc: "memory already allocated", F: componentsBatchExchange1_1000, N: 1000},
+	}
+}
+
+func componentsBatchAdd1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	filter := ecs.All(id1)
+
+	builder := ecs.NewBuilder(&w)
+	builder.NewBatch(1000)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		w.Batch().Add(ecs.All(), id1)
+		b.StopTimer()
+		w.Batch().Remove(filter, id1)
+	}
+}
+
+func componentsBatchAdd5_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	filter := ecs.All(id1, id2, id3, id4, id5)
+
+	builder := ecs.NewBuilder(&w)
+	builder.NewBatch(1000)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		w.Batch().Add(ecs.All(), id1, id2, id3, id4, id5)
+		b.StopTimer()
+		w.Batch().Remove(filter, id1, id2, id3, id4, id5)
+	}
+}
+
+func componentsBatchRemove1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	filter := ecs.All(id1)
+
+	builder := ecs.NewBuilder(&w, id1)
+	builder.NewBatch(1000)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		w.Batch().Remove(filter, id1)
+		b.StopTimer()
+		w.Batch().Add(ecs.All(), id1)
+	}
+}
+
+func componentsBatchRemove5_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	filter := ecs.All(id1, id2, id3, id4, id5)
+
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+	builder.NewBatch(1000)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		w.Batch().Remove(filter, id1, id2, id3, id4, id5)
+		b.StopTimer()
+		w.Batch().Add(ecs.All(), id1, id2, id3, id4, id5)
+	}
+}
+
+func componentsBatchExchange1_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	filter1 := ecs.All(id1)
+	filter2 := ecs.All(id2)
+	ex1 := []ecs.ID{id1}
+	ex2 := []ecs.ID{id2}
+
+	builder := ecs.NewBuilder(&w, id1)
+	builder.NewBatch(1000)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		w.Batch().Exchange(filter1, ex2, ex1)
+		b.StopTimer()
+		w.Batch().Exchange(filter2, ex1, ex2)
+	}
+}

--- a/benchmark/table/components_batch.go
+++ b/benchmark/table/components_batch.go
@@ -8,13 +8,13 @@ import (
 
 func benchesComponentsBatch() []bench {
 	return []bench{
-		{Name: "Batch.Add 1 Comp", Desc: "memory already allocated", F: componentsBatchAdd1_1000, N: 1000},
-		{Name: "Batch.Add 5 Comps", Desc: "memory already allocated", F: componentsBatchAdd5_1000, N: 1000},
+		{Name: "Batch.Add 1 Comp", Desc: "1000, memory already allocated", F: componentsBatchAdd1_1000, N: 1000},
+		{Name: "Batch.Add 5 Comps", Desc: "1000, memory already allocated", F: componentsBatchAdd5_1000, N: 1000},
 
-		{Name: "Batch.Remove 1 Comp", Desc: "", F: componentsBatchRemove1_1000, N: 1000},
-		{Name: "Batch.Remove 5 Comps", Desc: "", F: componentsBatchRemove5_1000, N: 1000},
+		{Name: "Batch.Remove 1 Comp", Desc: "1000", F: componentsBatchRemove1_1000, N: 1000},
+		{Name: "Batch.Remove 5 Comps", Desc: "1000", F: componentsBatchRemove5_1000, N: 1000},
 
-		{Name: "Batch.Exchange 1 Comp", Desc: "memory already allocated", F: componentsBatchExchange1_1000, N: 1000},
+		{Name: "Batch.Exchange 1 Comp", Desc: "1000, memory already allocated", F: componentsBatchExchange1_1000, N: 1000},
 	}
 }
 

--- a/benchmark/table/entities.go
+++ b/benchmark/table/entities.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+)
+
+func benchesEntities() []bench {
+	return []bench{
+		{Name: "World.NewEntity", Desc: "memory already allocated", F: entitiesCreate_1000, N: 1000},
+		{Name: "World.NewEntity w/ 1 Comp", Desc: "memory already allocated", F: entitiesCreate_1Comp_1000, N: 1000},
+		{Name: "World.NewEntity w/ 5 Comps", Desc: "memory already allocated", F: entitiesCreate_5Comp_1000, N: 1000},
+
+		{Name: "World.RemoveEntity", Desc: "", F: entitiesRemove_1000, N: 1000},
+		{Name: "World.RemoveEntity w/ 1 Comp", Desc: "", F: entitiesRemove_1Comp_1000, N: 1000},
+		{Name: "World.RemoveEntity w/ 5 Comps", Desc: "", F: entitiesRemove_5Comp_1000, N: 1000},
+	}
+}
+
+func entitiesCreate_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			_ = w.NewEntity()
+		}
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesCreate_1Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			_ = w.NewEntity(id1)
+		}
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesCreate_5Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			_ = w.NewEntity(id1, id2, id3, id4, id5)
+		}
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesRemove_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	builder := ecs.NewBuilder(&w)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		query := builder.NewBatchQ(1000)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+		b.StartTimer()
+		for _, e := range entities {
+			w.RemoveEntity(e)
+		}
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}
+
+func entitiesRemove_1Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	builder := ecs.NewBuilder(&w, id1)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		query := builder.NewBatchQ(1000)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+		b.StartTimer()
+		for _, e := range entities {
+			w.RemoveEntity(e)
+		}
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}
+
+func entitiesRemove_5Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		query := builder.NewBatchQ(1000)
+		for query.Next() {
+			entities = append(entities, query.Entity())
+		}
+		b.StartTimer()
+		for _, e := range entities {
+			w.RemoveEntity(e)
+		}
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}

--- a/benchmark/table/entities_batch.go
+++ b/benchmark/table/entities_batch.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+)
+
+func benchesEntitiesBatch() []bench {
+	return []bench{
+		{Name: "Builder.NewBatch", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_1000, N: 1000},
+		{Name: "Builder.NewBatch w/ 1 Comp", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_1Comp_1000, N: 1000},
+		{Name: "Builder.NewBatch w/ 5 Comps", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_5Comp_1000, N: 1000},
+
+		{Name: "Batch.RemoveEntities", Desc: "1/1000", F: entitiesBatchRemove_1000, N: 1000},
+		{Name: "Batch.RemoveEntities w/ 1 Comp", Desc: "1/1000", F: entitiesBatchRemove_1Comp_1000, N: 1000},
+		{Name: "Batch.RemoveEntities w/ 5 Comps", Desc: "1/1000", F: entitiesBatchRemove_5Comp_1000, N: 1000},
+	}
+}
+
+func entitiesBatchCreate_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	builder := ecs.NewBuilder(&w)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		builder.NewBatch(1000)
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesBatchCreate_1Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	builder := ecs.NewBuilder(&w, id1)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		builder.NewBatch(1000)
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesBatchCreate_5Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		builder.NewBatch(1000)
+		b.StopTimer()
+		w.Batch().RemoveEntities(ecs.All())
+	}
+}
+
+func entitiesBatchRemove_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	builder := ecs.NewBuilder(&w)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		builder.NewBatch(1000)
+		b.StartTimer()
+		w.Batch().RemoveEntities(ecs.All())
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}
+
+func entitiesBatchRemove_1Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	builder := ecs.NewBuilder(&w, id1)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		builder.NewBatch(1000)
+		b.StartTimer()
+		w.Batch().RemoveEntities(ecs.All())
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}
+
+func entitiesBatchRemove_5Comp_1000(b *testing.B) {
+	b.StopTimer()
+
+	w := ecs.NewWorld(ecs.NewConfig().WithCapacityIncrement(1024))
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+
+	entities := make([]ecs.Entity, 0, 1000)
+
+	for i := 0; i < b.N; i++ {
+		builder.NewBatch(1000)
+		b.StartTimer()
+		w.Batch().RemoveEntities(ecs.All())
+		b.StopTimer()
+		entities = entities[:0]
+	}
+}

--- a/benchmark/table/entities_batch.go
+++ b/benchmark/table/entities_batch.go
@@ -8,13 +8,13 @@ import (
 
 func benchesEntitiesBatch() []bench {
 	return []bench{
-		{Name: "Builder.NewBatch", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_1000, N: 1000},
-		{Name: "Builder.NewBatch w/ 1 Comp", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_1Comp_1000, N: 1000},
-		{Name: "Builder.NewBatch w/ 5 Comps", Desc: "1/1000, memory already allocated", F: entitiesBatchCreate_5Comp_1000, N: 1000},
+		{Name: "Builder.NewBatch", Desc: "1000, memory already allocated", F: entitiesBatchCreate_1000, N: 1000},
+		{Name: "Builder.NewBatch w/ 1 Comp", Desc: "1000, memory already allocated", F: entitiesBatchCreate_1Comp_1000, N: 1000},
+		{Name: "Builder.NewBatch w/ 5 Comps", Desc: "1000, memory already allocated", F: entitiesBatchCreate_5Comp_1000, N: 1000},
 
-		{Name: "Batch.RemoveEntities", Desc: "1/1000", F: entitiesBatchRemove_1000, N: 1000},
-		{Name: "Batch.RemoveEntities w/ 1 Comp", Desc: "1/1000", F: entitiesBatchRemove_1Comp_1000, N: 1000},
-		{Name: "Batch.RemoveEntities w/ 5 Comps", Desc: "1/1000", F: entitiesBatchRemove_5Comp_1000, N: 1000},
+		{Name: "Batch.RemoveEntities", Desc: "1000", F: entitiesBatchRemove_1000, N: 1000},
+		{Name: "Batch.RemoveEntities w/ 1 Comp", Desc: "1000", F: entitiesBatchRemove_1Comp_1000, N: 1000},
+		{Name: "Batch.RemoveEntities w/ 5 Comps", Desc: "1000", F: entitiesBatchRemove_5Comp_1000, N: 1000},
 	}
 }
 

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -15,29 +13,6 @@ type bench struct {
 }
 
 func main() {
-	runBenches("Query", benchesQuery(), toMarkdown)
-}
-
-func runBenches(title string, benches []bench, format func([]bench) string) {
-	for i := range benches {
-		b := &benches[i]
-		res := testing.Benchmark(b.F)
-		b.T = float64(res.T.Nanoseconds()) / float64(res.N*b.N)
-	}
-	fmt.Printf("## %s\n\n%s", title, format(benches))
-}
-
-func toMarkdown(benches []bench) string {
-	b := strings.Builder{}
-
-	b.WriteString(fmt.Sprintf("| %-28s | %-12s | %-28s |\n", "Operation", "Time", "Remark"))
-	b.WriteString(fmt.Sprintf("|%s|%s|%s|\n", strings.Repeat("-", 30), strings.Repeat("-", 14), strings.Repeat("-", 30)))
-
-	for i := range benches {
-		bench := &benches[i]
-		t := fmt.Sprintf("%.1f ns", bench.T)
-		b.WriteString(fmt.Sprintf("| %-28s | %12s | %-28s |\n", bench.Name, t, bench.Desc))
-	}
-
-	return b.String()
+	//runBenches("Query", benchesQuery(), toMarkdown)
+	runBenches("Entities", benchesEntities(), toMarkdown)
 }

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -15,21 +15,31 @@ type bench struct {
 }
 
 func main() {
-	benches := []bench{
-		{Name: "Iter", Desc: "", F: queryIter_100_000, N: 100_000},
-		{Name: "Iter + Get 1", Desc: "", F: queryIterGet_1_100_000, N: 100_000},
-		{Name: "Iter + Get 2", Desc: "", F: queryIterGet_2_100_000, N: 100_000},
-		{Name: "Iter + Get 5", Desc: "", F: queryIterGet_5_100_000, N: 100_000},
+	query := []bench{
+		{Name: "Query.Next", Desc: "", F: queryIter_100_000, N: 100_000},
+		{Name: "Query.Next + 1x Get", Desc: "", F: queryIterGet_1_100_000, N: 100_000},
+		{Name: "Query.Next + 2x Get", Desc: "", F: queryIterGet_2_100_000, N: 100_000},
+		{Name: "Query.Next + 5x Get", Desc: "", F: queryIterGet_5_100_000, N: 100_000},
+
+		{Name: "Query.EntityAt, 1 arch", Desc: "", F: querEntityAt_1Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 1 arch", Desc: "registered filter", F: querEntityAtRegistered_1Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 5 arch", Desc: "", F: querEntityAt_5Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 5 arch", Desc: "registered filter", F: querEntityAtRegistered_5Arch_1000, N: 1000},
+
+		{Name: "World.Query", Desc: "", F: queryCreate, N: 1},
+		{Name: "World.Query", Desc: "registered filter", F: queryCreateCached, N: 1},
 	}
 
+	runBenches("Query", query, toMarkdown)
+}
+
+func runBenches(title string, benches []bench, format func([]bench) string) {
 	for i := range benches {
 		b := &benches[i]
 		res := testing.Benchmark(b.F)
 		b.T = float64(res.T.Nanoseconds()) / float64(res.N*b.N)
 	}
-
-	md := toMarkdown(benches)
-	fmt.Println(md)
+	fmt.Printf("## %s\n\n%s", title, format(benches))
 }
 
 func toMarkdown(benches []bench) string {

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -16,4 +16,6 @@ func main() {
 	runBenches("Query", benchesQuery(), toMarkdown)
 	runBenches("Entities", benchesEntities(), toMarkdown)
 	runBenches("Entities, batched", benchesEntitiesBatch(), toMarkdown)
+	runBenches("Components", benchesComponents(), toMarkdown)
+	runBenches("Components, batched", benchesComponentsBatch(), toMarkdown)
 }

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -15,22 +15,7 @@ type bench struct {
 }
 
 func main() {
-	query := []bench{
-		{Name: "Query.Next", Desc: "", F: queryIter_100_000, N: 100_000},
-		{Name: "Query.Next + 1x Get", Desc: "", F: queryIterGet_1_100_000, N: 100_000},
-		{Name: "Query.Next + 2x Get", Desc: "", F: queryIterGet_2_100_000, N: 100_000},
-		{Name: "Query.Next + 5x Get", Desc: "", F: queryIterGet_5_100_000, N: 100_000},
-
-		{Name: "Query.EntityAt, 1 arch", Desc: "", F: querEntityAt_1Arch_1000, N: 1000},
-		{Name: "Query.EntityAt, 1 arch", Desc: "registered filter", F: querEntityAtRegistered_1Arch_1000, N: 1000},
-		{Name: "Query.EntityAt, 5 arch", Desc: "", F: querEntityAt_5Arch_1000, N: 1000},
-		{Name: "Query.EntityAt, 5 arch", Desc: "registered filter", F: querEntityAtRegistered_5Arch_1000, N: 1000},
-
-		{Name: "World.Query", Desc: "", F: queryCreate, N: 1},
-		{Name: "World.Query", Desc: "registered filter", F: queryCreateCached, N: 1},
-	}
-
-	runBenches("Query", query, toMarkdown)
+	runBenches("Query", benchesQuery(), toMarkdown)
 }
 
 func runBenches(title string, benches []bench, format func([]bench) string) {
@@ -45,12 +30,13 @@ func runBenches(title string, benches []bench, format func([]bench) string) {
 func toMarkdown(benches []bench) string {
 	b := strings.Builder{}
 
-	b.WriteString("| Operation | Time | Remark |\n")
-	b.WriteString("|-----------|------|--------|\n")
+	b.WriteString(fmt.Sprintf("| %-28s | %-12s | %-28s |\n", "Operation", "Time", "Remark"))
+	b.WriteString(fmt.Sprintf("|%s|%s|%s|\n", strings.Repeat("-", 30), strings.Repeat("-", 14), strings.Repeat("-", 30)))
 
 	for i := range benches {
 		bench := &benches[i]
-		b.WriteString(fmt.Sprintf("| %s | %.1f ns | %s |\n", bench.Name, bench.T, bench.Desc))
+		t := fmt.Sprintf("%.1f ns", bench.T)
+		b.WriteString(fmt.Sprintf("| %-28s | %12s | %-28s |\n", bench.Name, t, bench.Desc))
 	}
 
 	return b.String()

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -13,6 +13,7 @@ type bench struct {
 }
 
 func main() {
-	//runBenches("Query", benchesQuery(), toMarkdown)
+	runBenches("Query", benchesQuery(), toMarkdown)
 	runBenches("Entities", benchesEntities(), toMarkdown)
+	runBenches("Entities, batched", benchesEntitiesBatch(), toMarkdown)
 }

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type bench struct {
+	Name string
+	Desc string
+	F    func(b *testing.B)
+	N    int
+	T    float64
+}
+
+func main() {
+	benches := []bench{
+		{Name: "Iter", Desc: "", F: queryIter_100_000, N: 100_000},
+		{Name: "Iter + Get 1", Desc: "", F: queryIterGet_1_100_000, N: 100_000},
+		{Name: "Iter + Get 2", Desc: "", F: queryIterGet_2_100_000, N: 100_000},
+		{Name: "Iter + Get 5", Desc: "", F: queryIterGet_5_100_000, N: 100_000},
+	}
+
+	for i := range benches {
+		b := &benches[i]
+		res := testing.Benchmark(b.F)
+		b.T = float64(res.T.Nanoseconds()) / float64(res.N*b.N)
+	}
+
+	md := toMarkdown(benches)
+	fmt.Println(md)
+}
+
+func toMarkdown(benches []bench) string {
+	b := strings.Builder{}
+
+	b.WriteString("| Operation | Time | Remark |\n")
+	b.WriteString("|-----------|------|--------|\n")
+
+	for i := range benches {
+		bench := &benches[i]
+		b.WriteString(fmt.Sprintf("| %s | %.1f ns | %s |\n", bench.Name, bench.T, bench.Desc))
+	}
+
+	return b.String()
+}

--- a/benchmark/table/query.go
+++ b/benchmark/table/query.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/mlange-42/arche/ecs"
@@ -107,4 +108,145 @@ func queryIterGet_5_100_000(b *testing.B) {
 	b.StopTimer()
 	sum := c1.V + c2.V + c3.V + c4.V + c5.V
 	_ = sum
+}
+
+func querEntityAt_1Arch_1000(b *testing.B) {
+	b.StopTimer()
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	builder := ecs.NewBuilder(&w, id1)
+	builder.NewBatch(1000)
+
+	indices := make([]int, 1000)
+	for i := range indices {
+		indices[i] = rand.Intn(1000)
+	}
+
+	query := w.Query(ecs.All(id1))
+	b.StartTimer()
+	var e ecs.Entity
+	for i := 0; i < b.N; i++ {
+		for _, idx := range indices {
+			e = query.EntityAt(idx)
+		}
+	}
+	_ = e
+}
+
+func querEntityAtRegistered_1Arch_1000(b *testing.B) {
+	b.StopTimer()
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	builder := ecs.NewBuilder(&w, id1)
+	builder.NewBatch(1000)
+
+	indices := make([]int, 1000)
+	for i := range indices {
+		indices[i] = rand.Intn(1000)
+	}
+
+	f := ecs.All(id1)
+	filter := w.Cache().Register(f)
+
+	query := w.Query(&filter)
+	b.StartTimer()
+	var e ecs.Entity
+	for i := 0; i < b.N; i++ {
+		for _, idx := range indices {
+			e = query.EntityAt(idx)
+		}
+	}
+	_ = e
+}
+
+func querEntityAt_5Arch_1000(b *testing.B) {
+	b.StopTimer()
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+	builder.NewBatch(1000)
+
+	indices := make([]int, 1000)
+	for i := range indices {
+		indices[i] = rand.Intn(1000)
+	}
+
+	query := w.Query(ecs.All(id1))
+	b.StartTimer()
+	var e ecs.Entity
+	for i := 0; i < b.N; i++ {
+		for _, idx := range indices {
+			e = query.EntityAt(idx)
+		}
+	}
+	_ = e
+}
+
+func querEntityAtRegistered_5Arch_1000(b *testing.B) {
+	b.StopTimer()
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+	builder.NewBatch(1000)
+
+	indices := make([]int, 1000)
+	for i := range indices {
+		indices[i] = rand.Intn(1000)
+	}
+
+	f := ecs.All(id1)
+	filter := w.Cache().Register(f)
+
+	query := w.Query(&filter)
+	b.StartTimer()
+	var e ecs.Entity
+	for i := 0; i < b.N; i++ {
+		for _, idx := range indices {
+			e = query.EntityAt(idx)
+		}
+	}
+	_ = e
+}
+
+func queryCreate(b *testing.B) {
+	b.StopTimer()
+
+	world := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&world)
+	builder := ecs.NewBuilder(&world, id1)
+	builder.NewBatch(100)
+
+	filter := ecs.All(id1)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := world.Query(filter)
+		query.Close()
+	}
+}
+
+func queryCreateCached(b *testing.B) {
+	b.StopTimer()
+
+	world := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&world)
+	builder := ecs.NewBuilder(&world, id1)
+	builder.NewBatch(100)
+
+	f := ecs.All(id1)
+	filter := world.Cache().Register(f)
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		query := world.Query(&filter)
+		query.Close()
+	}
 }

--- a/benchmark/table/query.go
+++ b/benchmark/table/query.go
@@ -7,6 +7,23 @@ import (
 	"github.com/mlange-42/arche/ecs"
 )
 
+func benchesQuery() []bench {
+	return []bench{
+		{Name: "Query.Next", Desc: "", F: queryIter_100_000, N: 100_000},
+		{Name: "Query.Next + 1x Get", Desc: "", F: queryIterGet_1_100_000, N: 100_000},
+		{Name: "Query.Next + 2x Get", Desc: "", F: queryIterGet_2_100_000, N: 100_000},
+		{Name: "Query.Next + 5x Get", Desc: "", F: queryIterGet_5_100_000, N: 100_000},
+
+		{Name: "Query.EntityAt, 1 arch", Desc: "", F: querEntityAt_1Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 1 arch", Desc: "registered filter", F: querEntityAtRegistered_1Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 5 arch", Desc: "", F: querEntityAt_5Arch_1000, N: 1000},
+		{Name: "Query.EntityAt, 5 arch", Desc: "registered filter", F: querEntityAtRegistered_5Arch_1000, N: 1000},
+
+		{Name: "World.Query", Desc: "", F: queryCreate, N: 1},
+		{Name: "World.Query", Desc: "registered filter", F: queryCreateCached, N: 1},
+	}
+}
+
 func queryIter_100_000(b *testing.B) {
 	w := ecs.NewWorld()
 	builder := ecs.NewBuilder(&w)

--- a/benchmark/table/query.go
+++ b/benchmark/table/query.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/mlange-42/arche/ecs"
+)
+
+func queryIter_100_000(b *testing.B) {
+	w := ecs.NewWorld()
+	builder := ecs.NewBuilder(&w)
+	builder.NewBatch(100_000)
+	filter := ecs.All()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := w.Query(filter)
+		b.StartTimer()
+		for query.Next() {
+		}
+	}
+}
+
+func queryIterGet_1_100_000(b *testing.B) {
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+
+	builder := ecs.NewBuilder(&w, id1)
+	builder.NewBatch(100_000)
+	filter := ecs.All(id1)
+
+	var c1 *comp1
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := w.Query(filter)
+		b.StartTimer()
+		for query.Next() {
+			c1 = (*comp1)(query.Get(id1))
+		}
+	}
+	b.StopTimer()
+	sum := c1.V
+	_ = sum
+}
+
+func queryIterGet_2_100_000(b *testing.B) {
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+
+	builder := ecs.NewBuilder(&w, id1, id2)
+	builder.NewBatch(100_000)
+	filter := ecs.All(id1, id2)
+
+	var c1 *comp1
+	var c2 *comp2
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := w.Query(filter)
+		b.StartTimer()
+		for query.Next() {
+			c1 = (*comp1)(query.Get(id1))
+			c2 = (*comp2)(query.Get(id2))
+		}
+	}
+	b.StopTimer()
+	sum := c1.V + c2.V
+	_ = sum
+}
+
+func queryIterGet_5_100_000(b *testing.B) {
+	w := ecs.NewWorld()
+	id1 := ecs.ComponentID[comp1](&w)
+	id2 := ecs.ComponentID[comp2](&w)
+	id3 := ecs.ComponentID[comp3](&w)
+	id4 := ecs.ComponentID[comp4](&w)
+	id5 := ecs.ComponentID[comp5](&w)
+
+	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
+	builder.NewBatch(100_000)
+	filter := ecs.All(id1, id2, id3, id4, id5)
+
+	var c1 *comp1
+	var c2 *comp2
+	var c3 *comp3
+	var c4 *comp4
+	var c5 *comp5
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		query := w.Query(filter)
+		b.StartTimer()
+		for query.Next() {
+			c1 = (*comp1)(query.Get(id1))
+			c2 = (*comp2)(query.Get(id2))
+			c3 = (*comp3)(query.Get(id3))
+			c4 = (*comp4)(query.Get(id4))
+			c5 = (*comp5)(query.Get(id5))
+		}
+	}
+	b.StopTimer()
+	sum := c1.V + c2.V + c3.V + c4.V + c5.V
+	_ = sum
+}

--- a/benchmark/table/types.go
+++ b/benchmark/table/types.go
@@ -1,0 +1,21 @@
+package main
+
+type comp1 struct {
+	V int64
+}
+
+type comp2 struct {
+	V int64
+}
+
+type comp3 struct {
+	V int64
+}
+
+type comp4 struct {
+	V int64
+}
+
+type comp5 struct {
+	V int64
+}

--- a/benchmark/table/util.go
+++ b/benchmark/table/util.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func runBenches(title string, benches []bench, format func([]bench) string) {
+	for i := range benches {
+		b := &benches[i]
+		res := testing.Benchmark(b.F)
+		b.T = float64(res.T.Nanoseconds()) / float64(res.N*b.N)
+	}
+	fmt.Printf("## %s\n\n%s", title, format(benches))
+}
+
+func toMarkdown(benches []bench) string {
+	b := strings.Builder{}
+
+	b.WriteString(fmt.Sprintf("| %-32s | %-12s | %-28s |\n", "Operation", "Time", "Remark"))
+	b.WriteString(fmt.Sprintf("|%s|%s|%s|\n", strings.Repeat("-", 34), strings.Repeat("-", 14), strings.Repeat("-", 30)))
+
+	for i := range benches {
+		bench := &benches[i]
+		t := fmt.Sprintf("%.1f ns", bench.T)
+		b.WriteString(fmt.Sprintf("| %-32s | %12s | %-28s |\n", bench.Name, t, bench.Desc))
+	}
+
+	return b.String()
+}

--- a/benchmark/table/util.go
+++ b/benchmark/table/util.go
@@ -19,13 +19,14 @@ func toMarkdown(benches []bench) string {
 	b := strings.Builder{}
 
 	b.WriteString(fmt.Sprintf("| %-32s | %-12s | %-28s |\n", "Operation", "Time", "Remark"))
-	b.WriteString(fmt.Sprintf("|%s|%s|%s|\n", strings.Repeat("-", 34), strings.Repeat("-", 14), strings.Repeat("-", 30)))
+	b.WriteString(fmt.Sprintf("|%s|%s:|%s|\n", strings.Repeat("-", 34), strings.Repeat("-", 13), strings.Repeat("-", 30)))
 
 	for i := range benches {
 		bench := &benches[i]
 		t := fmt.Sprintf("%.1f ns", bench.T)
 		b.WriteString(fmt.Sprintf("| %-32s | %12s | %-28s |\n", bench.Name, t, bench.Desc))
 	}
+	b.WriteString("\n")
 
 	return b.String()
 }


### PR DESCRIPTION
## Query

| Operation                        | Time         | Remark                       |
|----------------------------------|-------------:|------------------------------|
| Query.Next                       |       1.0 ns |                              |
| Query.Next + 1x Get              |       1.6 ns |                              |
| Query.Next + 2x Get              |       2.3 ns |                              |
| Query.Next + 5x Get              |       4.4 ns |                              |
| Query.EntityAt, 1 arch           |      11.7 ns |                              |
| Query.EntityAt, 1 arch           |       2.8 ns | registered filter            |
| Query.EntityAt, 5 arch           |      14.9 ns |                              |
| Query.EntityAt, 5 arch           |       3.1 ns | registered filter            |
| World.Query                      |      46.3 ns |                              |
| World.Query                      |      34.1 ns | registered filter            |

## Entities

| Operation                        | Time         | Remark                       |
|----------------------------------|-------------:|------------------------------|
| World.NewEntity                  |      16.1 ns | memory already allocated     |
| World.NewEntity w/ 1 Comp        |      34.2 ns | memory already allocated     |
| World.NewEntity w/ 5 Comps       |      59.4 ns | memory already allocated     |
| World.RemoveEntity               |      15.6 ns |                              |
| World.RemoveEntity w/ 1 Comp     |      26.1 ns |                              |
| World.RemoveEntity w/ 5 Comps    |      54.8 ns |                              |

## Entities, batched

| Operation                        | Time         | Remark                       |
|----------------------------------|-------------:|------------------------------|
| Builder.NewBatch                 |       9.9 ns | 1000, memory already allocated |
| Builder.NewBatch w/ 1 Comp       |      10.0 ns | 1000, memory already allocated |
| Builder.NewBatch w/ 5 Comps      |      10.0 ns | 1000, memory already allocated |
| Batch.RemoveEntities             |       7.5 ns | 1000                         |
| Batch.RemoveEntities w/ 1 Comp   |       7.2 ns | 1000                         |
| Batch.RemoveEntities w/ 5 Comps  |       8.5 ns | 1000                         |

## Components

| Operation                        | Time         | Remark                       |
|----------------------------------|-------------:|------------------------------|
| World.Add 1 Comp                 |      49.4 ns | memory already allocated     |
| World.Add 5 Comps                |      79.0 ns | memory already allocated     |
| World.Remove 1 Comp              |      59.8 ns |                              |
| World.Remove 5 Comps             |     121.8 ns |                              |
| World.Exchange 1 Comp            |      56.4 ns | memory already allocated     |

## Components, batched

| Operation                        | Time         | Remark                       |
|----------------------------------|-------------:|------------------------------|
| Batch.Add 1 Comp                 |       8.8 ns | 1000, memory already allocated |
| Batch.Add 5 Comps                |       8.9 ns | 1000, memory already allocated |
| Batch.Remove 1 Comp              |      10.3 ns | 1000                         |
| Batch.Remove 5 Comps             |      16.1 ns | 1000                         |
| Batch.Exchange 1 Comp            |      10.3 ns | 1000, memory already allocated |