### PR TITLE
Better errors, better error tests, build tag `debug`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
         go test -tags tiny -v -covermode atomic -coverprofile="coverage.out" ./...
         go tool cover -func="coverage.out"
 
-  test_tiny:
+  test_debug:
     name: Run tests (debug)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,7 +69,25 @@ jobs:
         go get .
     - name: Run Unit tests (tiny)
       run: |
-        go test -v -covermode atomic -coverprofile="coverage.out" ./...
+        go test -tags tiny -v -covermode atomic -coverprofile="coverage.out" ./...
+        go tool cover -func="coverage.out"
+
+  test_tiny:
+    name: Run tests (debug)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.22.x'
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        go get .
+    - name: Run Unit tests (debug)
+      run: |
+        go test -tags debug -v -covermode atomic -coverprofile="coverage.out" ./...
         go tool cover -func="coverage.out"
 
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Features
 
 * Adds method `Query.EntityAt()`, useful for things like random sampling of entities (#358)
+* Adds build tag `debug` to improve error messages in a few places where we rely on standard library panics for performance (#377)
 
 ### Documentation
 
 * Adds [BENCHMARKS.md](https://github.com/mlange-42/arche/blob/main/BENCHMARKS.md) for a tabular overview of the runtime cost of typical *Arche* ECS operations (#367, #372)
 * Link benchmarking code in `README.md` and benchmarking tables (#375)
+* Documents build tags `tiny` and `debug` in package docs of `ecs` (#377)
 
 ### Bugfixes
 
@@ -21,6 +23,7 @@
 * Adds benchmarks for query creation (#366)
 * Upgrade to Go 1.22 in CI (#376)
 * Renames directory `examples` to `_examples` to accommodate changed test coverage behaviour of Go 1.22 (#376)
+* In unit tests, error messages of all panics are asserted (#377)
 
 ## [[v0.10.1]](https://github.com/mlange-42/arche/compare/v0.10.0...v0.10.1)
 

--- a/ecs/archetype_test.go
+++ b/ecs/archetype_test.go
@@ -58,7 +58,7 @@ func TestArchetype(t *testing.T) {
 	assert.Equal(t, 5, pos0.Y)
 	assert.Equal(t, 6, rot0.Angle)
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "Invalid number of components", func() {
 		arch.Add(
 			newEntity(1),
 			Component{ID: id(0), Comp: &Position{4, 5}},
@@ -87,7 +87,7 @@ func TestNewArchetype(t *testing.T) {
 		{ID: id(1), Type: reflect.TypeOf(rotation{})},
 		{ID: id(0), Type: reflect.TypeOf(Position{})},
 	}
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "component arguments must be sorted by ID", func() {
 		node := newArchNode(All(id(0), id(1)), &nodeData{}, ID{}, false, 32, comps)
 		arch := archetype{}
 		data := archetypeData{}

--- a/ecs/builder_test.go
+++ b/ecs/builder_test.go
@@ -25,10 +25,10 @@ func TestBuilder(t *testing.T) {
 	e2 := w.NewEntity()
 	b1.Add(e2)
 
-	assert.Panics(t, func() { b1.New(target) })
-	assert.Panics(t, func() { b1.NewBatch(10, target) })
-	assert.Panics(t, func() { b1.NewBatchQ(10, target) })
-	assert.Panics(t, func() { b1.Add(e1, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.New(target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.NewBatch(10, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.NewBatchQ(10, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.Add(e1, target) })
 
 	b1.NewBatch(10)
 	q := b1.NewBatchQ(10)
@@ -44,10 +44,10 @@ func TestBuilder(t *testing.T) {
 	b1.Add(e2)
 	e2 = w.NewEntity()
 
-	assert.Panics(t, func() { b1.New(target) })
-	assert.Panics(t, func() { b1.NewBatch(10, target) })
-	assert.Panics(t, func() { b1.NewBatchQ(10, target) })
-	assert.Panics(t, func() { b1.Add(e2, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.New(target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.NewBatch(10, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.NewBatchQ(10, target) })
+	assert.PanicsWithValue(t, "can't set target entity: builder has no relation", func() { b1.Add(e2, target) })
 
 	b1.NewBatch(10)
 	q = b1.NewBatchQ(10)

--- a/ecs/cache.go
+++ b/ecs/cache.go
@@ -45,7 +45,7 @@ func newCache() Cache {
 //	query := world.Query(&cached)
 func (c *Cache) Register(f Filter) CachedFilter {
 	if _, ok := f.(*CachedFilter); ok {
-		panic("filter is already cached")
+		panic("filter is already registered")
 	}
 	id := c.intPool.Get()
 	c.filters = append(c.filters,

--- a/ecs/cache_test.go
+++ b/ecs/cache_test.go
@@ -29,7 +29,7 @@ func TestFilterCache(t *testing.T) {
 	assert.Equal(t, 2, len(world.getArchetypes(&f1)))
 	assert.Equal(t, 1, len(world.getArchetypes(&f2)))
 
-	assert.Panics(t, func() { cache.Register(&f2) })
+	assert.PanicsWithValue(t, "filter is already registered", func() { cache.Register(&f2) })
 
 	e1 := cache.get(&f1)
 	e2 := cache.get(&f2)
@@ -43,8 +43,8 @@ func TestFilterCache(t *testing.T) {
 	assert.Equal(t, all1, ff1)
 	assert.Equal(t, all2, ff2)
 
-	assert.Panics(t, func() { cache.Unregister(&f1) })
-	assert.Panics(t, func() { cache.get(&f1) })
+	assert.PanicsWithValue(t, "no filter for id found to unregister", func() { cache.Unregister(&f1) })
+	assert.PanicsWithValue(t, "no filter for id found", func() { cache.get(&f1) })
 }
 
 func TestFilterCacheRelation(t *testing.T) {

--- a/ecs/doc.go
+++ b/ecs/doc.go
@@ -54,4 +54,14 @@
 //   - Add components: [Relations.ExchangeBatch], [Relations.ExchangeBatchQ]
 //   - Remove components: [Relations.ExchangeBatch], [Relations.ExchangeBatchQ]
 //   - Exchange components: [Relations.ExchangeBatch], [Relations.ExchangeBatchQ]
+//
+// # Build tags
+//
+// Arche provides 2 build tags:
+//   - tiny -- Reduces the maximum number of components to 64, giving a performance boost for mask-related operations.
+//   - debug -- Improves error messages on [Query] misuse, at the cost of performance.
+//
+// Usage:
+//
+//	go build -tags tiny .
 package ecs

--- a/ecs/pool_test.go
+++ b/ecs/pool_test.go
@@ -23,7 +23,7 @@ func TestEntityPool(t *testing.T) {
 	}
 	assert.Equal(t, expectedAll, p.entities, "Wrong initial entities")
 
-	assert.Panics(t, func() { p.Recycle(p.entities[0]) })
+	assert.PanicsWithValue(t, "can't recycle reserved zero entity", func() { p.Recycle(p.entities[0]) })
 
 	e0 := p.entities[1]
 	p.Recycle(e0)

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -9,6 +9,9 @@ import (
 //
 // Create queries through the [World] using [World.Query]. See there for more details.
 //
+// In case you get error messages like "index out of range [-1]" or "invalid memory address or nil pointer dereference",
+// try running with build tag `debug`.
+//
 // See also the generic alternatives [github.com/mlange-42/arche/generic.Query1],
 // [github.com/mlange-42/arche/generic.Query2], etc.
 // For advanced filtering, see package [github.com/mlange-42/arche/filter].

--- a/ecs/query.go
+++ b/ecs/query.go
@@ -78,6 +78,7 @@ func newBatchQuery(world *World, lockBit uint8, archetype *batchArchetypes) Quer
 //
 // Returns false if no next entity could be found.
 func (q *Query) Next() bool {
+	q.checkNext()
 	if q.entityIndex < q.entityIndexMax {
 		q.entityIndex++
 		return true
@@ -88,16 +89,19 @@ func (q *Query) Next() bool {
 
 // Has returns whether the current entity has the given component.
 func (q *Query) Has(comp ID) bool {
+	q.checkGet()
 	return q.access.HasComponent(comp)
 }
 
 // Get returns the pointer to the given component at the iterator's position.
 func (q *Query) Get(comp ID) unsafe.Pointer {
+	q.checkGet()
 	return q.access.Get(q.entityIndex, comp)
 }
 
 // Entity returns the entity at the iterator's position.
 func (q *Query) Entity() Entity {
+	q.checkGet()
 	return q.access.GetEntity(q.entityIndex)
 }
 
@@ -129,6 +133,7 @@ func (q *Query) EntityAt(index int) Entity {
 //
 // Panics if the entity does not have the given component, or if the component is not a [Relation].
 func (q *Query) Relation(comp ID) Entity {
+	q.checkGet()
 	if q.access.RelationComponent.id != comp.id {
 		panic(fmt.Sprintf("entity has no component %v, or it is not a relation component", q.world.registry.Types[comp.id]))
 	}

--- a/ecs/query_debug.go
+++ b/ecs/query_debug.go
@@ -1,0 +1,17 @@
+//go:build debug
+
+package ecs
+
+const isDebug = true
+
+func (q *Query) checkNext() {
+	if q.nodeIndex < -1 {
+		panic("query iteration already finished")
+	}
+}
+
+func (q *Query) checkGet() {
+	if q.access == nil {
+		panic("query already iterated or iteration not started yet")
+	}
+}

--- a/ecs/query_no_debug.go
+++ b/ecs/query_no_debug.go
@@ -1,0 +1,9 @@
+//go:build !debug
+
+package ecs
+
+const isDebug = false
+
+func (q *Query) checkNext() {}
+
+func (q *Query) checkGet() {}

--- a/ecs/registry_test.go
+++ b/ecs/registry_test.go
@@ -39,7 +39,7 @@ func TestComponentRegistryOverflow(t *testing.T) {
 
 	reg.registerComponent(reflect.TypeOf((*Position)(nil)).Elem(), 1)
 
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "exceeded the maximum of 1 component types or resource types", func() {
 		reg.registerComponent(reflect.TypeOf((*rotation)(nil)).Elem(), 1)
 	})
 }

--- a/ecs/relations_test.go
+++ b/ecs/relations_test.go
@@ -26,16 +26,16 @@ func TestRelationsExchange(t *testing.T) {
 	query.Close()
 
 	filter := ecs.All(posID, childID)
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "can't add relation: resulting entity has no component Velocity", func() {
 		w.Relations().ExchangeBatch(filter, nil, []ecs.ID{posID}, velID, parent2)
 	})
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "can't add relation: Velocity is not a relation component", func() {
 		w.Relations().ExchangeBatch(filter, []ecs.ID{velID}, []ecs.ID{posID}, velID, parent2)
 	})
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "exchange operation has no effect, but a relation is specified. Use Batch.SetRelation instead", func() {
 		w.Relations().ExchangeBatch(filter, nil, nil, childID, parent2)
 	})
-	assert.Panics(t, func() {
+	assert.PanicsWithValue(t, "exchange operation has no effect, but a relation is specified. Use Batch.SetRelation instead", func() {
 		_ = w.Relations().ExchangeBatchQ(filter, nil, nil, childID, parent2)
 	})
 

--- a/ecs/resources_test.go
+++ b/ecs/resources_test.go
@@ -26,7 +26,7 @@ func TestResources(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, Position{1, 2}, *pos)
 
-	assert.Panics(t, func() { res.Add(posID, &Position{1, 2}) })
+	assert.PanicsWithValue(t, "Resource of ID 0 was already added (type *ecs.Position)", func() { res.Add(posID, &Position{1, 2}) })
 
 	pos, ok = res.Get(posID).(*Position)
 	assert.True(t, ok)
@@ -36,7 +36,7 @@ func TestResources(t *testing.T) {
 	assert.True(t, res.Has(rotID))
 	res.Remove(rotID)
 	assert.False(t, res.Has(rotID))
-	assert.Panics(t, func() { res.Remove(rotID) })
+	assert.PanicsWithValue(t, "Resource of ID 1 is not present", func() { res.Remove(rotID) })
 }
 
 func TestResourcesReset(t *testing.T) {

--- a/ecs/util_test.go
+++ b/ecs/util_test.go
@@ -45,7 +45,8 @@ func TestLockMask(t *testing.T) {
 	locks.Unlock(l1)
 	assert.True(t, locks.IsLocked())
 
-	assert.Panics(t, func() { locks.Unlock(l1) })
+	assert.PanicsWithValue(t, "unbalanced unlock. Did you close a query that was already iterated?",
+		func() { locks.Unlock(l1) })
 
 	locks.Unlock(l2)
 	assert.False(t, locks.IsLocked())

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -469,7 +469,7 @@ func TestWorldAssignSet(t *testing.T) {
 	e0 := w.NewEntity()
 	e1 := w.NewEntity()
 
-	assert.PanicsWithValue(t, "", func() { w.Assign(e0) })
+	assert.PanicsWithValue(t, "no components given to assign", func() { w.Assign(e0) })
 
 	w.Assign(e0, Component{posID, &Position{2, 3}})
 	pos := (*Position)(w.Get(e0, posID))

--- a/generic/map_test.go
+++ b/generic/map_test.go
@@ -32,13 +32,13 @@ func TestGenericMap(t *testing.T) {
 
 	get2 := NewMap[testStruct1](&w)
 	assert.Equal(t, ecs.ComponentID[testStruct1](&w), get2.ID())
-	assert.Panics(t, func() { get2.Set(e0, &testStruct1{}) })
+	assert.PanicsWithValue(t, "can't copy component into entity that has no such component type", func() { get2.Set(e0, &testStruct1{}) })
 
 	w.RemoveEntity(e0)
 	_ = w.NewEntity()
 
-	assert.Panics(t, func() { get.Has(e0) })
-	assert.Panics(t, func() { get.Get(e0) })
+	assert.PanicsWithValue(t, "can't check for component of a dead entity", func() { get.Has(e0) })
+	assert.PanicsWithValue(t, "can't get component of a dead entity", func() { get.Get(e0) })
 }
 
 func TestGenericMapRelations(t *testing.T) {


### PR DESCRIPTION
* Tests all panics for the concrete error message
* Adds build tag `debug` for better error messages on queries, where we normally rely on out of bounds or nil pointer dereference
* Documents build tags