### PR TITLE
Optimize batch-exchange by bulk copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [[v0.15.1]](https://github.com/mlange-42/arche/compare/v0.15.0...v0.15.1)
+
+### Performance
+
+* Optimize batch operations (add, remove, exchange) by bulk-copying components (#473)
+
 ## [[v0.15.0]](https://github.com/mlange-42/arche/compare/v0.14.5...v0.15.0)
 
 Arche v0.15.0 features optimizations that vastly speed up the creation of huge numbers (millions) of entities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Performance
 
-* Optimize batch operations (add, remove, exchange) by bulk-copying components (#473)
+* Optimizes batch operations (add, remove, exchange) by bulk-copying components (#473)
 
 ## [[v0.15.0]](https://github.com/mlange-42/arche/compare/v0.14.5...v0.15.0)
 

--- a/benchmark/profile/exchange_large/main.go
+++ b/benchmark/profile/exchange_large/main.go
@@ -1,0 +1,128 @@
+package main
+
+// Profiling:
+// go build ./benchmark/profile/exchange_large
+// ./exchange_large
+// go tool pprof -http=":8000" -nodefraction=0.001 ./exchange_large cpu.pprof
+// go tool pprof -http=":8000" -nodefraction=0.001 ./exchange_large mem.pprof
+
+import (
+	"github.com/mlange-42/arche/ecs"
+	"github.com/pkg/profile"
+)
+
+type position struct {
+	X int
+	Y int
+}
+
+type velocity struct {
+	X int
+	Y int
+}
+
+type rotation struct {
+	Angle int
+}
+
+type c1 struct {
+	X int
+	Y int
+}
+
+type c2 struct {
+	X int
+	Y int
+}
+
+type c3 struct {
+	X int
+	Y int
+}
+
+type c4 struct {
+	X int
+	Y int
+}
+
+type c5 struct {
+	X int
+	Y int
+}
+
+type c6 struct {
+	X int
+	Y int
+}
+
+type c7 struct {
+	X int
+	Y int
+}
+
+type c8 struct {
+	X int
+	Y int
+}
+
+type c9 struct {
+	X int
+	Y int
+}
+
+type c10 struct {
+	X int
+	Y int
+}
+
+func main() {
+
+	count := 250
+	iters := 1000
+	entities := 1000
+
+	stop := profile.Start(profile.CPUProfile, profile.ProfilePath("."))
+	run(count, iters, entities)
+	stop.Stop()
+
+	stop = profile.Start(profile.MemProfileAllocs, profile.ProfilePath("."))
+	run(count, iters, entities)
+	stop.Stop()
+}
+
+func run(rounds, iters, numEntities int) {
+	for i := 0; i < rounds; i++ {
+		world := ecs.NewWorld(1024)
+
+		posID := ecs.ComponentID[position](&world)
+		velID := ecs.ComponentID[velocity](&world)
+		rotID := ecs.ComponentID[rotation](&world)
+
+		allIDs := []ecs.ID{
+			posID, velID,
+			ecs.ComponentID[c1](&world),
+			ecs.ComponentID[c2](&world),
+			ecs.ComponentID[c3](&world),
+			ecs.ComponentID[c4](&world),
+			ecs.ComponentID[c5](&world),
+			ecs.ComponentID[c6](&world),
+			ecs.ComponentID[c7](&world),
+			ecs.ComponentID[c8](&world),
+			ecs.ComponentID[c9](&world),
+			ecs.ComponentID[c10](&world),
+		}
+
+		world.Batch().New(numEntities, allIDs...)
+
+		filter := ecs.All(posID)
+
+		for j := 0; j < iters; j++ {
+			add := []ecs.ID{rotID}
+			remove := []ecs.ID{velID}
+			if j%2 != 0 {
+				add, remove = remove, add
+			}
+			world.Batch().Exchange(&filter, add, remove)
+		}
+	}
+}

--- a/benchmark/table/main.go
+++ b/benchmark/table/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 )
 
-const version = "v0.15.0"
+const version = "v0.15.1"
 
 func main() {
 	fmt.Printf("Last run: %s  \n", time.Now().Format(time.RFC1123))

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -225,6 +225,31 @@ func (a *archetype) SetPointer(index uint32, id ID, comp unsafe.Pointer) unsafe.
 	return dst
 }
 
+func (a *archetype) CopyFrom(other *archetype, id ID, startIndex uint32) {
+	if !a.Mask.Get(id) {
+		return
+	}
+	lay := a.getLayout(id)
+	size := lay.itemSize
+	if size == 0 {
+		return
+	}
+
+	otherLay := other.getLayout(id)
+
+	dst := lay.Get(uint32(startIndex))
+	src := otherLay.Get(0)
+
+	a.copy(src, dst, size*other.len)
+}
+
+func (a *archetype) CopyEntitiesFrom(other *archetype, startIndex uint32) {
+	dst := unsafe.Add(a.entityPointer, startIndex*entitySize)
+	src := other.entityPointer
+
+	a.copy(src, dst, entitySize*other.len)
+}
+
 // Reset removes all entities and components.
 //
 // Does NOT free the reserved memory.

--- a/ecs/archetype.go
+++ b/ecs/archetype.go
@@ -225,6 +225,8 @@ func (a *archetype) SetPointer(index uint32, id ID, comp unsafe.Pointer) unsafe.
 	return dst
 }
 
+// CopyFrom copies an entire component column from another archetype into this one,
+// starting at startIndex in this one.
 func (a *archetype) CopyFrom(other *archetype, id ID, startIndex uint32) {
 	if !a.Mask.Get(id) {
 		return
@@ -243,6 +245,8 @@ func (a *archetype) CopyFrom(other *archetype, id ID, startIndex uint32) {
 	a.copy(src, dst, size*other.len)
 }
 
+// CopyFrom copies all entities from another archetype into this one,
+// starting at startIndex in this one.
 func (a *archetype) CopyEntitiesFrom(other *archetype, startIndex uint32) {
 	dst := unsafe.Add(a.entityPointer, startIndex*entitySize)
 	src := other.entityPointer

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -630,6 +630,52 @@ func BenchmarkWorldExchangeBatchNoListener_1000(b *testing.B) {
 	}
 }
 
+func BenchmarkWorldExchangeBatchLargeNoListener_1000(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	allIDs := []ID{
+		posID,
+		ComponentID[testStruct0](&world),
+		ComponentID[testStruct1](&world),
+		ComponentID[testStruct2](&world),
+		ComponentID[testStruct3](&world),
+		ComponentID[testStruct4](&world),
+		ComponentID[testStruct5](&world),
+		ComponentID[testStruct6](&world),
+		ComponentID[testStruct7](&world),
+		ComponentID[testStruct8](&world),
+		ComponentID[testStruct9](&world),
+	}
+
+	builder := NewBuilder(&world, allIDs...)
+	builder.NewBatch(1000)
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			world.Batch().Exchange(filterPos, vel, pos)
+		} else {
+			world.Batch().Exchange(filterVel, pos, vel)
+		}
+		hasPos = !hasPos
+	}
+}
+
 func BenchmarkWorldExchangeBatchNoEvent_1000(b *testing.B) {
 	b.StopTimer()
 

--- a/ecs/world_internal.go
+++ b/ecs/world_internal.go
@@ -644,16 +644,13 @@ func (w *World) exchangeArch(oldArch *archetype, oldArchLen uint32, add []ID, re
 		idx := startIdx + i
 		entity := oldArch.GetEntity(i)
 		index := &w.entities[entity.id]
-		arch.SetEntity(idx, entity)
 		index.arch = arch
 		index.index = idx
+	}
 
-		for _, id := range oldIDs {
-			if mask.Get(id) {
-				comp := oldArch.Get(i, id)
-				arch.SetPointer(idx, id, comp)
-			}
-		}
+	arch.CopyEntitiesFrom(oldArch, startIdx)
+	for _, id := range oldIDs {
+		arch.CopyFrom(oldArch, id, startIdx)
 	}
 
 	if !target.IsZero() {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -546,16 +546,22 @@ func TestWorldExchangeBatch2(t *testing.T) {
 	velID := ComponentID[Velocity](&w)
 	rotID := ComponentID[rotation](&w)
 
-	query := w.Batch().NewQ(100, posID, velID)
+	query := w.Batch().NewQ(10, posID, rotID)
 	for query.Next() {
 		pos := (*Position)(query.Get(posID))
 		pos.X = int(query.Entity().ID())
 	}
 
-	w.Batch().Exchange(All(posID), []ID{rotID}, []ID{velID})
+	query = w.Batch().NewQ(100, posID, velID)
+	for query.Next() {
+		pos := (*Position)(query.Get(posID))
+		pos.X = int(query.Entity().ID())
+	}
+
+	w.Batch().Exchange(All(posID, velID), []ID{rotID}, []ID{velID})
 
 	query = w.Query(All(posID, rotID))
-	assert.Equal(t, 100, query.Count())
+	assert.Equal(t, 110, query.Count())
 
 	i := 1
 	for query.Next() {
@@ -564,6 +570,10 @@ func TestWorldExchangeBatch2(t *testing.T) {
 		assert.Equal(t, i, pos.X)
 		i++
 	}
+
+	query = w.Query(All(posID, velID))
+	assert.Equal(t, 0, query.Count())
+	query.Close()
 }
 
 func TestWorldAssignSet(t *testing.T) {

--- a/ecs/world_test.go
+++ b/ecs/world_test.go
@@ -539,6 +539,33 @@ func TestWorldExchangeBatch(t *testing.T) {
 	q.Close()
 }
 
+func TestWorldExchangeBatch2(t *testing.T) {
+	w := NewWorld()
+
+	posID := ComponentID[Position](&w)
+	velID := ComponentID[Velocity](&w)
+	rotID := ComponentID[rotation](&w)
+
+	query := w.Batch().NewQ(100, posID, velID)
+	for query.Next() {
+		pos := (*Position)(query.Get(posID))
+		pos.X = int(query.Entity().ID())
+	}
+
+	w.Batch().Exchange(All(posID), []ID{rotID}, []ID{velID})
+
+	query = w.Query(All(posID, rotID))
+	assert.Equal(t, 100, query.Count())
+
+	i := 1
+	for query.Next() {
+		pos := (*Position)(query.Get(posID))
+		assert.Equal(t, int(query.Entity().ID()), pos.X)
+		assert.Equal(t, i, pos.X)
+		i++
+	}
+}
+
 func TestWorldAssignSet(t *testing.T) {
 	w := NewWorld()
 


### PR DESCRIPTION
Bulk-copy component data between archetypes on batch operations. As an example, for entities with 10 components, the speedup is 5-10 fold.