### PR TITLE
Speed up reset of small archetypes by zeroing memory manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [[unpublished]](https://github.com/mlange-42/arche/compare/v0.15.1...main)
+
+### Performance
+
+* Speeds up reset of small archetypes by zeroing memory manually (#475)
+
 ## [[v0.15.1]](https://github.com/mlange-42/arche/compare/v0.15.0...v0.15.1)
 
 ### Performance

--- a/benchmark/profile/exchange_batch/main.go
+++ b/benchmark/profile/exchange_batch/main.go
@@ -1,0 +1,63 @@
+package main
+
+// Profiling:
+// go build ./benchmark/profile/exchange_batch
+// ./exchange_batch
+// go tool pprof -http=":8000" -nodefraction=0.001 ./exchange_batch cpu.pprof
+// go tool pprof -http=":8000" -nodefraction=0.001 ./exchange_batch mem.pprof
+
+import (
+	"github.com/mlange-42/arche/ecs"
+	"github.com/pkg/profile"
+)
+
+type position struct {
+	X int
+	Y int
+}
+
+type velocity struct {
+	X int
+	Y int
+}
+
+type rotation struct {
+	Angle int
+}
+
+func main() {
+
+	count := 20
+	iters := 100000
+	entities := 32
+
+	stop := profile.Start(profile.CPUProfile, profile.ProfilePath("."))
+	run(count, iters, entities)
+	stop.Stop()
+
+	stop = profile.Start(profile.MemProfileAllocs, profile.ProfilePath("."))
+	run(count, iters, entities)
+	stop.Stop()
+}
+
+func run(rounds, iters, numEntities int) {
+	for i := 0; i < rounds; i++ {
+		world := ecs.NewWorld(1024)
+
+		posID := ecs.ComponentID[position](&world)
+		velID := ecs.ComponentID[velocity](&world)
+		rotID := ecs.ComponentID[rotation](&world)
+
+		for j := 0; j < numEntities; j++ {
+			_ = world.NewEntity(posID, velID)
+		}
+		add := []ecs.ID{rotID}
+		remove := []ecs.ID{velID}
+		filter := ecs.All(posID)
+
+		for j := 0; j < iters; j++ {
+			world.Batch().Exchange(&filter, add, remove)
+			add, remove = remove, add
+		}
+	}
+}

--- a/ecs/world_benchmark_test.go
+++ b/ecs/world_benchmark_test.go
@@ -598,6 +598,38 @@ func BenchmarkWorldExchangeEventCallback_1000(b *testing.B) {
 	_ = temp
 }
 
+func BenchmarkWorldExchangeBatchNoListener_1(b *testing.B) {
+	b.StopTimer()
+
+	world := NewWorld()
+
+	posID := ComponentID[Position](&world)
+	velID := ComponentID[Velocity](&world)
+
+	builder := NewBuilder(&world, posID)
+	builder.NewBatch(1)
+
+	filterPos := All(posID)
+	filterVel := All(velID)
+
+	pos := []ID{posID}
+	vel := []ID{velID}
+
+	world.Batch().Exchange(filterPos, vel, pos)
+	world.Batch().Exchange(filterVel, pos, vel)
+
+	b.StartTimer()
+	hasPos := true
+	for i := 0; i < b.N; i++ {
+		if hasPos {
+			world.Batch().Exchange(filterPos, vel, pos)
+		} else {
+			world.Batch().Exchange(filterVel, pos, vel)
+		}
+		hasPos = !hasPos
+	}
+}
+
 func BenchmarkWorldExchangeBatchNoListener_1000(b *testing.B) {
 	b.StopTimer()
 


### PR DESCRIPTION
Speeds up batch operations (add, remove, exchange) over entities that previously were in small archetypes.