### PR TITLE
[breaking] Rename types in `ecs.stats` to remove redundant "Stats"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.10.1...main)
 
+### Breaking changes
+
+* Renames types in `ecs.stats` to follow Go standards.
+`stats.WorldStats` -> `stats.World`, `stats.NodeStats` -> `stats.Node`, ... (#388)
+
 ### Features
 
 * Adds method `Query.EntityAt()`, useful for things like random sampling of entities (#358)

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -298,7 +298,7 @@ func (a *archetype) Cap() uint32 {
 }
 
 // Stats generates statistics for an archetype
-func (a *archetype) Stats(reg *componentRegistry) stats.ArchetypeStats {
+func (a *archetype) Stats(reg *componentRegistry) stats.Archetype {
 	ids := a.Components()
 	aCompCount := len(ids)
 	aTypes := make([]reflect.Type, aCompCount)
@@ -314,7 +314,7 @@ func (a *archetype) Stats(reg *componentRegistry) stats.ArchetypeStats {
 	}
 	memory := cap * (int(entitySize) + memPerEntity)
 
-	return stats.ArchetypeStats{
+	return stats.Archetype{
 		IsActive: a.IsActive(),
 		Size:     int(a.Len()),
 		Capacity: cap,
@@ -323,7 +323,7 @@ func (a *archetype) Stats(reg *componentRegistry) stats.ArchetypeStats {
 }
 
 // UpdateStats updates statistics for an archetype
-func (a *archetype) UpdateStats(node *stats.NodeStats, stats *stats.ArchetypeStats, reg *componentRegistry) {
+func (a *archetype) UpdateStats(node *stats.Node, stats *stats.Archetype, reg *componentRegistry) {
 	cap := int(a.Cap())
 	memory := cap * (int(entitySize) + node.MemoryPerEntity)
 

--- a/ecs/archetype_node.go
+++ b/ecs/archetype_node.go
@@ -186,7 +186,7 @@ func (a *archNode) Reset(cache *Cache) {
 }
 
 // Stats generates statistics for an archetype node.
-func (a *archNode) Stats(reg *componentRegistry) stats.NodeStats {
+func (a *archNode) Stats(reg *componentRegistry) stats.Node {
 	ids := a.Ids
 	aCompCount := len(ids)
 	aTypes := make([]reflect.Type, aCompCount)
@@ -199,10 +199,10 @@ func (a *archNode) Stats(reg *componentRegistry) stats.NodeStats {
 	cap := 0
 	count := 0
 	memory := 0
-	var archStats []stats.ArchetypeStats
+	var archStats []stats.Archetype
 	if arches != nil {
 		numArches = arches.Len()
-		archStats = make([]stats.ArchetypeStats, numArches)
+		archStats = make([]stats.Archetype, numArches)
 		var i int32
 		for i = 0; i < numArches; i++ {
 			archStats[i] = arches.Get(i).Stats(reg)
@@ -220,7 +220,7 @@ func (a *archNode) Stats(reg *componentRegistry) stats.NodeStats {
 		memPerEntity += int(aTypes[j].Size())
 	}
 
-	return stats.NodeStats{
+	return stats.Node{
 		ArchetypeCount:       int(numArches),
 		ActiveArchetypeCount: int(numArches) - len(a.freeIndices),
 		IsActive:             a.IsActive,
@@ -237,7 +237,7 @@ func (a *archNode) Stats(reg *componentRegistry) stats.NodeStats {
 }
 
 // UpdateStats updates statistics for an archetype node.
-func (a *archNode) UpdateStats(stats *stats.NodeStats, reg *componentRegistry) {
+func (a *archNode) UpdateStats(stats *stats.Node, reg *componentRegistry) {
 	if !a.IsActive {
 		return
 	}

--- a/ecs/stats/stats.go
+++ b/ecs/stats/stats.go
@@ -7,40 +7,40 @@ import (
 	"strings"
 )
 
-// WorldStats provide statistics for an [ecs.World].
-type WorldStats struct {
-	// Entity statistics
-	Entities EntityStats
-	// Total number of components
+// World provide statistics for an [ecs.World].
+type World struct {
+	// Entity statistics.
+	Entities Entities
+	// Total number of components.
 	ComponentCount int
-	// Component types, indexed by component ID
+	// Component types, indexed by component ID.
 	ComponentTypes []reflect.Type
-	// Locked state of the world
+	// Locked state of the world.
 	Locked bool
-	// Node statistics
-	Nodes []NodeStats
-	// Number of active nodes
+	// Node statistics.
+	Nodes []Node
+	// Number of active nodes.
 	ActiveNodeCount int
-	// Memory used by entities and components
+	// Memory used by entities and components.
 	Memory int
-	// Number of cached filters
+	// Number of cached filters.
 	CachedFilters int
 }
 
-// EntityStats provide statistics about [ecs.World] entities.
-type EntityStats struct {
-	// Currently used/alive entities
+// Entities provide statistics about [ecs.World] entities.
+type Entities struct {
+	// Currently used/alive entities.
 	Used int
-	// Current capacity of the entity pool
+	// Current capacity of the entity pool.
 	Total int
-	// Recycled/available entities
+	// Recycled/available entities.
 	Recycled int
-	// Current capacity of the entities list
+	// Current capacity of the entities list.
 	Capacity int
 }
 
-// NodeStats provide statistics for an archetype graph node.
-type NodeStats struct {
+// Node provide statistics for an archetype graph node.
+type Node struct {
 	// Total number of archetypes, incl. inactive.
 	ArchetypeCount int
 	// Number of active archetypes.
@@ -49,37 +49,37 @@ type NodeStats struct {
 	IsActive bool
 	// Whether the node contains relation archetypes.
 	HasRelation bool
-	// Number of components
+	// Number of components.
 	Components int
-	// Component IDs
+	// Component IDs.
 	ComponentIDs []uint8
-	// Component types for ComponentIDs
+	// Component types for ComponentIDs.
 	ComponentTypes []reflect.Type
-	// Memory for components per entity
+	// Memory for components per entity, in bytes.
 	MemoryPerEntity int
-	// Total reserved memory for entities and components, in bytes
+	// Total reserved memory for entities and components, in bytes.
 	Memory int
-	// Number of entities in the archetype
+	// Number of entities in the archetypes of this node.
 	Size int
-	// Capacity of the archetype
+	// Sum of capacity of the archetypes in this node.
 	Capacity int
-	// Archetype statistics
-	Archetypes []ArchetypeStats
+	// Archetype statistics.
+	Archetypes []Archetype
 }
 
-// ArchetypeStats provide statistics for an archetype.
-type ArchetypeStats struct {
-	// Whether the archetype is currently active
+// Archetype provide statistics for an archetype.
+type Archetype struct {
+	// Whether the archetype is currently active.
 	IsActive bool
-	// Number of entities in the archetype
+	// Number of entities in the archetype.
 	Size int
-	// Capacity of the archetype
+	// Capacity of the archetype.
 	Capacity int
-	// Total reserved memory for entities and components, in bytes
+	// Total reserved memory for entities and components, in bytes.
 	Memory int
 }
 
-func (s *WorldStats) String() string {
+func (s *World) String() string {
 	b := strings.Builder{}
 
 	fmt.Fprintf(
@@ -101,11 +101,11 @@ func (s *WorldStats) String() string {
 	return b.String()
 }
 
-func (s *EntityStats) String() string {
+func (s *Entities) String() string {
 	return fmt.Sprintf("Entities -- Used: %d, Recycled: %d, Total: %d, Capacity: %d\n", s.Used, s.Recycled, s.Total, s.Capacity)
 }
 
-func (s *NodeStats) String() string {
+func (s *Node) String() string {
 	if !s.IsActive {
 		return ""
 	}

--- a/ecs/stats/stats_test.go
+++ b/ecs/stats/stats_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 func TestStats(t *testing.T) {
-	stats := WorldStats{
-		Entities:       EntityStats{},
+	stats := World{
+		Entities:       Entities{},
 		ComponentCount: 1,
 		ComponentTypes: []reflect.Type{reflect.TypeOf(1)},
 		Locked:         false,
-		Nodes: []NodeStats{
+		Nodes: []Node{
 			{
 				Size:           1,
 				Capacity:       128,

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -30,7 +30,7 @@ type World struct {
 	locks          lockMask                  // World locks.
 	registry       componentRegistry         // Component registry.
 	filterCache    Cache                     // Cache for registered filters.
-	stats          stats.WorldStats          // Cached world statistics
+	stats          stats.World               // Cached world statistics
 }
 
 // NewWorld creates a new [World] from an optional [Config].
@@ -442,11 +442,11 @@ func (w *World) SetListener(listener Listener) {
 
 // Stats reports statistics for inspecting the World.
 //
-// The underlying [stats.WorldStats] object is re-used and updated between calls.
+// The underlying [stats.World] object is re-used and updated between calls.
 // The returned pointer should thus not be stored for later analysis.
 // Rather, the required data should be extracted immediately.
-func (w *World) Stats() *stats.WorldStats {
-	w.stats.Entities = stats.EntityStats{
+func (w *World) Stats() *stats.World {
+	w.stats.Entities = stats.Entities{
 		Used:     w.entityPool.Len(),
 		Total:    w.entityPool.Cap(),
 		Recycled: w.entityPool.Available(),

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -248,7 +248,7 @@ func BenchmarkWorldStats_1Arch(b *testing.B) {
 
 	b.StartTimer()
 
-	var st *stats.WorldStats
+	var st *stats.World
 	for i := 0; i < b.N; i++ {
 		st = w.Stats()
 	}
@@ -279,7 +279,7 @@ func BenchmarkWorldStats_10Arch(b *testing.B) {
 
 	b.StartTimer()
 
-	var st *stats.WorldStats
+	var st *stats.World
 	for i := 0; i < b.N; i++ {
 		st = w.Stats()
 	}


### PR DESCRIPTION
- stats.WorldStats -> stats.World
- stats.EntityStats -> stats.Entities
- stats.NodeStats -> stats.Node
- stats.ArchetypeStats -> stats.Archetype
