### PR TITLE
Fix `EntityAt` benchmarks to actually use 5 archetypes

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -13,15 +13,15 @@ However, all benchmarks run in the CI in the same job and hence on the same mach
 |----------------------------------|-------------:|------------------------------|
 | Query.Next                       |       1.0 ns |                              |
 | Query.Next + 1x Query.Get        |       1.6 ns |                              |
-| Query.Next + 2x Query.Get        |       2.3 ns |                              |
+| Query.Next + 2x Query.Get        |       2.2 ns |                              |
 | Query.Next + 5x Query.Get        |       4.4 ns |                              |
-| Query.Next + Query.Relation      |       2.2 ns |                              |
+| Query.Next + Query.Relation      |       2.3 ns |                              |
 | Query.EntityAt, 1 arch           |      12.0 ns |                              |
 | Query.EntityAt, 1 arch           |       2.8 ns | registered filter            |
-| Query.EntityAt, 5 arch           |      16.1 ns |                              |
-| Query.EntityAt, 5 arch           |       2.8 ns | registered filter            |
-| World.Query                      |      46.0 ns |                              |
-| World.Query                      |      33.6 ns | registered filter            |
+| Query.EntityAt, 5 arch           |      31.6 ns |                              |
+| Query.EntityAt, 5 arch           |       4.9 ns | registered filter            |
+| World.Query                      |      45.1 ns |                              |
+| World.Query                      |      33.4 ns | registered filter            |
 
 ## World access
 
@@ -37,40 +37,40 @@ However, all benchmarks run in the CI in the same job and hence on the same mach
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| World.NewEntity                  |      16.6 ns | memory already allocated     |
-| World.NewEntity w/ 1 Comp        |      33.6 ns | memory already allocated     |
-| World.NewEntity w/ 5 Comps       |      47.0 ns | memory already allocated     |
-| World.RemoveEntity               |      15.4 ns |                              |
-| World.RemoveEntity w/ 1 Comp     |      25.7 ns |                              |
-| World.RemoveEntity w/ 5 Comps    |      54.4 ns |                              |
+| World.NewEntity                  |      16.2 ns | memory already allocated     |
+| World.NewEntity w/ 1 Comp        |      34.0 ns | memory already allocated     |
+| World.NewEntity w/ 5 Comps       |      45.1 ns | memory already allocated     |
+| World.RemoveEntity               |      14.7 ns |                              |
+| World.RemoveEntity w/ 1 Comp     |      27.0 ns |                              |
+| World.RemoveEntity w/ 5 Comps    |      53.5 ns |                              |
 
 ## Entities, batched
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| Builder.NewBatch                 |       9.6 ns | 1000, memory already allocated |
-| Builder.NewBatch w/ 1 Comp       |       9.8 ns | 1000, memory already allocated |
-| Builder.NewBatch w/ 5 Comps      |       9.6 ns | 1000, memory already allocated |
-| Batch.RemoveEntities             |       6.9 ns | 1000                         |
-| Batch.RemoveEntities w/ 1 Comp   |       7.1 ns | 1000                         |
-| Batch.RemoveEntities w/ 5 Comps  |       7.9 ns | 1000                         |
+| Builder.NewBatch                 |       9.7 ns | 1000, memory already allocated |
+| Builder.NewBatch w/ 1 Comp       |      10.1 ns | 1000, memory already allocated |
+| Builder.NewBatch w/ 5 Comps      |      10.2 ns | 1000, memory already allocated |
+| Batch.RemoveEntities             |       7.0 ns | 1000                         |
+| Batch.RemoveEntities w/ 1 Comp   |       7.2 ns | 1000                         |
+| Batch.RemoveEntities w/ 5 Comps  |       7.6 ns | 1000                         |
 
 ## Components
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| World.Add 1 Comp                 |      50.7 ns | memory already allocated     |
-| World.Add 5 Comps                |      67.6 ns | memory already allocated     |
-| World.Remove 1 Comp              |      59.0 ns |                              |
-| World.Remove 5 Comps             |     101.0 ns |                              |
-| World.Exchange 1 Comp            |      60.5 ns | memory already allocated     |
+| World.Add 1 Comp                 |      48.2 ns | memory already allocated     |
+| World.Add 5 Comps                |      66.9 ns | memory already allocated     |
+| World.Remove 1 Comp              |      58.1 ns |                              |
+| World.Remove 5 Comps             |     103.6 ns |                              |
+| World.Exchange 1 Comp            |      55.5 ns | memory already allocated     |
 
 ## Components, batched
 
 | Operation                        | Time         | Remark                       |
 |----------------------------------|-------------:|------------------------------|
