### PR TITLE
Fix Dispatch.AddListener

### DIFF
--- a/listener/dispatch.go
+++ b/listener/dispatch.go
@@ -45,7 +45,7 @@ func (l *Dispatch) AddListener(ls ecs.Listener) {
 	l.listeners = append(l.listeners, ls)
 	l.events |= ls.Subscriptions()
 
-	cmp := l.Components()
+	cmp := ls.Components()
 	if cmp == nil {
 		l.hasComponents = false
 	} else {


### PR DESCRIPTION
I noticed that my listeners which were added to an initially empty Dispatch were not being notified. This fixes it.