### PR TITLE
Add callback methods, fix premature notifications issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+
+## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.14.0...main)
+
+### Features
+
+* Adds `World.NewEntityFn`, `World.AddFn` and `World.ExchangeFn` that call a callback function before listener notification (#445)
+
+### Bugfixes
+
+* Fixes generic `MapX.Assign` and `MapX.NewWith` notifying listeners before setting components (#445, issue #443)
+
 ## [[v0.14.0]](https://github.com/mlange-42/arche/compare/v0.13.3...v0.14.0)
 
 ### Features

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -193,7 +193,9 @@ func (a *archetype) SetEntity(index uint32, entity Entity) {
 	a.addEntity(index, &entity)
 }
 
-// Set overwrites a component with the data behind the given pointer
+// Set overwrites a component with the data behind the given pointer.
+//
+// Deprecated: Method is slow and should not be used.
 func (a *archetype) Set(index uint32, id ID, comp interface{}) unsafe.Pointer {
 	lay := a.getLayout(id)
 	dst := a.Get(index, id)

--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -115,7 +115,7 @@ func (b *Builder) Add(entity Entity, target ...Entity) {
 			panic("can't set target entity: builder has no relation")
 		}
 		if b.comps == nil {
-			b.world.exchange(entity, b.ids, nil, b.relationID, b.hasRelation, target[0])
+			b.world.exchange(entity, b.ids, nil, b.relationID, b.hasRelation, target[0], nil)
 			return
 		}
 		b.world.assign(entity, b.relationID, b.hasRelation, target[0], b.comps...)

--- a/ecs/relations.go
+++ b/ecs/relations.go
@@ -86,7 +86,7 @@ func (r *Relations) SetBatchQ(filter Filter, comp ID, target Entity) Query {
 //
 // See also the generic variants under [github.com/mlange-42/arche/generic.Exchange].
 func (r *Relations) Exchange(entity Entity, add []ID, rem []ID, relation ID, target Entity) {
-	r.world.exchange(entity, add, rem, relation, true, target)
+	r.world.exchange(entity, add, rem, relation, true, target, nil)
 }
 
 // ExchangeBatch exchanges components for many entities, matching a filter.

--- a/ecs/world.go
+++ b/ecs/world.go
@@ -65,12 +65,12 @@ func NewWorld(config ...Config) World {
 //	world.NewEntity(ids...)
 //
 // For more advanced and batched entity creation, see [Builder] and [Batch].
-// See also [World.NewEntityAndThen] the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
+// See also [World.NewEntityFn] the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
 func (w *World) NewEntity(comps ...ID) Entity {
 	return w.newEntity(nil, comps...)
 }
 
-// NewEntityAndThen returns a new or recycled [Entity].
+// NewEntityFn returns a new or recycled [Entity].
 // The given component types are added to the entity.
 //
 // The callback fn is called before the world's listener is notified.
@@ -87,13 +87,13 @@ func (w *World) NewEntity(comps ...ID) Entity {
 // For maximum performance, pre-allocate a slice of component IDs and pass it using ellipsis:
 //
 //	// fast
-//	world.NewEntityAndThen(nil, idA, idB, idC)
+//	world.NewEntityFn(nil, idA, idB, idC)
 //	// even faster
 //	world.NewEntity(nil, ids...)
 //
 // For more advanced and batched entity creation, see [Builder] and [Batch].
 // See also [World.NewEntity] and the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
-func (w *World) NewEntityAndThen(fn func(e Entity), comps ...ID) Entity {
+func (w *World) NewEntityFn(fn func(e Entity), comps ...ID) Entity {
 	return w.newEntity(fn, comps...)
 }
 
@@ -308,7 +308,7 @@ func (w *World) HasUnchecked(entity Entity, comp ID) bool {
 //	// even faster
 //	world.Add(entity, ids...)
 //
-// See also [World.AddAndThen], [World.Exchange] and [World.ExchangeAndThen].
+// See also [World.AddFn], [World.Exchange] and [World.ExchangeFn].
 // See also the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
 func (w *World) Add(entity Entity, comps ...ID) {
 	w.Exchange(entity, comps, nil)
@@ -333,10 +333,10 @@ func (w *World) Add(entity Entity, comps ...ID) {
 //	// even faster
 //	world.Add(entity, ids...)
 //
-// See also [World.Add], [World.Exchange] and [World.ExchangeAndThen].
+// See also [World.Add], [World.Exchange] and [World.ExchangeFn].
 // See also the generic variants under [github.com/mlange-42/arche/generic.Map1], etc.
-func (w *World) AddAndThen(entity Entity, fn func(Entity), comps ...ID) {
-	w.ExchangeAndThen(entity, comps, nil, fn)
+func (w *World) AddFn(entity Entity, fn func(Entity), comps ...ID) {
+	w.ExchangeFn(entity, comps, nil, fn)
 }
 
 // Assign assigns multiple components to an [Entity], using pointers for the content.
@@ -423,7 +423,7 @@ func (w *World) Exchange(entity Entity, add []ID, rem []ID) {
 //   - when called on a locked world. Do not use during [Query] iteration!
 //
 // See also [Relations.Exchange] and the generic variants under [github.com/mlange-42/arche/generic.Exchange].
-func (w *World) ExchangeAndThen(entity Entity, add []ID, rem []ID, fn func(Entity)) {
+func (w *World) ExchangeFn(entity Entity, add []ID, rem []ID, fn func(Entity)) {
 	w.exchange(entity, add, rem, ID{}, false, Entity{}, fn)
 }
 

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -892,7 +892,9 @@ func (w *World) checkLocked() {
 	}
 }
 
-// Copies a component to an entity
+// Copies a component to an entity.
+//
+// Deprecated: Method is slow and should not be used.
 func (w *World) copyTo(entity Entity, id ID, comp interface{}) unsafe.Pointer {
 	if !w.Has(entity, id) {
 		panic("can't copy component into entity that has no such component type")

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -407,13 +407,19 @@ func (w *World) assign(entity Entity, relation ID, hasRelation bool, target Enti
 // exchange with relation target.
 // Panics if adding a component already present or removing a component not present.
 // Also panics if the same component ID is in the add or remove list twice.
-func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRelation bool, target Entity) {
+func (w *World) exchange(entity Entity, add []ID, rem []ID, relation ID, hasRelation bool, target Entity, fn func(Entity)) {
 	if w.listener != nil {
 		arch, oldMask, oldTarget, oldRel := w.exchangeNoNotify(entity, add, rem, relation, hasRelation, target)
+		if fn != nil {
+			fn(entity)
+		}
 		w.notifyExchange(arch, oldMask, entity, add, rem, oldTarget, oldRel)
 		return
 	}
 	w.exchangeNoNotify(entity, add, rem, relation, hasRelation, target)
+	if fn != nil {
+		fn(entity)
+	}
 }
 
 // perform exchange operation without notifying listeners.

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -115,6 +115,86 @@ func TestWorldNewEntites(t *testing.T) {
 	}
 }
 
+func TestWorldNewEntityFn(t *testing.T) {
+	w := NewWorld()
+
+	posID := ComponentID[Position](&w)
+	velID := ComponentID[Velocity](&w)
+
+	e := w.NewEntityFn(
+		func(e Entity) {
+			pos := (*Position)(w.Get(e, posID))
+			*pos = Position{X: 1, Y: 2}
+		},
+		posID, velID,
+	)
+
+	pos := (*Position)(w.Get(e, posID))
+	assert.Equal(t, *pos, Position{X: 1, Y: 2})
+
+	// Test listener
+	event := false
+	listener := newTestListener(func(world *World, e EntityEvent) {
+		pos := (*Position)(w.Get(e.Entity, posID))
+		assert.Equal(t, *pos, Position{X: 1, Y: 2})
+		event = true
+	})
+	w.SetListener(&listener)
+
+	_ = w.NewEntityFn(
+		func(e Entity) {
+			pos := (*Position)(w.Get(e, posID))
+			*pos = Position{X: 1, Y: 2}
+		},
+		posID, velID,
+	)
+
+	assert.True(t, event)
+}
+
+func TestWorldAddFn(t *testing.T) {
+	w := NewWorld()
+
+	posID := ComponentID[Position](&w)
+	velID := ComponentID[Velocity](&w)
+
+	e := w.NewEntity()
+
+	w.AddFn(
+		e,
+		func(e Entity) {
+			pos := (*Position)(w.Get(e, posID))
+			*pos = Position{X: 1, Y: 2}
+		},
+		posID, velID,
+	)
+
+	pos := (*Position)(w.Get(e, posID))
+	assert.Equal(t, *pos, Position{X: 1, Y: 2})
+
+	// Test listener
+	e = w.NewEntity()
+
+	evt := false
+	listener := newTestListener(func(world *World, e EntityEvent) {
+		pos := (*Position)(w.Get(e.Entity, posID))
+		assert.Equal(t, *pos, Position{X: 1, Y: 2})
+		evt = true
+	})
+	w.SetListener(&listener)
+
+	w.AddFn(
+		e,
+		func(e Entity) {
+			pos := (*Position)(w.Get(e, posID))
+			*pos = Position{X: 1, Y: 2}
+		},
+		posID, velID,
+	)
+
+	assert.True(t, evt)
+}
+
 func TestWorldComponents(t *testing.T) {
 	w := NewWorld()
 

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -283,13 +283,13 @@ func TestWorldExchange(t *testing.T) {
 	e0 = w.NewEntity(rel1ID)
 
 	assert.PanicsWithValue(t, "entity already has a relation component",
-		func() { w.exchange(e0, []ID{rel2ID}, nil, rel2ID, true, target) })
+		func() { w.exchange(e0, []ID{rel2ID}, nil, rel2ID, true, target, nil) })
 	assert.PanicsWithValue(t, "can't add relation: Position is not a relation component",
-		func() { w.exchange(e0, []ID{posID}, nil, posID, true, target) })
+		func() { w.exchange(e0, []ID{posID}, nil, posID, true, target, nil) })
 
 	w.Remove(e0, rel1ID)
 	assert.PanicsWithValue(t, "can't add relation: resulting entity has no component testRelationA",
-		func() { w.exchange(e0, []ID{posID}, nil, rel1ID, true, target) })
+		func() { w.exchange(e0, []ID{posID}, nil, rel1ID, true, target, nil) })
 }
 
 func TestWorldExchangeRelation(t *testing.T) {

--- a/generic/_generate/map.go.txt
+++ b/generic/_generate/map.go.txt
@@ -101,7 +101,7 @@ func (m *Map{{ .Index }}{{ .Types }}) NewBatchQ(count int, target ...ecs.Entity)
 // See also [ecs.NewBuilderWith].
 func (m *Map{{ .Index }}{{ .Types }}) NewWith({{ .Arguments }}, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				{{ .Assign }}
 			},
@@ -180,7 +180,7 @@ func (m *Map{{ .Index }}{{ .Types }}) AddBatchQ(filter ecs.Filter, target ...ecs
 //
 // See also [ecs.World.Assign].
 func (m *Map{{ .Index }}{{ .Types }}) Assign(entity ecs.Entity, {{ .Arguments }}) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			{{ .Assign }}

--- a/generic/_generate/map.go.txt
+++ b/generic/_generate/map.go.txt
@@ -101,8 +101,12 @@ func (m *Map{{ .Index }}{{ .Types }}) NewBatchQ(count int, target ...ecs.Entity)
 // See also [ecs.NewBuilderWith].
 func (m *Map{{ .Index }}{{ .Types }}) NewWith({{ .Arguments }}, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		{{ .Assign }}
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				{{ .Assign }}
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -176,9 +180,13 @@ func (m *Map{{ .Index }}{{ .Types }}) AddBatchQ(filter ecs.Filter, target ...ecs
 //
 // See also [ecs.World.Assign].
 func (m *Map{{ .Index }}{{ .Types }}) Assign(entity ecs.Entity, {{ .Arguments }}) {
-	m.world.Add(entity, m.ids...)
-
-	{{ .Assign }}
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			{{ .Assign }}
+		},
+		m.ids...,
+	)
 }
 {{ end }}
 

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -108,8 +108,12 @@ func (m *Map1[A]) NewBatchQ(count int, target ...ecs.Entity) Query1[A] {
 // See also [ecs.NewBuilderWith].
 func (m *Map1[A]) NewWith(a *A, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -184,9 +188,13 @@ func (m *Map1[A]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query1[A] {
 //
 // See also [ecs.World.Assign].
 func (m *Map1[A]) Assign(entity ecs.Entity, a *A) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map1's components from the given entity.
@@ -368,9 +376,13 @@ func (m *Map2[A, B]) NewBatchQ(count int, target ...ecs.Entity) Query2[A, B] {
 // See also [ecs.NewBuilderWith].
 func (m *Map2[A, B]) NewWith(a *A, b *B, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -447,10 +459,14 @@ func (m *Map2[A, B]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query2[A
 //
 // See also [ecs.World.Assign].
 func (m *Map2[A, B]) Assign(entity ecs.Entity, a *A, b *B) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map2's components from the given entity.
@@ -637,10 +653,14 @@ func (m *Map3[A, B, C]) NewBatchQ(count int, target ...ecs.Entity) Query3[A, B, 
 // See also [ecs.NewBuilderWith].
 func (m *Map3[A, B, C]) NewWith(a *A, b *B, c *C, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -719,11 +739,15 @@ func (m *Map3[A, B, C]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query
 //
 // See also [ecs.World.Assign].
 func (m *Map3[A, B, C]) Assign(entity ecs.Entity, a *A, b *B, c *C) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map3's components from the given entity.
@@ -915,11 +939,15 @@ func (m *Map4[A, B, C, D]) NewBatchQ(count int, target ...ecs.Entity) Query4[A, 
 // See also [ecs.NewBuilderWith].
 func (m *Map4[A, B, C, D]) NewWith(a *A, b *B, c *C, d *D, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -1000,12 +1028,16 @@ func (m *Map4[A, B, C, D]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Qu
 //
 // See also [ecs.World.Assign].
 func (m *Map4[A, B, C, D]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map4's components from the given entity.
@@ -1202,12 +1234,16 @@ func (m *Map5[A, B, C, D, E]) NewBatchQ(count int, target ...ecs.Entity) Query5[
 // See also [ecs.NewBuilderWith].
 func (m *Map5[A, B, C, D, E]) NewWith(a *A, b *B, c *C, d *D, e *E, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -1290,13 +1326,17 @@ func (m *Map5[A, B, C, D, E]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity)
 //
 // See also [ecs.World.Assign].
 func (m *Map5[A, B, C, D, E]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map5's components from the given entity.
@@ -1498,13 +1538,17 @@ func (m *Map6[A, B, C, D, E, F]) NewBatchQ(count int, target ...ecs.Entity) Quer
 // See also [ecs.NewBuilderWith].
 func (m *Map6[A, B, C, D, E, F]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -1589,14 +1633,18 @@ func (m *Map6[A, B, C, D, E, F]) AddBatchQ(filter ecs.Filter, target ...ecs.Enti
 //
 // See also [ecs.World.Assign].
 func (m *Map6[A, B, C, D, E, F]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map6's components from the given entity.
@@ -1803,14 +1851,18 @@ func (m *Map7[A, B, C, D, E, F, G]) NewBatchQ(count int, target ...ecs.Entity) Q
 // See also [ecs.NewBuilderWith].
 func (m *Map7[A, B, C, D, E, F, G]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -1897,15 +1949,19 @@ func (m *Map7[A, B, C, D, E, F, G]) AddBatchQ(filter ecs.Filter, target ...ecs.E
 //
 // See also [ecs.World.Assign].
 func (m *Map7[A, B, C, D, E, F, G]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map7's components from the given entity.
@@ -2117,15 +2173,19 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewBatchQ(count int, target ...ecs.Entity
 // See also [ecs.NewBuilderWith].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
-		*(*H)(m.world.Get(entity, m.id7)) = *h
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+				*(*H)(m.world.Get(entity, m.id7)) = *h
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -2214,16 +2274,20 @@ func (m *Map8[A, B, C, D, E, F, G, H]) AddBatchQ(filter ecs.Filter, target ...ec
 //
 // See also [ecs.World.Assign].
 func (m *Map8[A, B, C, D, E, F, G, H]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
-	*(*H)(m.world.Get(entity, m.id7)) = *h
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+			*(*H)(m.world.Get(entity, m.id7)) = *h
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map8's components from the given entity.
@@ -2440,16 +2504,20 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) NewBatchQ(count int, target ...ecs.Ent
 // See also [ecs.NewBuilderWith].
 func (m *Map9[A, B, C, D, E, F, G, H, I]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
-		*(*H)(m.world.Get(entity, m.id7)) = *h
-		*(*I)(m.world.Get(entity, m.id8)) = *i
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+				*(*H)(m.world.Get(entity, m.id7)) = *h
+				*(*I)(m.world.Get(entity, m.id8)) = *i
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -2540,17 +2608,21 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) AddBatchQ(filter ecs.Filter, target ..
 //
 // See also [ecs.World.Assign].
 func (m *Map9[A, B, C, D, E, F, G, H, I]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
-	*(*H)(m.world.Get(entity, m.id7)) = *h
-	*(*I)(m.world.Get(entity, m.id8)) = *i
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+			*(*H)(m.world.Get(entity, m.id7)) = *h
+			*(*I)(m.world.Get(entity, m.id8)) = *i
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map9's components from the given entity.
@@ -2772,17 +2844,21 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewBatchQ(count int, target ...ecs
 // See also [ecs.NewBuilderWith].
 func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
-		*(*H)(m.world.Get(entity, m.id7)) = *h
-		*(*I)(m.world.Get(entity, m.id8)) = *i
-		*(*J)(m.world.Get(entity, m.id9)) = *j
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+				*(*H)(m.world.Get(entity, m.id7)) = *h
+				*(*I)(m.world.Get(entity, m.id8)) = *i
+				*(*J)(m.world.Get(entity, m.id9)) = *j
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -2875,18 +2951,22 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) AddBatchQ(filter ecs.Filter, targe
 //
 // See also [ecs.World.Assign].
 func (m *Map10[A, B, C, D, E, F, G, H, I, J]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
-	*(*H)(m.world.Get(entity, m.id7)) = *h
-	*(*I)(m.world.Get(entity, m.id8)) = *i
-	*(*J)(m.world.Get(entity, m.id9)) = *j
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+			*(*H)(m.world.Get(entity, m.id7)) = *h
+			*(*I)(m.world.Get(entity, m.id8)) = *i
+			*(*J)(m.world.Get(entity, m.id9)) = *j
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map10's components from the given entity.
@@ -3113,18 +3193,22 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewBatchQ(count int, target ...
 // See also [ecs.NewBuilderWith].
 func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
-		*(*H)(m.world.Get(entity, m.id7)) = *h
-		*(*I)(m.world.Get(entity, m.id8)) = *i
-		*(*J)(m.world.Get(entity, m.id9)) = *j
-		*(*K)(m.world.Get(entity, m.id10)) = *k
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+				*(*H)(m.world.Get(entity, m.id7)) = *h
+				*(*I)(m.world.Get(entity, m.id8)) = *i
+				*(*J)(m.world.Get(entity, m.id9)) = *j
+				*(*K)(m.world.Get(entity, m.id10)) = *k
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -3219,19 +3303,23 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) AddBatchQ(filter ecs.Filter, ta
 //
 // See also [ecs.World.Assign].
 func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
-	*(*H)(m.world.Get(entity, m.id7)) = *h
-	*(*I)(m.world.Get(entity, m.id8)) = *i
-	*(*J)(m.world.Get(entity, m.id9)) = *j
-	*(*K)(m.world.Get(entity, m.id10)) = *k
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+			*(*H)(m.world.Get(entity, m.id7)) = *h
+			*(*I)(m.world.Get(entity, m.id8)) = *i
+			*(*J)(m.world.Get(entity, m.id9)) = *j
+			*(*K)(m.world.Get(entity, m.id10)) = *k
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map11's components from the given entity.
@@ -3463,19 +3551,23 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewBatchQ(count int, target 
 // See also [ecs.NewBuilderWith].
 func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, l *L, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntity(m.ids...)
-		*(*A)(m.world.Get(entity, m.id0)) = *a
-		*(*B)(m.world.Get(entity, m.id1)) = *b
-		*(*C)(m.world.Get(entity, m.id2)) = *c
-		*(*D)(m.world.Get(entity, m.id3)) = *d
-		*(*E)(m.world.Get(entity, m.id4)) = *e
-		*(*F)(m.world.Get(entity, m.id5)) = *f
-		*(*G)(m.world.Get(entity, m.id6)) = *g
-		*(*H)(m.world.Get(entity, m.id7)) = *h
-		*(*I)(m.world.Get(entity, m.id8)) = *i
-		*(*J)(m.world.Get(entity, m.id9)) = *j
-		*(*K)(m.world.Get(entity, m.id10)) = *k
-		*(*L)(m.world.Get(entity, m.id11)) = *l
+		entity := m.world.NewEntityAndThen(
+			func(entity ecs.Entity) {
+				*(*A)(m.world.Get(entity, m.id0)) = *a
+				*(*B)(m.world.Get(entity, m.id1)) = *b
+				*(*C)(m.world.Get(entity, m.id2)) = *c
+				*(*D)(m.world.Get(entity, m.id3)) = *d
+				*(*E)(m.world.Get(entity, m.id4)) = *e
+				*(*F)(m.world.Get(entity, m.id5)) = *f
+				*(*G)(m.world.Get(entity, m.id6)) = *g
+				*(*H)(m.world.Get(entity, m.id7)) = *h
+				*(*I)(m.world.Get(entity, m.id8)) = *i
+				*(*J)(m.world.Get(entity, m.id9)) = *j
+				*(*K)(m.world.Get(entity, m.id10)) = *k
+				*(*L)(m.world.Get(entity, m.id11)) = *l
+			},
+			m.ids...,
+		)
 		return entity
 	}
 
@@ -3572,20 +3664,24 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) AddBatchQ(filter ecs.Filter,
 //
 // See also [ecs.World.Assign].
 func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, l *L) {
-	m.world.Add(entity, m.ids...)
-
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.Get(entity, m.id1)) = *b
-	*(*C)(m.world.Get(entity, m.id2)) = *c
-	*(*D)(m.world.Get(entity, m.id3)) = *d
-	*(*E)(m.world.Get(entity, m.id4)) = *e
-	*(*F)(m.world.Get(entity, m.id5)) = *f
-	*(*G)(m.world.Get(entity, m.id6)) = *g
-	*(*H)(m.world.Get(entity, m.id7)) = *h
-	*(*I)(m.world.Get(entity, m.id8)) = *i
-	*(*J)(m.world.Get(entity, m.id9)) = *j
-	*(*K)(m.world.Get(entity, m.id10)) = *k
-	*(*L)(m.world.Get(entity, m.id11)) = *l
+	m.world.AddAndThen(
+		entity,
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.Get(entity, m.id1)) = *b
+			*(*C)(m.world.Get(entity, m.id2)) = *c
+			*(*D)(m.world.Get(entity, m.id3)) = *d
+			*(*E)(m.world.Get(entity, m.id4)) = *e
+			*(*F)(m.world.Get(entity, m.id5)) = *f
+			*(*G)(m.world.Get(entity, m.id6)) = *g
+			*(*H)(m.world.Get(entity, m.id7)) = *h
+			*(*I)(m.world.Get(entity, m.id8)) = *i
+			*(*J)(m.world.Get(entity, m.id9)) = *j
+			*(*K)(m.world.Get(entity, m.id10)) = *k
+			*(*L)(m.world.Get(entity, m.id11)) = *l
+		},
+		m.ids...,
+	)
 }
 
 // Remove the Map12's components from the given entity.

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -108,7 +108,7 @@ func (m *Map1[A]) NewBatchQ(count int, target ...ecs.Entity) Query1[A] {
 // See also [ecs.NewBuilderWith].
 func (m *Map1[A]) NewWith(a *A, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 			},
@@ -188,7 +188,7 @@ func (m *Map1[A]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query1[A] {
 //
 // See also [ecs.World.Assign].
 func (m *Map1[A]) Assign(entity ecs.Entity, a *A) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -376,7 +376,7 @@ func (m *Map2[A, B]) NewBatchQ(count int, target ...ecs.Entity) Query2[A, B] {
 // See also [ecs.NewBuilderWith].
 func (m *Map2[A, B]) NewWith(a *A, b *B, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -459,7 +459,7 @@ func (m *Map2[A, B]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query2[A
 //
 // See also [ecs.World.Assign].
 func (m *Map2[A, B]) Assign(entity ecs.Entity, a *A, b *B) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -653,7 +653,7 @@ func (m *Map3[A, B, C]) NewBatchQ(count int, target ...ecs.Entity) Query3[A, B, 
 // See also [ecs.NewBuilderWith].
 func (m *Map3[A, B, C]) NewWith(a *A, b *B, c *C, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -739,7 +739,7 @@ func (m *Map3[A, B, C]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Query
 //
 // See also [ecs.World.Assign].
 func (m *Map3[A, B, C]) Assign(entity ecs.Entity, a *A, b *B, c *C) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -939,7 +939,7 @@ func (m *Map4[A, B, C, D]) NewBatchQ(count int, target ...ecs.Entity) Query4[A, 
 // See also [ecs.NewBuilderWith].
 func (m *Map4[A, B, C, D]) NewWith(a *A, b *B, c *C, d *D, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -1028,7 +1028,7 @@ func (m *Map4[A, B, C, D]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity) Qu
 //
 // See also [ecs.World.Assign].
 func (m *Map4[A, B, C, D]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -1234,7 +1234,7 @@ func (m *Map5[A, B, C, D, E]) NewBatchQ(count int, target ...ecs.Entity) Query5[
 // See also [ecs.NewBuilderWith].
 func (m *Map5[A, B, C, D, E]) NewWith(a *A, b *B, c *C, d *D, e *E, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -1326,7 +1326,7 @@ func (m *Map5[A, B, C, D, E]) AddBatchQ(filter ecs.Filter, target ...ecs.Entity)
 //
 // See also [ecs.World.Assign].
 func (m *Map5[A, B, C, D, E]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -1538,7 +1538,7 @@ func (m *Map6[A, B, C, D, E, F]) NewBatchQ(count int, target ...ecs.Entity) Quer
 // See also [ecs.NewBuilderWith].
 func (m *Map6[A, B, C, D, E, F]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -1633,7 +1633,7 @@ func (m *Map6[A, B, C, D, E, F]) AddBatchQ(filter ecs.Filter, target ...ecs.Enti
 //
 // See also [ecs.World.Assign].
 func (m *Map6[A, B, C, D, E, F]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -1851,7 +1851,7 @@ func (m *Map7[A, B, C, D, E, F, G]) NewBatchQ(count int, target ...ecs.Entity) Q
 // See also [ecs.NewBuilderWith].
 func (m *Map7[A, B, C, D, E, F, G]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -1949,7 +1949,7 @@ func (m *Map7[A, B, C, D, E, F, G]) AddBatchQ(filter ecs.Filter, target ...ecs.E
 //
 // See also [ecs.World.Assign].
 func (m *Map7[A, B, C, D, E, F, G]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -2173,7 +2173,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewBatchQ(count int, target ...ecs.Entity
 // See also [ecs.NewBuilderWith].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -2274,7 +2274,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) AddBatchQ(filter ecs.Filter, target ...ec
 //
 // See also [ecs.World.Assign].
 func (m *Map8[A, B, C, D, E, F, G, H]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -2504,7 +2504,7 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) NewBatchQ(count int, target ...ecs.Ent
 // See also [ecs.NewBuilderWith].
 func (m *Map9[A, B, C, D, E, F, G, H, I]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -2608,7 +2608,7 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) AddBatchQ(filter ecs.Filter, target ..
 //
 // See also [ecs.World.Assign].
 func (m *Map9[A, B, C, D, E, F, G, H, I]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -2844,7 +2844,7 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewBatchQ(count int, target ...ecs
 // See also [ecs.NewBuilderWith].
 func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -2951,7 +2951,7 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) AddBatchQ(filter ecs.Filter, targe
 //
 // See also [ecs.World.Assign].
 func (m *Map10[A, B, C, D, E, F, G, H, I, J]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -3193,7 +3193,7 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewBatchQ(count int, target ...
 // See also [ecs.NewBuilderWith].
 func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -3303,7 +3303,7 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) AddBatchQ(filter ecs.Filter, ta
 //
 // See also [ecs.World.Assign].
 func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a
@@ -3551,7 +3551,7 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewBatchQ(count int, target 
 // See also [ecs.NewBuilderWith].
 func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, l *L, target ...ecs.Entity) ecs.Entity {
 	if len(target) == 0 {
-		entity := m.world.NewEntityAndThen(
+		entity := m.world.NewEntityFn(
 			func(entity ecs.Entity) {
 				*(*A)(m.world.Get(entity, m.id0)) = *a
 				*(*B)(m.world.Get(entity, m.id1)) = *b
@@ -3664,7 +3664,7 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) AddBatchQ(filter ecs.Filter,
 //
 // See also [ecs.World.Assign].
 func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) Assign(entity ecs.Entity, a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, l *L) {
-	m.world.AddAndThen(
+	m.world.AddFn(
 		entity,
 		func(entity ecs.Entity) {
 			*(*A)(m.world.Get(entity, m.id0)) = *a


### PR DESCRIPTION
Adds `World.NewEntityFn`, `World.AddFn` and `World.ExchangeFn` that call a callback function before listener notification.

Uses these methods in generic `MapX.NewWith` and `MapX.Assign`.

Fixes #443.