-| Batch.Add 1 Comp                 |       9.0 ns | 1000, memory already allocated |
-| Batch.Add 5 Comps                |       9.1 ns | 1000, memory already allocated |
-| Batch.Remove 1 Comp              |       9.8 ns | 1000                         |
-| Batch.Remove 5 Comps             |      14.9 ns | 1000                         |
+| Batch.Add 1 Comp                 |       8.4 ns | 1000, memory already allocated |
+| Batch.Add 5 Comps                |       8.9 ns | 1000, memory already allocated |
+| Batch.Remove 1 Comp              |      10.3 ns | 1000                         |
+| Batch.Remove 5 Comps             |      15.3 ns | 1000                         |
 | Batch.Exchange 1 Comp            |      10.0 ns | 1000, memory already allocated |

--- a/benchmark/table/query.go
+++ b/benchmark/table/query.go
@@ -186,8 +186,9 @@ func querEntityAtRegistered_1Arch_1000(b *testing.B) {
 
 	indices := make([]int, 1000)
 	for i := range indices {
-		indices[i] = rand.Intn(1000)
+		indices[i] = i
 	}
+	rand.Shuffle(len(indices), func(i, j int) { indices[i], indices[j] = indices[j], indices[i] })
 
 	f := ecs.All(id1)
 	filter := w.Cache().Register(f)
@@ -211,13 +212,23 @@ func querEntityAt_5Arch_1000(b *testing.B) {
 	id3 := ecs.ComponentID[comp3](&w)
 	id4 := ecs.ComponentID[comp4](&w)
 	id5 := ecs.ComponentID[comp5](&w)
-	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
-	builder.NewBatch(1000)
+
+	b1 := ecs.NewBuilder(&w, id1)
+	b2 := ecs.NewBuilder(&w, id1, id2)
+	b3 := ecs.NewBuilder(&w, id1, id3)
+	b4 := ecs.NewBuilder(&w, id1, id4)
+	b5 := ecs.NewBuilder(&w, id1, id5)
+	b1.NewBatch(200)
+	b2.NewBatch(200)
+	b3.NewBatch(200)
+	b4.NewBatch(200)
+	b5.NewBatch(200)
 
 	indices := make([]int, 1000)
 	for i := range indices {
-		indices[i] = rand.Intn(1000)
+		indices[i] = i
 	}
+	rand.Shuffle(len(indices), func(i, j int) { indices[i], indices[j] = indices[j], indices[i] })
 
 	query := w.Query(ecs.All(id1))
 	b.StartTimer()
@@ -238,8 +249,17 @@ func querEntityAtRegistered_5Arch_1000(b *testing.B) {
 	id3 := ecs.ComponentID[comp3](&w)
 	id4 := ecs.ComponentID[comp4](&w)
 	id5 := ecs.ComponentID[comp5](&w)
-	builder := ecs.NewBuilder(&w, id1, id2, id3, id4, id5)
-	builder.NewBatch(1000)
+
+	b1 := ecs.NewBuilder(&w, id1)
+	b2 := ecs.NewBuilder(&w, id1, id2)
+	b3 := ecs.NewBuilder(&w, id1, id3)
+	b4 := ecs.NewBuilder(&w, id1, id4)
+	b5 := ecs.NewBuilder(&w, id1, id5)
+	b1.NewBatch(200)
+	b2.NewBatch(200)
+	b3.NewBatch(200)
+	b4.NewBatch(200)
+	b5.NewBatch(200)
 
 	indices := make([]int, 1000)
 	for i := range indices {


### PR DESCRIPTION
`Query.EntityAt` benchmarks did not actually use 5 archetypes, as stated.