### PR TITLE
Fix missing listener notification in `MapX.NewWith`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-
-## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.14.1...main)
+## [[v0.14.2]](https://github.com/mlange-42/arche/compare/v0.14.1...v0.14.2)
 
 ### Performance
 
@@ -8,6 +7,11 @@
 ### Documentation
 
 * Fix method names and ordering in benchmark tables (#448)
+* Document listener notification handling in `MapX.NewWith` (#450)
+
+### Bugfixes
+
+* Fix missing listener notification in `MapX.NewWith` when called with a relation target (#450)
 
 ## [[v0.14.1]](https://github.com/mlange-42/arche/compare/v0.14.0...v0.14.1)
 

--- a/generic/_generate/map.go.txt
+++ b/generic/_generate/map.go.txt
@@ -97,6 +97,7 @@ func (m *Map{{ .Index }}{{ .Types }}) NewBatchQ(count int, target ...ecs.Entity)
 // NewWith creates a new [ecs.Entity] with the Map{{ .Index }}'s components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map{{ .Index }}'s [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map{{ .Index }}{{ .Types }}) NewWith({{ .Arguments }}, target ...ecs.Entity) ecs.Entity {
@@ -113,8 +114,12 @@ func (m *Map{{ .Index }}{{ .Types }}) NewWith({{ .Arguments }}, target ...ecs.En
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	{{ .Assign }}
+	entity := m.world.NewEntityFn(
+			func(entity ecs.Entity) {
+				{{ .Assign }}
+			},
+			m.ids...,
+		)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }

--- a/generic/map_generated.go
+++ b/generic/map_generated.go
@@ -104,6 +104,7 @@ func (m *Map1[A]) NewBatchQ(count int, target ...ecs.Entity) Query1[A] {
 // NewWith creates a new [ecs.Entity] with the Map1's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map1's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map1[A]) NewWith(a *A, target ...ecs.Entity) ecs.Entity {
@@ -120,8 +121,12 @@ func (m *Map1[A]) NewWith(a *A, target ...ecs.Entity) ecs.Entity {
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -372,6 +377,7 @@ func (m *Map2[A, B]) NewBatchQ(count int, target ...ecs.Entity) Query2[A, B] {
 // NewWith creates a new [ecs.Entity] with the Map2's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map2's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map2[A, B]) NewWith(a *A, b *B, target ...ecs.Entity) ecs.Entity {
@@ -389,9 +395,13 @@ func (m *Map2[A, B]) NewWith(a *A, b *B, target ...ecs.Entity) ecs.Entity {
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -649,6 +659,7 @@ func (m *Map3[A, B, C]) NewBatchQ(count int, target ...ecs.Entity) Query3[A, B, 
 // NewWith creates a new [ecs.Entity] with the Map3's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map3's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map3[A, B, C]) NewWith(a *A, b *B, c *C, target ...ecs.Entity) ecs.Entity {
@@ -667,10 +678,14 @@ func (m *Map3[A, B, C]) NewWith(a *A, b *B, c *C, target ...ecs.Entity) ecs.Enti
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -935,6 +950,7 @@ func (m *Map4[A, B, C, D]) NewBatchQ(count int, target ...ecs.Entity) Query4[A, 
 // NewWith creates a new [ecs.Entity] with the Map4's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map4's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map4[A, B, C, D]) NewWith(a *A, b *B, c *C, d *D, target ...ecs.Entity) ecs.Entity {
@@ -954,11 +970,15 @@ func (m *Map4[A, B, C, D]) NewWith(a *A, b *B, c *C, d *D, target ...ecs.Entity)
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -1230,6 +1250,7 @@ func (m *Map5[A, B, C, D, E]) NewBatchQ(count int, target ...ecs.Entity) Query5[
 // NewWith creates a new [ecs.Entity] with the Map5's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map5's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map5[A, B, C, D, E]) NewWith(a *A, b *B, c *C, d *D, e *E, target ...ecs.Entity) ecs.Entity {
@@ -1250,12 +1271,16 @@ func (m *Map5[A, B, C, D, E]) NewWith(a *A, b *B, c *C, d *D, e *E, target ...ec
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -1534,6 +1559,7 @@ func (m *Map6[A, B, C, D, E, F]) NewBatchQ(count int, target ...ecs.Entity) Quer
 // NewWith creates a new [ecs.Entity] with the Map6's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map6's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map6[A, B, C, D, E, F]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, target ...ecs.Entity) ecs.Entity {
@@ -1555,13 +1581,17 @@ func (m *Map6[A, B, C, D, E, F]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, tar
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -1847,6 +1877,7 @@ func (m *Map7[A, B, C, D, E, F, G]) NewBatchQ(count int, target ...ecs.Entity) Q
 // NewWith creates a new [ecs.Entity] with the Map7's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map7's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map7[A, B, C, D, E, F, G]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, target ...ecs.Entity) ecs.Entity {
@@ -1869,14 +1900,18 @@ func (m *Map7[A, B, C, D, E, F, G]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, 
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -2169,6 +2204,7 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewBatchQ(count int, target ...ecs.Entity
 // NewWith creates a new [ecs.Entity] with the Map8's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map8's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map8[A, B, C, D, E, F, G, H]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, target ...ecs.Entity) ecs.Entity {
@@ -2192,15 +2228,19 @@ func (m *Map8[A, B, C, D, E, F, G, H]) NewWith(a *A, b *B, c *C, d *D, e *E, f *
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
-	*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+			*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -2500,6 +2540,7 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) NewBatchQ(count int, target ...ecs.Ent
 // NewWith creates a new [ecs.Entity] with the Map9's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map9's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map9[A, B, C, D, E, F, G, H, I]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, target ...ecs.Entity) ecs.Entity {
@@ -2524,16 +2565,20 @@ func (m *Map9[A, B, C, D, E, F, G, H, I]) NewWith(a *A, b *B, c *C, d *D, e *E, 
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
-	*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
-	*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+			*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+			*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -2840,6 +2885,7 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewBatchQ(count int, target ...ecs
 // NewWith creates a new [ecs.Entity] with the Map10's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map10's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, target ...ecs.Entity) ecs.Entity {
@@ -2865,17 +2911,21 @@ func (m *Map10[A, B, C, D, E, F, G, H, I, J]) NewWith(a *A, b *B, c *C, d *D, e 
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
-	*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
-	*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
-	*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+			*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+			*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
+			*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -3189,6 +3239,7 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewBatchQ(count int, target ...
 // NewWith creates a new [ecs.Entity] with the Map11's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map11's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, target ...ecs.Entity) ecs.Entity {
@@ -3215,18 +3266,22 @@ func (m *Map11[A, B, C, D, E, F, G, H, I, J, K]) NewWith(a *A, b *B, c *C, d *D,
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
-	*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
-	*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
-	*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
-	*(*K)(m.world.GetUnchecked(entity, m.id10)) = *k
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+			*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+			*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
+			*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
+			*(*K)(m.world.GetUnchecked(entity, m.id10)) = *k
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }
@@ -3547,6 +3602,7 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewBatchQ(count int, target 
 // NewWith creates a new [ecs.Entity] with the Map12's components, using the supplied values.
 //
 // The optional argument can be used to set the target [ecs.Entity] for the Map12's [ecs.Relation].
+// A potential [ecs.Listener] is notified about the relation target change in a separate event.
 //
 // See also [ecs.NewBuilderWith].
 func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewWith(a *A, b *B, c *C, d *D, e *E, f *F, g *G, h *H, i *I, j *J, k *K, l *L, target ...ecs.Entity) ecs.Entity {
@@ -3574,19 +3630,23 @@ func (m *Map12[A, B, C, D, E, F, G, H, I, J, K, L]) NewWith(a *A, b *B, c *C, d 
 	if !m.hasRelation {
 		panic("map has no relation defined")
 	}
-	entity := m.world.NewEntity(m.ids...)
-	*(*A)(m.world.Get(entity, m.id0)) = *a
-	*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
-	*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
-	*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
-	*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
-	*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
-	*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
-	*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
-	*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
-	*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
-	*(*K)(m.world.GetUnchecked(entity, m.id10)) = *k
-	*(*L)(m.world.GetUnchecked(entity, m.id11)) = *l
+	entity := m.world.NewEntityFn(
+		func(entity ecs.Entity) {
+			*(*A)(m.world.Get(entity, m.id0)) = *a
+			*(*B)(m.world.GetUnchecked(entity, m.id1)) = *b
+			*(*C)(m.world.GetUnchecked(entity, m.id2)) = *c
+			*(*D)(m.world.GetUnchecked(entity, m.id3)) = *d
+			*(*E)(m.world.GetUnchecked(entity, m.id4)) = *e
+			*(*F)(m.world.GetUnchecked(entity, m.id5)) = *f
+			*(*G)(m.world.GetUnchecked(entity, m.id6)) = *g
+			*(*H)(m.world.GetUnchecked(entity, m.id7)) = *h
+			*(*I)(m.world.GetUnchecked(entity, m.id8)) = *i
+			*(*J)(m.world.GetUnchecked(entity, m.id9)) = *j
+			*(*K)(m.world.GetUnchecked(entity, m.id10)) = *k
+			*(*L)(m.world.GetUnchecked(entity, m.id11)) = *l
+		},
+		m.ids...,
+	)
 	m.world.Relations().Set(entity, m.relation, target[0])
 	return entity
 }


### PR DESCRIPTION
There were no notifications when called with a relation target.
Documented notification behaviour.