### PR TITLE
Ensure Assign() copies components before notifying listeners

### DIFF
--- a/ecs/world_event_test.go
+++ b/ecs/world_event_test.go
@@ -107,6 +107,14 @@ func TestWorldListener(t *testing.T) {
 		EventTypes:  event.ComponentRemoved | event.RelationChanged | event.TargetChanged,
 	}, events[len(events)-1])
 
+	w.Assign(e0, Component{ID: posID, Comp: &Position{X: 1, Y: 2}})
+	assert.Equal(t, 11, len(events))
+	assert.Equal(t, EntityEvent{
+		Entity:     e0,
+		Added:      All(posID),
+		AddedIDs:   []ID{posID},
+		EventTypes: event.ComponentAdded,
+	}, events[len(events)-1])
 }
 
 func TestWorldListenerBuilder(t *testing.T) {


### PR DESCRIPTION
When calling `Assign()`, listeners get notified of a `ComponentAdded` event after the `exchange()` happens but before the component gets copied. This means that if that component gets fetched in the listener it will be a "zero" component.

The changes in this PR ensure that components are copied before notifying listeners. It splits the internal `exchange()` function into `exchange()`, `exchangeNoNotify()` and `notifyExchange()`.  This allows us to perform the `copyTo()` in the `Assign()` before notifying the listeners.